### PR TITLE
The ability to install msxml6 (x86 and x64 version) on 64-bit Wine prefix

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -6433,10 +6433,21 @@ load_msxml6()
 {
     # Service Pack 1
     # http://www.microsoft.com/downloads/details.aspx?familyid=D21C292C-368B-4CE1-9DAB-3E9827B70604
-    w_download http://download.microsoft.com/download/e/a/f/eafb8ee7-667d-4e30-bb39-4694b5b3006f/msxml6_x86.msi 5125220e985b33c946bbf9f60e2b222c7570bfa2
+    if [ $W_ARCH = win64 ]
+    then
+        w_download http://download.microsoft.com/download/e/a/f/eafb8ee7-667d-4e30-bb39-4694b5b3006f/msxml6_x64.msi ca0c0814a9c7024583edb997296aad7cb0a3cbf7
+    else
+        w_download http://download.microsoft.com/download/e/a/f/eafb8ee7-667d-4e30-bb39-4694b5b3006f/msxml6_x86.msi 5125220e985b33c946bbf9f60e2b222c7570bfa2
+    fi
     w_override_dlls native,builtin msxml6
     rm -f "$W_SYSTEM32_DLLS/msxml6.dll"
-    w_try "$WINE" msiexec /i "$W_CACHE"/msxml6/msxml6_x86.msi $W_UNATTENDED_SLASH_Q
+    if [ $W_ARCH = win64 ]
+    then
+        rm -f "$W_SYSTEM64_DLLS/msxml6.dll"
+        w_try "wine64" msiexec /i "$W_CACHE"/msxml6/msxml6_x64.msi $W_UNATTENDED_SLASH_Q
+    else
+        w_try "$WINE" msiexec /i "$W_CACHE"/msxml6/msxml6_x86.msi $W_UNATTENDED_SLASH_Q
+    fi
 }
 
 #----------------------------------------------------------------


### PR DESCRIPTION
Without this fix, it is impossible to install msxml6 on 64-bit Wine prefix with winetricks.