### PR TITLE
winetricks: add binkw32 verb

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -707,9 +707,9 @@ w_download_to()
         # Also affects ttf files on github
         _W_filetype=`which file 2>/dev/null`
         case $_W_filetype-$_W_file in
-        /*-*.exe|/*-*.ttf)
+        /*-*.exe|/*-*.ttf|/*-*.zip)
             case `file "$_W_file"` in
-            *gzip*) mv "$_W_file" "$_W_file.gz"; gunzip < "$_W_file.gz" > "$_W_file";;
+            *:*gzip*) mv "$_W_file" "$_W_file.gz"; gunzip < "$_W_file.gz" > "$_W_file";;
             esac
         esac
 
@@ -4298,6 +4298,28 @@ load_crypt32()
     w_try_cabextract --directory="$W_SYSTEM32_DLLS" "$W_TMP"/i386/crypt32.dl_
 
     w_override_dlls native crypt32
+}
+
+#----------------------------------------------------------------
+
+w_metadata binkw32 dlls \
+    title="RAD Game Tools binkw32.dll" \
+    publisher="RAD Game Tools, Inc." \
+    year="2000" \
+    media="download" \
+    file1="__32-binkw32.dll3.0.0.0.zip" \
+    installed_file1="$W_SYSTEM32_DLLS_WIN/binkw32.dll"
+
+load_binkw32()
+{
+    # Mirror: http://www.dlldump.com/download-dll-files_new.php/dllfiles/B/binkw32.dll/1.0q/download.html
+    # Checksum of the decompressed file: 613f81f82e12131e86ae60dd318941f40db2200f
+    w_download http://www.down-dll.com/dll/b/__32-binkw32.dll3.0.0.0.zip 991f77e8df513ccb8663dc4a2753fbf90338ef5c
+
+    w_try_unzip -d "$W_TMP" "$W_CACHE"/binkw32/__32-binkw32.dll3.0.0.0.zip
+    w_try cp "$W_TMP"/binkw32.dll "$W_SYSTEM32_DLLS"/binkw32.dll
+
+    w_override_dlls native binkw32
 }
 
 #----------------------------------------------------------------


### PR DESCRIPTION
Some games do not ship a binkw32.dll (somehow required for video rendering?), having a winetricks recipe for that makes it easier to test such bugs. One example is: https://bugs.wine-staging.com/show_bug.cgi?id=155

Some comments on the patch:

* The changes to `w_download_to` are required since the webserver is not happy with winetricks passing the accept-encoding header, and wget returns a gzip compressed result. The replacement `*gzip*` -> `*:*gzip*` was done to make sure it doesn't accidentially match the filename instead of the file type. **Needs testing on MacOS/BSD!**

* Metadata information is based on the file metadata.

* I know that `down-dll.com` is probably not really the best mirror, but the checksum matches the expected one, and it doesn't require any cookies. If it breaks we might have to find a better alternative, but that could happen with any mirror, so ...