### PR TITLE
debian: Make wine an optional dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,9 +13,11 @@ Homepage: http://winetricks.org
 Depends: cabextract,
         p7zip,
         unzip,
-        wget,
-        wine,
-        xdg-utils
+        wget
+Recommends: zenity | kdebase-bin,
+        xdg-utils,
+        sudo | gksu,
+        wine
 Description: Simple tool to work around common problems in Wine.
  Winetricks has a menu of supported games/apps for which it can do all the
  workarounds automatically. It also lets you install missing DLLs or


### PR DESCRIPTION
This patch mimes the dependency behavior of the Ubuntu winetricks package and marks Wine as an optional dependency which gets installed by default. The change makes it possible to use winetricks with 3rd party of self compiled wine versions without forcing the user to install the distro provided wine package.