### PR TITLE
Fix a broken test in non-bash shells

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -2037,7 +2037,7 @@ w_conflicts()
 {
     for x in $2
     do
-        if test $(grep -w "$x" "$WINEPREFIX/winetricks.log")
+        if grep -qw "$x" "$WINEPREFIX/winetricks.log"
         then
             w_die "error: $1 conflicts with $x, which is already installed."
         fi


### PR DESCRIPTION
```
$ winetricks dotnet45
Executing w_do_call dotnet45
/usr/bin/winetricks: 1968: test: dotnet20: unexpected operator
------------------------------------------------------
error: dotnet45 conflicts with dotnet20sp2, which is already installed.
------------------------------------------------------
```
It doesn't appear to have any adverse affects (it is reporting the conflict correctly), but the test fails. I have modified the check to use the exit code of grep -q (indicating the presence of matches), rather than testing for matches using test.