### PR TITLE
Fixed "mv: cannot stat" error on failed SHA1 chksum

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -501,7 +501,7 @@ w_expand_env()
 # get sha1sum string and set $_W_gotsum to it
 w_get_sha1sum()
 {
-    _W_file=$1
+    local _W_file=$1
     _W_gotsum=`$WINETRICKS_SHA1SUM < "$_W_file" | sed 's/(stdin)= //;s/ .*//'`
 }
 


### PR DESCRIPTION
Made _W_path a local variable in function w_get_sha1sum to prevent it from overwriting the value set in the main script.