### PR TITLE
Update the version of Kindle for PC.

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -6351,7 +6351,7 @@ load_kde()
 w_metadata kindle apps \
     title="Amazon Kindle" \
     publisher="Amazon" \
-    year="2011" \
+    year="2015" \
     media="download" \
     file1="KindleForPC-installer.exe" \
     installed_exe1="$W_PROGRAMS_WIN/Amazon/Kindle/Kindle.exe" \
@@ -6359,7 +6359,7 @@ w_metadata kindle apps \
 
 load_kindle()
 {
-    w_download http://kindleforpc.amazon.com/36154/KindleForPC-installer.exe aca576086de7abd1d82c211dbeeb810387e046f5
+    w_download http://kindleforpc.amazon.com/40666/KindleForPC-installer.exe 10e8c82587f8c08b77e5ed55dd94d9851a2a899c
     cd "$W_CACHE"/kindle
     w_try "$WINE" $file1 ${W_OPT_UNATTENDED:+ /S}
     w_declare_exe "$W_PROGRAMS_WIN\\Amazon\\Kindle" Kindle.exe


### PR DESCRIPTION
The current winetricks version of Kindle for PC won't login to Amazon -- Amazon has this thing about trying to make you run the latest version of their software -- and I am not sure it will still auto-update either.

Ideally the user should always install a reasonably recent version of Kindle for PC, or Amazon may refuse to let it work...