### PR TITLE
winetricks crashes on installers with space in name

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -501,7 +501,7 @@ w_expand_env()
 # get sha1sum string and set $_W_gotsum to it
 w_get_sha1sum()
 {
-    local _W_file=$1
+    local _W_file="$1"
     _W_gotsum=`$WINETRICKS_SHA1SUM < "$_W_file" | sed 's/(stdin)= //;s/ .*//'`
 }
 


### PR DESCRIPTION
Please double-check this but it seems the $1 argument to w_get_sha1sum needs quotes. I've seen failures on multiple verbs with spaces in the executable names until I add quotes to the argument as in this patch.

Example, when loading dotnet45:
...
Executing load_dotnet30sp1
./winetricks: 504: local: 2003: bad variable name

The file being executed is:
~/.cache/winetricks/dotnet30sp1/XPSEP XP and Server 2003 32 bit.msi
