### PR TITLE
dxdiag: Add versions to w_workaround_wine_bug

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -9104,11 +9104,11 @@ load_dxdiag()
     then
         w_call dxdiagn
     fi
-    if w_workaround_wine_bug 25715
+    if w_workaround_wine_bug 25715 "" 1.7.28,
     then
         w_call quartz
     fi
-    if w_workaround_wine_bug 25716
+    if w_workaround_wine_bug 25716 "" 1.7.29,
     then
         w_call devenum
     fi


### PR DESCRIPTION
Add versions to w_workaround_wine_bug (#25715 and #25716).
Wine bug [#25715](https://bugs.winehq.org/show_bug.cgi?id=25715) is fixed in Wine 1.7.28, and [#25716](https://bugs.winehq.org/show_bug.cgi?id=25716) is fixed in 1.7.29.