### PR TITLE
Use `which` instead of `type`

### DIFF
--- a/tests/winetricks-test
+++ b/tests/winetricks-test
@@ -45,7 +45,7 @@ QUICKCHECK="flash"
 # middle of a two day run.
 for tool in time cabextract
 do
-    type $tool
+    which $tool
     ret=$?
     if [ ! $ret -eq 0 ]
     then


### PR DESCRIPTION
`type` will also report for builtin shell commands like `time` which we don't want.
On ArchLinux for bash 4.3 `type time` returns 'time is a shell keyword' and thus it will pass even if I don't have `time` installed.
