### PR TITLE
Update hash for updated dotnet_verifier

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -5953,7 +5953,8 @@ load_dotnet_verifier()
     # 2013/03/28: sha1sum 0eba832a0733cd47b7639463dd5a22a41e95ee6e
     # 2014/01/23: sha1sum 8818f3460826145e2a66bb91727afa7cd531037b
     # 2014/11/22: sha1sum 47de0b849c4c3d354df23588c709108e7816d788
-    w_download http://blogs.msdn.com/cfs-file.ashx/__key/CommunityServer-Components-PostAttachments/00-08-99-90-04/netfx_5F00_setupverifier_5F00_new.zip 47de0b849c4c3d354df23588c709108e7816d788
+    # 2015/07/31: sha1sum 32f24526a5716737281dc260451b60a641b23c7e
+    w_download http://blogs.msdn.com/cfs-file.ashx/__key/CommunityServer-Components-PostAttachments/00-08-99-90-04/netfx_5F00_setupverifier_5F00_new.zip 32f24526a5716737281dc260451b60a641b23c7e
 
     cd "$W_CACHE"/dotnet_verifier
 


### PR DESCRIPTION
dotnet_verifier was updated so need to update it's hash
```
July 31, 2015        - Add the ability to verify the .NET Framework 4.6. Updated tool to
                       allow it to differentiate between Windows 8.1 and Windows 10.
```
