### PR TITLE
Add download tests and delete cache only for those

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -11257,7 +11257,7 @@ w_metadata algodoo_demo games \
 
 load_algodoo_demo()
 {
-    w_download  http://www.algodoo.com/download/Algodoo_1_7_1-Win32.exe caa73e73669a8787652a6bed123bbe2682152f12
+    w_download http://www.algodoo.com/download/Algodoo_1_7_1-Win32.exe caa73e73669a8787652a6bed123bbe2682152f12
 
     cd "$W_CACHE/$W_PACKAGE"
     w_ahk_do "
@@ -11360,8 +11360,7 @@ w_metadata aoe3_demo games \
 load_aoe3_demo()
 {
 
-    w_download "http://download.microsoft.com/download/a/5/2/a525997e-8423-435b-b694-08118d235064/aoe3trial.exe" \
-        2b0a123243092d79f910db5691d99d469f7c17c3
+    w_download "http://download.microsoft.com/download/a/5/2/a525997e-8423-435b-b694-08118d235064/aoe3trial.exe" 2b0a123243092d79f910db5691d99d469f7c17c3
 
     if w_workaround_wine_bug 24897 "Installing msxml4 to avoid font problem" 1.3.9,
     then
@@ -12534,9 +12533,7 @@ w_metadata crayonphysics_demo games \
 
 load_crayonphysics_demo()
 {
-    w_download \
-        http://crayonphysicsdeluxe.s3.amazonaws.com/$file1 \
-        4ffd64c630f69e7cf024ef946c2c64c8c4ce4eac
+    w_download http://crayonphysicsdeluxe.s3.amazonaws.com/crayon_release52demo.exe 4ffd64c630f69e7cf024ef946c2c64c8c4ce4eac
     # Inno Setup installer
     w_try "$WINE" "$W_CACHE/$W_PACKAGE/$file1" ${W_OPT_UNATTENDED:+ /sp- /silent /norestart}
     w_declare_exe "$W_PROGRAMS_X86_WIN\\Crayon Physics Deluxe Demo" crayon.exe
@@ -15428,8 +15425,7 @@ load_myth2_demo()
     # source code to Project Magma for further development.
 
     # 1 May 2011 1.7.2 sha1sum e0a8f707377e71314a471a09ad2a55179ea44588
-    w_download http://tain.totalcodex.net/items/download/myth-ii-demo-windows \
-        e0a8f707377e71314a471a09ad2a55179ea44588 $file1
+    w_download http://tain.totalcodex.net/items/download/myth-ii-demo-windows e0a8f707377e71314a471a09ad2a55179ea44588 Myth2_Demo_172.exe
     cd "$W_CACHE/$W_PACKAGE"
 
     w_ahk_do "

--- a/tests/winetricks-test
+++ b/tests/winetricks-test
@@ -453,12 +453,191 @@ test_full() {
     test_speed list-installed
 }
 
+# get sha1sum string and set $_W_gotsum to it
+w_get_sha1sum()
+{
+    local _W_file="$1"
+    _W_gotsum=`sha1sum < "$_W_file" | sed 's/(stdin)= //;s/ .*//'`
+}
+
+# verify an sha1sum
+w_verify_sha1sum()
+{
+    _W_vs_wantsum=$1
+    _W_vs_file=$2
+
+    w_get_sha1sum "$_W_vs_file"
+    if [ "$_W_gotsum"x != "$_W_vs_wantsum"x ]
+    then
+        echo "sha1sum mismatch! Wanted $_W_vs_wantsum but got $_W_gotsum"
+        return 1
+    fi
+    unset _W_vs_wantsum _W_vs_file _W_gotsum
+    return 0
+}
+
+# Open a folder for the user in the specified directory
+# Usage: w_open_folder directory
+w_open_folder()
+{
+    for _W_cmd in xdg-open open cygstart true
+    do
+        _W_cmdpath=`which $_W_cmd`
+        if test -n "$_W_cmdpath"
+        then
+            break
+        fi
+    done
+    $_W_cmd "$1" &
+    unset _W_cmd _W_cmdpath
+}
+
+# Open a web browser for the user to the given page
+# Usage: w_open_webpage url
+w_open_webpage()
+{
+    # See http://www.dwheeler.com/essays/open-files-urls.html
+    for _W_cmd in xdg-open sdtwebclient cygstart open firefox true
+    do
+        _W_cmdpath=`which $_W_cmd`
+        if test -n "$_W_cmdpath"
+        then
+            break
+        fi
+    done
+    $_W_cmd "$1" &
+    unset _W_cmd _W_cmdpath
+}
+
+wt_get_cache_folder() {
+    echo -n "$W_CACHE/`echo -n $1 | tr '[:upper:]' '[:lower:]' | sha1sum | cut -d ' ' -f 1`"
+}
+
+wt_check_file() {
+    _W_file="$1"
+    _W_sha1sum="$2"
+    _W_text="$3"
+
+    if test -s "$_W_file"
+    then
+        w_verify_sha1sum "$_W_sha1sum" "$_W_file"
+        if test $? -eq 0
+        then
+            pass $_W_text
+        else
+            fail $_W_text
+        fi
+    else
+        echo "File $_W_file not found or is empty!"
+        fail $_W_text
+    fi
+}
+
+test_download_manual() {
+    _W_url="$1"
+    _W_file="$2"
+    _W_sha1sum="$3"
+    _W_cache=`wt_get_cache_folder "$_W_url"`
+
+    echo "Testing manual download for '$_W_file'"
+
+    if ! test -f "$_W_cache/$_W_file"
+    then
+        mkdir -p "$_W_cache"
+        printf "Please download '$_W_file' from '$_W_url'\nplace it in $_W_cache\nthen press enter to continue script."
+        w_open_folder "$_W_cache"
+        w_open_webpage "$_W_url"
+        sleep 3   # give some time for browser to open
+        read
+    fi
+
+    wt_check_file "$_W_cache/$_W_file" "$_W_sha1sum" "$_W_url ($_W_file)"
+}
+
+test_download_to() {
+    _W_url="$2"
+    _W_sha1sum="$3"
+    _W_file="$4"
+    _W_cookiejar="$5"
+
+    if [ "$_W_file"x = ""x ]
+    then
+        _W_file=`basename "$_W_url"`
+    fi
+
+    echo "Testing download for '$_W_file'"
+
+    _W_cache=`wt_get_cache_folder "$_W_url"`
+    if test ! -d "$_W_cache"
+    then
+        mkdir -p "$_W_cache"
+    fi
+
+    _W_dl_olddir=`pwd`
+    cd "$_W_cache"
+
+    # Use -nd to insulate ourselves from people who set -x in WGETRC
+    # [*] --retry-connrefused works around the broken sf.net mirroring
+    # system when downloading corefonts
+    # [*] --read-timeout is useful on the adobe server that doesn't
+    # close the connection unless you tell it to (control-C or closing
+    # the socket)
+    wget -O "$_W_file" -nd \
+         -c --read-timeout=300 --retry-connrefused \
+         --header "Accept-Encoding: gzip,deflate" \
+         ${_W_cookiejar:+--load-cookies "$_W_cookiejar"} \
+         ${_W_agent:+--user-agent="$_W_agent"} \
+         "$_W_url"
+
+    cd "$_W_dl_olddir"
+    unset _W_dl_olddir
+
+    wt_check_file "$_W_cache/$_W_file" "$_W_sha1sum" "$_W_url ($_W_file)"
+}
+
+test_download() {
+   test_download_to "" "$@"
+}
+
+wt_gather_links() {
+   grep -E $1 ./winetricks | sed 's/^ *//' | sed -e 's,$WINETRICKS_SOURCEFORGE,'$WINETRICKS_SOURCEFORGE',g' | \
+        sed 's/^w_download/test_download/' | sort -f -u > $WT_LINK_LIST
+   # remove links which contains variables
+   sed -i '/[^\\]\$/d' $WT_LINK_LIST
+}
+
+wt_init_downloads() {
+   export W_CACHE="/tmp/winetricks-cache"
+   rm -rf "$W_CACHE"
+   mkdir -p $W_CACHE
+   WINETRICKS_SOURCEFORGE=http://downloads.sourceforge.net
+   WT_LINK_LIST="/tmp/winetricks_links.tmp"
+}
+
+test_downloads() {
+   wt_init_downloads
+   wt_gather_links '^\s*w_download(_to)?\s'
+   echo "`wc -l $WT_LINK_LIST | cut -d ' ' -f 1` downloads to check"
+   . $WT_LINK_LIST
+   rm -f $WT_LINK_LIST
+}
+
+test_manual_downloads() {
+   wt_init_downloads
+   wt_gather_links '^\s*w_download_manual\s'
+   echo "`wc -l $WT_LINK_LIST | cut -d ' ' -f 1` manual downloads to check"
+   . $WT_LINK_LIST
+   rm -f $WT_LINK_LIST
+}
+
 case "$1" in
 preload) test_preload;;
 quick) test_quick;;
 dotnet) test_preload ; test_dotnet;;
 full)  test_full;;
-*)     echo "Usage: $0 quick|full"; exit 1;;
+downloads)  test_downloads;;
+manual_downloads)  test_manual_downloads;;
+*)     echo "Usage: $0 quick|full|downloads|manual_downloads"; exit 1;;
 esac
 
 echo "Test over, $errors failures, $passes successes."

--- a/tests/winetricks-test
+++ b/tests/winetricks-test
@@ -3,8 +3,8 @@
 
 # Override this if you want to put the work area on a different disk
 WINE_PREFIXES=${WINE_PREFIXES:-$HOME/winetrickstest-prefixes}
-preloadcache="$HOME/winetricks-preload-cache"
-cache="$HOME/winetricks-cache"
+XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+cache="$XDG_CACHE_HOME/winetricks"
 
 set -x
 
@@ -412,7 +412,7 @@ test_install_cached_or_download()
 # Run this if you don't want to re-download them.
 test_preload()
 {
-    export W_CACHE="$preloadcache"
+    export W_CACHE="$cache"
     for a in msxml3 mdac27 dotnet30
     do
        rm -rf $WINE_PREFIXES/$a
@@ -425,11 +425,6 @@ test_quick()
     echo "warning: quick test takes up around 20GB"
     # Test the frequent download-changes-checksum offenders first
     export W_CACHE="$cache"
-    rm -rf "$W_CACHE"
-    if test -d "$preloadcache"
-    then
-        cp -a "$preloadcache" "$W_CACHE"
-    fi
     for a in $QUICKCHECK
     do
        rm -rf "$WINE_PREFIXES"/$a


### PR DESCRIPTION
This is basically update to #528 
Implementation isn't very pretty because had to copy some code from winetricks*, but it works fine, will test all links  (220 + 40 manual) and no need to run wine tests itself to check downloads.


\*I recommend splitting winetricks in multiple files and in makefile concatenate it together so it's more manageable, like apps/dlls in different files and could reuse code, wouldn't need to copy like this...
