### PR TITLE
vcrun2015: Avoid permission error

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -8145,6 +8145,7 @@ load_vcrun2015()
         w_download https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe 3155cb0f146b927fcc30647c1a904cd162548c8c
         if w_workaround_wine_bug 30713 "Manually extracting the 64-bit dlls"
         then
+            rm -f "$W_TMP"/*  # Avoid permission error
             w_try_cabextract --directory="$W_TMP" vc_redist.x64.exe
             w_try_cabextract --directory="$W_TMP" "$W_TMP/a10"
             w_try_cabextract --directory="$W_TMP" "$W_TMP/a11"


### PR DESCRIPTION
cabextract fails if wineprefix is 64bit.
This patch fixes this.