### PR TITLE
Offer both old and new versions of Adobe Digital Editions.

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -9282,6 +9282,26 @@ load_abiword()
 #----------------------------------------------------------------
 
 w_metadata adobe_diged apps \
+    title="Adobe Digital Editionsi 1.7" \
+    publisher="Adobe" \
+    year="2011" \
+    media="download" \
+    file1="setup.exe" \
+    installed_exe1="$W_PROGRAMS_X86_WIN/Adobe/Adobe Digital Editions/digitaleditions.exe" \
+    homepage="http://www.adobe.com/products/digitaleditions/"
+
+load_adobe_diged()
+{
+    w_download http://kb2.adobe.com/cps/403/kb403051/attachments/setup.exe 4c79685408fa6ca12ef8bb0e0eaa4a846e21f915
+    # NSIS installer
+    w_try "$WINE" "$W_CACHE"/$W_PACKAGE/setup.exe ${W_OPT_UNATTENDED:+ /S}
+    w_declare_exe "$W_PROGRAMS_X86_WIN\\Adobe\\Adobe Digital Editions" \
+        digitaleditions.exe
+}
+
+#----------------------------------------------------------------
+
+w_metadata adobe_diged4 apps \
     title="Adobe Digital Editions" \
     publisher="Adobe" \
     year="2015" \
@@ -9290,7 +9310,7 @@ w_metadata adobe_diged apps \
     installed_exe1="$W_PROGRAMS_X86_WIN/Adobe/Adobe Digital Editions 4.5/DigitalEditions.exe" \
     homepage="http://www.adobe.com/products/digitaleditions/"
 
-load_adobe_diged()
+load_adobe_diged4()
 {
     w_download http://download.adobe.com/pub/adobe/digitaleditions/ADE_4.5_Installer.exe
 

--- a/src/winetricks
+++ b/src/winetricks
@@ -9318,6 +9318,10 @@ load_adobe_diged4()
     then
         w_call corefonts
     fi
+    if [ ! -x "`which winbindd 2>/dev/null`" ]
+    then
+        w_warn "Adobe Digital Editions 4.5 requires winbind (part of samba) to be installed, but winbind was not detected."
+    fi
 
     w_call dotnet40
 


### PR DESCRIPTION
The new version has features that might be undesirable, especially to anyone who absolutely must use an old E-Ink ereader. ;)
I chose to use adobe_diged4 for the new version, since the old version is known to be reliable, does not require winbind/samba which may or may not be installed, and also because I subjectively feel it should be the default. :wink:

Also provide a warning when installing ADE 4.5 if winbind is not detected, since the application fails to actually run without it.

These changes are in reference to comments made in #561