### PR TITLE
Add "sound=pulse" verb

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -18874,6 +18874,9 @@ w_metadata sound=disabled settings \
 w_metadata sound=oss settings \
     title_uk="Поставити звуковий драйвер OSS" \
     title="Set sound driver to OSS"
+w_metadata sound=pulse settings \
+    title_uk="Поставити звуковий драйвер PulseAudio" \
+    title="Set sound driver to PulseAudio"
 
 load_sound()
 {


### PR DESCRIPTION
Set sound driver to PulseAudio.

Note: PulseAudio support is available since Wine 1.7.55.