### PR TITLE
updated sha1sum of steamsetup.exe

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -10904,7 +10904,8 @@ load_steam()
     # 11 Dec 2014 7ad8fbeffa6c963b821f80129c15c9d8e85f9a4a
     #  6 Jan 2015 e04aefe8bc894f11f211edec8e8a008abe0147d2
     # 21 Jun 2015 0e8046d40c38d817338135ec73a5b217cc340cf5
-    w_download http://media.steampowered.com/client/installer/SteamSetup.exe 0e8046d40c38d817338135ec73a5b217cc340cf5
+    # 29 Dec 2015 728e3c82fd57c68cbbdb64965719081ffee6272c
+    w_download http://media.steampowered.com/client/installer/SteamSetup.exe 728e3c82fd57c68cbbdb64965719081ffee6272c
     cd "$W_CACHE"/steam
 
     # Install corefonts first, so if the user doesn't have cabextract/Wine with cab support, we abort before installing Steam.


### PR DESCRIPTION
installing steam from winetricks fails because of a sha1sum mismatch (probably due to a new version of the steam installer)

just updated the sha1sum of the new executable so it can run