### PR TITLE
Adapt to new Debian /usr/bin/wineserver[-development].

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -4049,15 +4049,14 @@ winetricks_init()
         ;;
      *)
         WINE="${WINE:-wine}"
-        # Find wineserver.  Some distros (Debian) don't have it on the path,
-        # on the mistaken understanding that user scripts never need it :-(
-        # If wineserver is from wine-development set WINE to wine-development.
-        # FIXME: get packagers to put wineserver on the path.
+        # Find wineserver.
+        # Some distros (Debian before wine 1.8-2) don't have it on the path.
         for x in \
             "$WINESERVER" \
             "${WINE}server" \
             "`which wineserver 2> /dev/null`" \
             "`dirname $WINE`/server/wineserver" \
+            /usr/bin/wineserver-development \
             /usr/lib/wine/wineserver \
             /usr/lib/i386-kfreebsd-gnu/wine/wineserver \
             /usr/lib/i386-linux-gnu/wine/wineserver \
@@ -4075,7 +4074,7 @@ winetricks_init()
             if test -x "$x"
             then
                 case "$x" in
-                 /usr/lib/*/wine-development/wineserver)
+                 /usr/lib/*/wine-development/wineserver|/usr/bin/wineserver-development)
                     if test -x /usr/bin/wine-development
                     then
                         WINE="/usr/bin/wine-development"


### PR DESCRIPTION
Hi

Debian provides /usr/bin/wineserver since wine 1.8-2. So the existing workarounds for finding the wineserver are only needed for older Debian versions.
However for wine-development the wineserver will be /usr/bin/wineserver-development. I added that to the list and the binary detection code.

Thanks a lot
jre
