### PR TITLE
src/release.sh: create local signed release tarball

### DIFF
--- a/src/release.sh
+++ b/src/release.sh
@@ -39,4 +39,13 @@ git tag -s -m "winetricks-${version}" ${version}
 git push
 git push --tags
 
+# create local tarball, identical to github's generated one
+git archive --prefix="winetricks-${version}/" -o "../${version}.tar.gz" "${version}"
+
+# create a detached signature of the tarball
+gpg --armor --detach-sign "../${version}.tar.gz"
+
+echo "Go to https://github.com/winetricks/winetricks/releases/edit/${version}"
+echo "and upload the signature ../${version}.tar.gz.asc."
+
 exit 0


### PR DESCRIPTION
From the discussion at
http://lists.alioth.debian.org/pipermail/pkg-wine-party/2016-May/005549.html

See https://wiki.debian.org/Creating%20signed%20GitHub%20releases

Currently the  tarball is created bit-by-bit identical.
There might be issues if github recreates the tarballs later
and changes their gzip or git archive implementations.

Unfortunately github currently doesn't provide remote shell
access, so the signature needs to be uploaded in their
webinterface.
