### PR TITLE
mt4: do not use checksum for mt4setup.exe which may change

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -10433,7 +10433,7 @@ w_metadata mt4 apps \
 
 load_mt4()
 {
-    w_download https://download.mql5.com/cdn/web/metaquotes.software.corp/mt4/mt4setup.exe 07c094fc95916ba2b8d0282795717db3f4a5a9ba
+    w_download https://download.mql5.com/cdn/web/metaquotes.software.corp/mt4/mt4setup.exe
 
     if w_workaround_wine_bug 7156 "${title} needs wingdings.ttf, installing opensymbol"
     then


### PR DESCRIPTION
Currently installing `mt4` fails, because of checksum. This binary changes quiet recently, because of frequent upgrades.

The solution is to remove the hardcoded checksum.

Here is how it fails with the checksum:

```
$ ./winetricks mt4
Using winetricks 20160425 - sha1sum: d36800329168f106664455b692b6e62214ffdb4d with wine-1.6.2
Executing w_do_call mt4
Executing load_mt4
Executing mkdir -p /home/kenorb/.cache/winetricks/mt4
Downloading https://download.mql5.com/cdn/web/metaquotes.software.corp/mt4/mt4setup.exe to /home/kenorb/.cache/winetricks/mt4
--2016-05-29 03:31:13--  https://download.mql5.com/cdn/web/metaquotes.software.corp/mt4/mt4setup.exe
Resolving download.mql5.com (download.mql5.com)... 78.140.180.43
Connecting to download.mql5.com (download.mql5.com)|78.140.180.43|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 592152 (578K) [application/exe]
Saving to: ‘mt4setup.exe’

mt4setup.exe                                    100%[========================================================================================================>] 578.27K  --.-KB/s   in 0.07s  

2016-05-29 03:31:14 (8.07 MB/s) - ‘mt4setup.exe’ saved [592152/592152]

------------------------------------------------------
Checksum for /home/kenorb/.cache/winetricks/mt4/mt4setup.exe did not match, retrying download
------------------------------------------------------
Downloading https://web.archive.org/web/https://download.mql5.com/cdn/web/metaquotes.software.corp/mt4/mt4setup.exe to /home/kenorb/.cache/winetricks/mt4
--2016-05-29 03:31:14--  https://web.archive.org/web/https://download.mql5.com/cdn/web/metaquotes.software.corp/mt4/mt4setup.exe
Resolving web.archive.org (web.archive.org)... 207.241.225.186
Connecting to web.archive.org (web.archive.org)|207.241.225.186|:443... connected.
HTTP request sent, awaiting response... 403 Forbidden
2016-05-29 03:31:14 ERROR 403: Forbidden.

------------------------------------------------------
Downloading https://web.archive.org/web/https://download.mql5.com/cdn/web/metaquotes.software.corp/mt4/mt4setup.exe failed
```