### PR TITLE
use detected torify and torify options for aria2c

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -796,9 +796,15 @@ w_download_to()
         esac
 
         case "$WINETRICKS_OPT_TORIFY" in
-        1) torify=torify ; if [ ! -x "$(which torify 2>/dev/null)" ] ; then
-           w_die "--torify was used, but torify is not installed, please install it." ; exit 1 ; fi ;;
-        *) torify= ;;
+        1) torify=torify
+           # torify needs --async-dns=false, see https://github.com/tatsuhiro-t/aria2/issues/613
+           aria2c_torify_opts="--async-dns=false"
+           if [ ! -x "$(which torify 2>/dev/null)" ]
+           then
+               w_die "--torify was used, but torify is not installed, please install it." ; exit 1
+           fi ;;
+        *) torify=
+           aria2c_torify_opts= ;;
         esac
 
         if [ -x "$(which aria2c 2>/dev/null)" ]
@@ -813,13 +819,8 @@ w_download_to()
             #   ovewritten by the new aria2 process
             # http-accept-gzip=true (still needed) ?
 
-            # torify needs --async-dns=false, see https://github.com/tatsuhiro-t/aria2/issues/613
-            case $WINETRICKS_OPT_TORIFY in
-            1) torify aria2c --async-dns=false --continue --daemon=false --dir "$_W_cache"  --enable-rpc=false --input-file='' \
-                --max-connection-per-server=5 --out "$_W_file" --save-session='' --stream-piece-selector=geom "$_W_url" ;;
-            *) aria2c --continue --daemon=false --dir "$_W_cache"  --enable-rpc=false --input-file='' \
-                --max-connection-per-server=5 --out "$_W_file" --save-session='' --stream-piece-selector=geom "$_W_url" ;;
-            esac
+            $torify aria2c $aria2c_torify_opts --continue --daemon=false --dir "$_W_cache"  --enable-rpc=false --input-file='' \
+                --max-connection-per-server=5 --out "$_W_file" --save-session='' --stream-piece-selector=geom "$_W_url"
         elif [ -x "$(which wget 2>/dev/null)" ]
         then
            # Use -nd to insulate ourselves from people who set -x in WGETRC


### PR DESCRIPTION
this patch removes copy-paste code and masks direct run aria2c and torify (need against shell code requirement tools).