### PR TITLE
Add AppStream appdata file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,8 @@ install:
 	$(INSTALL_DATA) src/winetricks.1 $(DESTDIR)$(PREFIX)/share/man/man1/winetricks.1
 	$(INSTALL) -d $(DESTDIR)$(PREFIX)/share/applications
 	$(INSTALL_DATA) src/winetricks.desktop $(DESTDIR)$(PREFIX)/share/applications/winetricks.desktop
+	$(INSTALL) -d $(DESTDIR)$(PREFIX)/share/appdata
+	$(INSTALL_DATA) src/winetricks.appdata.xml $(DESTDIR)$(PREFIX)/share/appdata/winetricks.appdata.xml
 	$(INSTALL) -d $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps
 	$(INSTALL_DATA) src/winetricks.svg $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/winetricks.svg
 

--- a/src/winetricks.appdata.xml
+++ b/src/winetricks.appdata.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2017 Daniel Rusek <mail@asciiwolf.com> -->
+<component type="desktop">
+  <id>winetricks.desktop</id>
+  <project_license>GPL-2.1</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Winetricks</name>
+  <summary>Work around problems and install applications under Wine</summary>
+  <description>
+    <p>
+    Winetricks is an easy way to work around problems in Wine.
+    </p>
+    <p>
+    It lets you install missing DLLs or tweak various Wine settings individually.
+    It also has a menu of supported games/apps for which it can do all the workarounds automatically.
+    </p>
+  </description>
+  <url type="homepage">https://github.com/Winetricks/winetricks</url>
+  <update_contact>mail@asciiwolf.com</update_contact>
+</component>


### PR DESCRIPTION
AppStream is a cross-distro XML format to provide metadata for software components and to assign unique identifiers to software. The metadata can for example be used by software centers like GNOME Software or KDE Discover to display a user-friendly application-centric way on the package archive.

This PR adds an AppStream AppData file.