### PR TITLE
Add VLGothic Japanese fonts and aliases for "Meiryo" fonts

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -10151,6 +10151,28 @@ load_fakejapanese_ipamona()
 
 #----------------------------------------------------------------
 
+w_metadata fakejapanese_vlgothic fonts \
+    title="Creates aliases for Japanese Meiryo fonts using VLGothic fonts" \
+    publisher="Project Vine / Daisuke Suzuki" \
+    year="2014"
+
+load_fakejapanese_vlgothic()
+{
+    w_call vlgothic
+
+    # Aliases to set:
+    # Meiryo UI --> VL Gothic
+    # Meiryo (メイリオ) --> VL Gothic
+
+    jpname_meiryo="$(echo "メイリオ" | iconv -f utf8 -t cp932)"
+
+    w_register_font_replacement "Meiryo UI" "VL Gothic"
+    w_register_font_replacement "Meiryo" "VL Gothic"
+    w_register_font_replacement "$jpname_meiryo" "VL Gothic"
+}
+
+#----------------------------------------------------------------
+
 w_metadata fakekorean fonts \
     title="Creates aliases for Korean fonts using Baekmuk fonts" \
     publisher="Wooderart Inc. / kldp.net" \

--- a/src/winetricks
+++ b/src/winetricks
@@ -10422,6 +10422,9 @@ w_metadata vlgothic fonts \
 
 load_vlgothic()
 {
+    # The "homepage" is already assigned in w_do_call()
+    # and this works as expected
+    # shellcheck disable=SC2154
     w_download "$homepage/downloads/62375/$file1" 982040db2f9cb73d7c6ab7d9d163f2ed46d1180f330c9ba2fae303649bf8102d
 
     w_try_cd "$W_TMP"

--- a/src/winetricks
+++ b/src/winetricks
@@ -10389,6 +10389,30 @@ load_uff()
 
 #----------------------------------------------------------------
 
+w_metadata vlgothic fonts \
+    title="VLGothic Japanese fonts" \
+    publisher="Project Vine / Daisuke Suzuki" \
+    year="2014" \
+    media="download" \
+    file1="VLGothic-20141206.tar.xz" \
+    installed_file1="$W_FONTSDIR_WIN/VL-Gothic-Regular.ttf" \
+    homepage="https://ja.osdn.net/projects/vlgothic"
+
+load_vlgothic()
+{
+    w_download "$homepage/downloads/62375/$file1" 982040db2f9cb73d7c6ab7d9d163f2ed46d1180f330c9ba2fae303649bf8102d
+
+    w_try_cd "$W_TMP"
+
+    unxz -dc "$W_CACHE/$W_PACKAGE/$file1" | tar -xf -
+    w_try mv ./VLGothic/*.ttf "$W_FONTSDIR_UNIX"
+
+    w_register_font VL-Gothic-Regular.ttf "VL Gothic"
+    w_register_font VL-PGothic-Regular.ttf "VL PGothic"
+}
+
+#----------------------------------------------------------------
+
 w_metadata wenquanyi fonts \
     title="WenQuanYi CJK font" \
     publisher="wenq.org" \


### PR DESCRIPTION
## About the patchset

I found a game which requires "Meiryo" Japanese fonts (which are included since Windows Vista). In this game, some characters (mainly letters/numbers) are invisible unless aliases for "Meiryo" fonts are defined.

The patches add "vlgothic" and "fakejapanese_vlgothic" verbs:

* vlgothic: Install VLGothic fonts
* fakejapanese_vlgothic: Add aliases for "Meiryo" fonts ("メイリオ", "Meiryo" and "Meiryo UI")

## Screenshots

* [Windows](https://2.bp.blogspot.com/-6Y2NjLDBVg8/WdD45idATfI/AAAAAAAABBc/aOxPWfTTTjs4J2Oj7xvGF6ooKod4F_WQQCKgBGAs/s1600/yumemigusa-keybindings-windows.png)

* [Unpatched (broken: some characters are invisible, DroidSansFallbackFull.ttf is used)](https://1.bp.blogspot.com/-RxF1jY9sO8U/WdD45nWybyI/AAAAAAAABBc/p0ltBfDEnvU_1quFU4oLl6sqLktvC8mpgCKgBGAs/s1600/yumemigusa-keybindings-unpatched.png)

* [Use IPAMona to replace "Meiryo" (set manually)](https://2.bp.blogspot.com/-uLLqpl1_-XU/WdD45qD8P4I/AAAAAAAABBc/bywIBV8Y6_k2SImjYzkj37dM7-VA9G7_gCKgBGAs/s1600/yumemigusa-keybindings-ipamona.png)

* [Use VLGothic to replace "Meiryo" (use this patchset)](https://4.bp.blogspot.com/-F5rCt6Q_MZk/WdD45hSkQ5I/AAAAAAAABBc/mpfPsRKZTDke6Aa5wb-GYtSmB0hAweTPwCKgBGAs/s1600/yumemigusa-keybindings-vlgothic.png)

## About fakejapanese verbs

I think VLGothic is more suitable than IPAMona and Takao fonts to replace "Meiryo" fonts, but VLGothic is less suitable than IPAMona to replace "MS Gothic/MS Mincho" fonts. So I need both "fakejapanese_vlgothic" and "fakejapanese(_ipamona)".
