### PR TITLE
tracking stats: create cache directory if needed

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -18787,6 +18787,9 @@ winetricks_stats_save()
 {
     # Save opt-in status
     if test "$WINETRICKS_STATS_REPORT"; then
+        if test ! -d "$W_CACHE"; then
+            mkdir -p "$W_CACHE"
+        fi
         echo "$WINETRICKS_STATS_REPORT" > "$W_CACHE"/track_usage
     fi
 }
@@ -18841,11 +18844,10 @@ winetricks_stats_init()
                     $WINETRICKS_GUI --info --text "$declined"
                     WINETRICKS_STATS_REPORT=0
                 fi
-                echo $WINETRICKS_STATS_REPORT > "$W_CACHE"/track_usage
+                winetricks_stats_save
                 ;;
         esac
     fi
-    winetricks_stats_save
 }
 
 # Retrieve a short string with the operating system name and version


### PR DESCRIPTION
If ~/.cache/winetricks did not exist, this failed before:

```
$ ./winetricks 
------------------------------------------------------
You are using a 64-bit WINEPREFIX. Note that many verbs only install 32-bit versions of packages. If you encounter problems, please retest in a clean 32-bit WINEPREFIX before reporting a bug.
------------------------------------------------------
Using winetricks 20171018-next - sha256sum: e586dbf0ebdd7969b558e1e03372bfd7e735a98a33e95bdad32d831e6b2cc2db with wine-2.18 (Debian 2.18-1+wip1) and WINEARCH=win64
Gtk-Message: GtkDialog mapped without a transient parent. This is discouraged.
Gtk-Message: GtkDialog mapped without a transient parent. This is discouraged.
Gtk-Message: GtkDialog mapped without a transient parent. This is discouraged.
./winetricks: 18844: ./winetricks: cannot create /home/jens/.cache/winetricks/track_usage: Directory nonexistent
./winetricks: 18790: ./winetricks: cannot create /home/jens/.cache/winetricks/track_usage: Directory nonexistent
```

So in winetricks_stats_save first test for the directories existence and create it if necessary.

In winetricks_stats_init just use winetricks_stats_save instead of hardcoding the command. Also only call it if the user was asked about it, but before displaying the confirmation message.

EDIT: Dropped the "but before displaying the confirmation message" change.

Greets!