### PR TITLE
Fix font duplication

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -514,6 +514,49 @@ w_try_unzip()
     w_try "$WINE" "$W_PROGRAMS_X86_WIN\\7-Zip\\7z.exe" x "$(w_pathconv -w "$zipfile")" -o"$(w_pathconv -w "$destdir")" "$@"
 }
 
+# Copy font files matching a glob pattern from source directory to destination directory.
+# Also remove any file in the destination directory that has the same name as
+# any of the files that we're trying to copy, but with different case letters.
+# Note: it converts font file names to lower case to avoid inconsistencies due to paths
+#       being case-insensitive under Wine.
+w_try_cp_font_files()
+{
+    # $1 - source directory
+    # $2 - destination directory
+    # $3 - optional font file glob pattern (default: "*.ttf")
+
+    _W_src_dir="$1"
+    _W_dest_dir="$2"
+    _W_pattern="$3"
+    shift 2
+
+    if test ! -d "$_W_src_dir"; then
+        w_die "bug: missing source dir"
+    fi
+
+    if test ! -d "$_W_dest_dir"; then
+        w_die "bug: missing destination dir"
+    fi
+
+    if test -z "$_W_pattern"; then
+        _W_pattern="*.ttf"
+    fi
+
+    _W_src_files=$(find "$_W_src_dir" -maxdepth 1 -type f -iname "$_W_pattern")
+
+    for _W_src_file in $_W_src_files; do
+        # Extract the file name and lower case it
+        _W_file_name=$(basename "$_W_src_file" | tr "[:upper:]" "[:lower:]")
+
+        # Remove any existing font files that might have the same name, but with different case characters
+        find "$_W_dest_dir" -maxdepth 1 -type f -iname "$_W_file_name" -exec rm '{}' ';'
+
+        w_try cp -f "$_W_src_file" "$_W_dest_dir/$_W_file_name"
+    done
+
+    unset _W_src_files _W_dest_dir _W_src_file _W_file_name
+}
+
 w_read_key()
 {
     if test ! "$W_OPT_UNATTENDED"; then

--- a/src/winetricks
+++ b/src/winetricks
@@ -10086,11 +10086,11 @@ load_baekmuk()
 {
     # See http://kldp.net/projects/baekmuk for project page
     # Need to download from Debian as the project page has unique captcha tokens per visitor
-    w_download http://http.debian.net/debian/pool/main/f/fonts-baekmuk/fonts-baekmuk_2.2.orig.tar.gz 08ab7dffb55d5887cc942ce370f5e33b756a55fbb4eaf0b90f244070e8d51882
+    w_download "http://http.debian.net/debian/pool/main/f/fonts-baekmuk/fonts-baekmuk_2.2.orig.tar.gz" 08ab7dffb55d5887cc942ce370f5e33b756a55fbb4eaf0b90f244070e8d51882
 
     w_try_cd "$W_TMP"
-    tar zxvf "$W_CACHE/$W_PACKAGE/$file1" baekmuk-ttf-2.2/ttf
-    w_try mv baekmuk-ttf-2.2/ttf/*.ttf "$W_FONTSDIR_UNIX"
+    w_try tar -zxf "$W_CACHE/$W_PACKAGE/$file1" baekmuk-ttf-2.2/ttf
+    w_try_cp_font_files baekmuk-ttf-2.2/ttf/ "$W_FONTSDIR_UNIX"
     w_register_font batang.ttf "Baekmuk Batang"
     w_register_font gulim.ttf "Baekmuk Gulim"
     w_register_font dotum.ttf "Baekmuk Dotum"
@@ -10126,9 +10126,10 @@ w_metadata cambria fonts \
 load_cambria()
 {
     # https://www.microsoft.com/en-us/download/details.aspx?id=13
-    w_download_to consolas https://download.microsoft.com/download/E/6/7/E675FFFC-2A6D-4AB0-B3EB-27C9F8C8F696/PowerPointViewer.exe 249473568eba7a1e4f95498acba594e0f42e6581add4dead70c1dfb908a09423
-    w_try_cabextract -d "$W_TMP" -L -F ppviewer.cab "$W_CACHE"/consolas/PowerPointViewer.exe
-    w_try_cabextract -d "$W_FONTSDIR_UNIX" -L -F 'CAMBRIA*.TT*' "$W_TMP"/ppviewer.cab
+    w_download_to PowerPointViewer "https://download.microsoft.com/download/E/6/7/E675FFFC-2A6D-4AB0-B3EB-27C9F8C8F696/PowerPointViewer.exe" 249473568eba7a1e4f95498acba594e0f42e6581add4dead70c1dfb908a09423
+    w_try_cabextract -d "$W_TMP" -F "ppviewer.cab" "$W_CACHE/PowerPointViewer/$file1"
+    w_try_cabextract -d "$W_TMP" -F "CAMBRIA*.TT*" "$W_TMP/ppviewer.cab"
+    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "CAMBRIA*.TT*"
     w_register_font cambria.ttc "Cambria"
     w_register_font cambriab.ttf "Cambria Bold"
     w_register_font cambriai.ttf "Cambria Italic"
@@ -10148,9 +10149,10 @@ w_metadata constantia fonts \
 load_constantia()
 {
     # https://www.microsoft.com/en-us/download/details.aspx?id=13
-    w_download_to consolas https://download.microsoft.com/download/E/6/7/E675FFFC-2A6D-4AB0-B3EB-27C9F8C8F696/PowerPointViewer.exe 249473568eba7a1e4f95498acba594e0f42e6581add4dead70c1dfb908a09423
-    w_try_cabextract -d "$W_TMP" -L -F ppviewer.cab "$W_CACHE"/consolas/PowerPointViewer.exe
-    w_try_cabextract -d "$W_FONTSDIR_UNIX" -L -F 'CONSTAN*.TTF' "$W_TMP"/ppviewer.cab
+    w_download_to PowerPointViewer "https://download.microsoft.com/download/E/6/7/E675FFFC-2A6D-4AB0-B3EB-27C9F8C8F696/PowerPointViewer.exe" 249473568eba7a1e4f95498acba594e0f42e6581add4dead70c1dfb908a09423
+    w_try_cabextract -d "$W_TMP" -F "ppviewer.cab" "$W_CACHE/PowerPointViewer/$file1"
+    w_try_cabextract -d "$W_TMP" -F "CONSTAN*.TTF" "$W_TMP/ppviewer.cab"
+    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "CONSTAN*.TTF"
     w_register_font constan.ttf "Constantia"
     w_register_font constanb.ttf "Constantia Bold"
     w_register_font constani.ttf "Constantia Italic"
@@ -10170,9 +10172,10 @@ w_metadata consolas fonts \
 load_consolas()
 {
     # https://www.microsoft.com/en-us/download/details.aspx?id=13
-    w_download https://download.microsoft.com/download/E/6/7/E675FFFC-2A6D-4AB0-B3EB-27C9F8C8F696/PowerPointViewer.exe 249473568eba7a1e4f95498acba594e0f42e6581add4dead70c1dfb908a09423
-    w_try_cabextract -d "$W_TMP" -L -F ppviewer.cab "$W_CACHE"/consolas/PowerPointViewer.exe
-    w_try_cabextract -d "$W_FONTSDIR_UNIX" -L -F 'CONSOL*.TTF' "$W_TMP"/ppviewer.cab
+    w_download_to PowerPointViewer "https://download.microsoft.com/download/E/6/7/E675FFFC-2A6D-4AB0-B3EB-27C9F8C8F696/PowerPointViewer.exe" 249473568eba7a1e4f95498acba594e0f42e6581add4dead70c1dfb908a09423
+    w_try_cabextract -d "$W_TMP" -F "ppviewer.cab" "$W_CACHE/PowerPointViewer/$file1"
+    w_try_cabextract -d "$W_TMP" -F "CONSOLA*.TTF" "$W_TMP/ppviewer.cab"
+    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "CONSOLA*.TTF"
     w_register_font consola.ttf "Consoleas"
     w_register_font consolab.ttf "Consoleas Bold"
     w_register_font consolai.ttf "Consoleas Italic"
@@ -10187,85 +10190,84 @@ w_metadata corefonts fonts \
     year="2008" \
     media="download" \
     file1="arial32.exe" \
-    installed_file1="$W_FONTSDIR_WIN/Arial.TTF"
+    installed_file1="$W_FONTSDIR_WIN/arial.ttf"
 
 load_corefonts()
 {
-    # FIXME: why is this commented out? Should be removed or enabled.
-    w_download https://mirrors.kernel.org/gentoo/distfiles/arial32.exe 85297a4d146e9c87ac6f74822734bdee5f4b2a722d7eaa584b7f2cbf76f478f6
-    w_download https://mirrors.kernel.org/gentoo/distfiles/arialb32.exe a425f0ffb6a1a5ede5b979ed6177f4f4f4fdef6ae7c302a7b7720ef332fec0a8
-    w_download https://mirrors.kernel.org/gentoo/distfiles/comic32.exe 9c6df3feefde26d4e41d4a4fe5db2a89f9123a772594d7f59afd062625cd204e
-    w_download https://mirrors.kernel.org/gentoo/distfiles/courie32.exe bb511d861655dde879ae552eb86b134d6fae67cb58502e6ff73ec5d9151f3384
-    w_download https://mirrors.kernel.org/gentoo/distfiles/georgi32.exe 2c2c7dcda6606ea5cf08918fb7cd3f3359e9e84338dc690013f20cd42e930301
-    w_download https://mirrors.kernel.org/gentoo/distfiles/impact32.exe 6061ef3b7401d9642f5dfdb5f2b376aa14663f6275e60a51207ad4facf2fccfb
-    w_download https://mirrors.kernel.org/gentoo/distfiles/times32.exe db56595ec6ef5d3de5c24994f001f03b2a13e37cee27bc25c58f6f43e8f807ab
-    w_download https://mirrors.kernel.org/gentoo/distfiles/trebuc32.exe 5a690d9bb8510be1b8b4fe49f1f2319651fe51bbe54775ddddd8ef0bd07fdac9
-    w_download https://mirrors.kernel.org/gentoo/distfiles/verdan32.exe c1cb61255e363166794e47664e2f21af8e3a26cb6346eb8d2ae2fa85dd5aad96
-    w_download https://mirrors.kernel.org/gentoo/distfiles/webdin32.exe 64595b5abc1080fba8610c5c34fab5863408e806aafe84653ca8575bed17d75a
+    w_download "https://mirrors.kernel.org/gentoo/distfiles/arial32.exe" 85297a4d146e9c87ac6f74822734bdee5f4b2a722d7eaa584b7f2cbf76f478f6
+    w_download "https://mirrors.kernel.org/gentoo/distfiles/arialb32.exe" a425f0ffb6a1a5ede5b979ed6177f4f4f4fdef6ae7c302a7b7720ef332fec0a8
+    w_download "https://mirrors.kernel.org/gentoo/distfiles/comic32.exe" 9c6df3feefde26d4e41d4a4fe5db2a89f9123a772594d7f59afd062625cd204e
+    w_download "https://mirrors.kernel.org/gentoo/distfiles/courie32.exe" bb511d861655dde879ae552eb86b134d6fae67cb58502e6ff73ec5d9151f3384
+    w_download "https://mirrors.kernel.org/gentoo/distfiles/georgi32.exe" 2c2c7dcda6606ea5cf08918fb7cd3f3359e9e84338dc690013f20cd42e930301
+    w_download "https://mirrors.kernel.org/gentoo/distfiles/impact32.exe" 6061ef3b7401d9642f5dfdb5f2b376aa14663f6275e60a51207ad4facf2fccfb
+    w_download "https://mirrors.kernel.org/gentoo/distfiles/times32.exe" db56595ec6ef5d3de5c24994f001f03b2a13e37cee27bc25c58f6f43e8f807ab
+    w_download "https://mirrors.kernel.org/gentoo/distfiles/trebuc32.exe" 5a690d9bb8510be1b8b4fe49f1f2319651fe51bbe54775ddddd8ef0bd07fdac9
+    w_download "https://mirrors.kernel.org/gentoo/distfiles/verdan32.exe" c1cb61255e363166794e47664e2f21af8e3a26cb6346eb8d2ae2fa85dd5aad96
+    w_download "https://mirrors.kernel.org/gentoo/distfiles/webdin32.exe" 64595b5abc1080fba8610c5c34fab5863408e806aafe84653ca8575bed17d75a
 
     # Natively installed versions of these fonts will cause the installers
     # to exit silently. Because there are apps out there that depend on the
     # files being present in the Windows font directory we use cabextract
     # to obtain the files and register the fonts by hand.
 
-    w_try_cabextract -q --directory="$W_TMP" "$W_CACHE"/corefonts/arial32.exe
-    w_try cp -f "$W_TMP"/Arial*.TTF "$W_FONTSDIR_UNIX"
-    w_register_font Arial.TTF "Arial"
-    w_register_font Arialbd.TTF "Arial Bold"
-    w_register_font Arialbi.TTF "Arial Bold Italic"
-    w_register_font Ariali.TTF "Arial Italic"
+    w_try_cabextract -d "$W_TMP" "$W_CACHE"/corefonts/arial32.exe
+    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "Arial*.TTF"
+    w_register_font arial.ttf "Arial"
+    w_register_font arialbd.ttf "Arial Bold"
+    w_register_font arialbi.ttf "Arial Bold Italic"
+    w_register_font ariali.ttf "Arial Italic"
 
-    w_try_cabextract -q --directory="$W_TMP" "$W_CACHE"/corefonts/arialb32.exe
-    w_try cp -f "$W_TMP"/AriBlk.TTF "$W_FONTSDIR_UNIX"
-    w_register_font AriBlk.TTF "Arial Black"
+    w_try_cabextract -d "$W_TMP" "$W_CACHE"/corefonts/arialb32.exe
+    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "AriBlk.TTF"
+    w_register_font ariblk.ttf "Arial Black"
 
-    w_try_cabextract -q --directory="$W_TMP" "$W_CACHE"/corefonts/comic32.exe
-    w_try cp -f "$W_TMP"/Comic*.TTF "$W_FONTSDIR_UNIX"
-    w_register_font Comic.TTF "Comic Sans MS"
-    w_register_font Comicbd.TTF "Comic Sans MS Bold"
+    w_try_cabextract -d "$W_TMP" "$W_CACHE"/corefonts/comic32.exe
+    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "Comic*.TTF"
+    w_register_font comic.ttf "Comic Sans MS"
+    w_register_font comicbd.ttf "Comic Sans MS Bold"
 
-    w_try_cabextract -q --directory="$W_TMP" "$W_CACHE"/corefonts/courie32.exe
-    w_try cp -f "$W_TMP"/cour*.ttf "$W_FONTSDIR_UNIX"
-    w_register_font Cour.TTF "Courier New"
-    w_register_font CourBD.TTF "Courier New Bold"
-    w_register_font CourBI.TTF "Courier New Bold Italic"
-    w_register_font Couri.TTF "Courier New Italic"
+    w_try_cabextract -d "$W_TMP" "$W_CACHE"/corefonts/courie32.exe
+    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "cour*.ttf"
+    w_register_font cour.ttf "Courier New"
+    w_register_font courbd.ttf "Courier New Bold"
+    w_register_font courbi.ttf "Courier New Bold Italic"
+    w_register_font couri.ttf "Courier New Italic"
 
-    w_try_cabextract -q --directory="$W_TMP" "$W_CACHE"/corefonts/georgi32.exe
-    w_try cp -f "$W_TMP"/Georgia*.TTF "$W_FONTSDIR_UNIX"
-    w_register_font Georgia.TTF "Georgia"
-    w_register_font Georgiab.TTF "Georgia Bold"
-    w_register_font Georgiaz.TTF "Georgia Bold Italic"
-    w_register_font Georgiai.TTF "Georgia Italic"
+    w_try_cabextract -d "$W_TMP" "$W_CACHE"/corefonts/georgi32.exe
+    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "Georgia*.TTF"
+    w_register_font georgia.ttf "Georgia"
+    w_register_font georgiab.ttf "Georgia Bold"
+    w_register_font georgiaz.ttf "Georgia Bold Italic"
+    w_register_font georgiai.ttf "Georgia Italic"
 
-    w_try_cabextract -q --directory="$W_TMP" "$W_CACHE"/corefonts/impact32.exe
-    w_try cp -f "$W_TMP"/Impact.TTF "$W_FONTSDIR_UNIX"
-    w_register_font Impact.TTF "Impact"
+    w_try_cabextract -d "$W_TMP" "$W_CACHE"/corefonts/impact32.exe
+    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "Impact.TTF"
+    w_register_font impact.ttf "Impact"
 
-    w_try_cabextract -q --directory="$W_TMP" "$W_CACHE"/corefonts/times32.exe
-    w_try cp -f "$W_TMP"/Times*.TTF "$W_FONTSDIR_UNIX"
-    w_register_font Times.TTF "Times New Roman"
-    w_register_font Timesbd.TTF "Times New Roman Bold"
-    w_register_font Timesbi.TTF "Times New Roman Bold Italic"
-    w_register_font Timesi.TTF "Times New Roman Italic"
+    w_try_cabextract -d "$W_TMP" "$W_CACHE"/corefonts/times32.exe
+    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "Times*.TTF"
+    w_register_font times.ttf "Times New Roman"
+    w_register_font timesbd.ttf "Times New Roman Bold"
+    w_register_font timesbi.ttf "Times New Roman Bold Italic"
+    w_register_font timesi.ttf "Times New Roman Italic"
 
-    w_try_cabextract -q --directory="$W_TMP" "$W_CACHE"/corefonts/trebuc32.exe
-    w_try cp -f "$W_TMP"/[tT]rebuc*.ttf "$W_FONTSDIR_UNIX"
-    w_register_font Trebuc.TTF "Trebucet MS"
-    w_register_font Trebucbd.TTF "Trebucet MS Bold"
-    w_register_font Trebucbi.TTF "Trebucet MS Bold Italic"
-    w_register_font Trebucit.TTF "Trebucet MS Italic"
+    w_try_cabextract -d "$W_TMP" "$W_CACHE"/corefonts/trebuc32.exe
+    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "[tT]rebuc*.ttf"
+    w_register_font trebuc.ttf "Trebucet MS"
+    w_register_font trebucbd.ttf "Trebucet MS Bold"
+    w_register_font trebucbi.ttf "Trebucet MS Bold Italic"
+    w_register_font trebucit.ttf "Trebucet MS Italic"
 
-    w_try_cabextract -q --directory="$W_TMP" "$W_CACHE"/corefonts/verdan32.exe
-    w_try cp -f "$W_TMP"/Verdana*.TTF "$W_FONTSDIR_UNIX"
-    w_register_font Verdana.TTF "Verdana"
-    w_register_font Verdanab.TTF "Verdana Bold"
-    w_register_font Verdanaz.TTF "Verdana Bold Italic"
-    w_register_font Verdanai.TTF "Verdana Italic"
+    w_try_cabextract -d "$W_TMP" "$W_CACHE"/corefonts/verdan32.exe
+    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "Verdana*.TTF"
+    w_register_font verdana.ttf "Verdana"
+    w_register_font verdanab.ttf "Verdana Bold"
+    w_register_font verdanaz.ttf "Verdana Bold Italic"
+    w_register_font verdanai.ttf "Verdana Italic"
 
-    w_try_cabextract -q --directory="$W_TMP" "$W_CACHE"/corefonts/webdin32.exe
-    w_try cp -f "$W_TMP"/Webdings.TTF "$W_FONTSDIR_UNIX"
-    w_register_font Webdings.TTF "Webdings"
+    w_try_cabextract -d "$W_TMP" "$W_CACHE"/corefonts/webdin32.exe
+    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "Webdings.TTF"
+    w_register_font webdings.ttf "Webdings"
 }
 
 #----------------------------------------------------------------
@@ -10276,12 +10278,12 @@ w_metadata droid fonts \
     year="2009" \
     media="download" \
     file1="DroidSans-Bold.ttf" \
-    installed_file1="$W_FONTSDIR_WIN/DroidSans-Bold.ttf"
+    installed_file1="$W_FONTSDIR_WIN/droidsans-bold.ttf"
 
 do_droid() {
-    w_download "${DROID_URL}${1}?raw=true" "${3}"  "${1}"
-    w_try cp -f "$W_CACHE/droid/$1" "$W_FONTSDIR_UNIX"
-    w_register_font "$1" "$2"
+    w_download "${_W_droid_url}${1}?raw=true" "$3"  "$1"
+    w_try_cp_font_files "$W_CACHE/droid" "$W_FONTSDIR_UNIX" "$1"
+    w_register_font "$(echo "$1" | tr "[:upper:]" "[:lower:]")" "$2"
 }
 
 load_droid()
@@ -10290,7 +10292,7 @@ load_droid()
     # Old URL was http://android.git.kernel.org/?p=platform/frameworks/base.git;a=blob_plain;f=data/fonts/'
     # Then it was https://github.com/android/platform_frameworks_base/blob/master/data/fonts/
     # but the fonts are no longer in master. Using an older commit instead:
-    DROID_URL='https://github.com/android/platform_frameworks_base/blob/feef9887e8f8eb6f64fc1b4552c02efb5755cdc1/data/fonts/'
+    _W_droid_url="https://github.com/android/platform_frameworks_base/blob/feef9887e8f8eb6f64fc1b4552c02efb5755cdc1/data/fonts/"
 
     do_droid DroidSans-Bold.ttf        "Droid Sans Bold"         2f529a3e60c007979d95d29794c3660694217fb882429fb33919d2245fe969e9
     do_droid DroidSansFallback.ttf     "Droid Sans Fallback"     05d71b179ef97b82cf1bb91cef290c600a510f77f39b4964359e3ef88378c79d
@@ -10301,6 +10303,8 @@ load_droid()
     do_droid DroidSerif-Bold.ttf       "Droid Serif Bold"        d28533eed8368f047eb5f57a88a91ba2ffc8b69a2dec5e50fe3f0c11ae3f4d8e
     do_droid DroidSerif-Italic.ttf     "Droid Serif Italic"      8a55a4823886234792991dd304dfa1fa120ae99483ec6c2255597d7d913b9a55
     do_droid DroidSerif-Regular.ttf    "Droid Serif"             22aea9471bea5bce1ec3bf7136c84f075b3d11cf09dffdc3dba05e570094cbde
+
+    unset _W_droid_url
 }
 
 #----------------------------------------------------------------
@@ -10316,26 +10320,26 @@ w_metadata eufonts fonts \
 load_eufonts()
 {
     # https://www.microsoft.com/en-us/download/details.aspx?id=16083
-    w_download https://download.microsoft.com/download/a/1/8/a180e21e-9c2b-4b54-9c32-bf7fd7429970/EUupdate.EXE 464dd2cd5f09f489f9ac86ea7790b7b8548fc4e46d9f889b68d2cdce47e09ea8
-    w_try_cabextract -q --directory="$W_TMP" "$W_CACHE"/eufonts/EUupdate.EXE
-    w_try cp -f "$W_TMP"/*.ttf "$W_FONTSDIR_UNIX"
+    w_download "https://download.microsoft.com/download/a/1/8/a180e21e-9c2b-4b54-9c32-bf7fd7429970/EUupdate.EXE" 464dd2cd5f09f489f9ac86ea7790b7b8548fc4e46d9f889b68d2cdce47e09ea8
+    w_try_cabextract -d "$W_TMP" "$W_CACHE"/eufonts/EUupdate.EXE
+    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX"
 
-    w_register_font ArialBd.ttf "Arial Bold"
-    w_register_font ArialBI.ttf "Arial Bold Italic"
-    w_register_font ArialI.ttf "Arial Italic"
-    w_register_font Arial.ttf "Arial"
-    w_register_font TimesBd.ttf "Times New Roman Bold"
-    w_register_font TimesBI.ttf "Times New Roman Bold Italic"
-    w_register_font TimesI.ttf "Times New Roman Italic"
-    w_register_font Times.ttf "Times New Roman"
+    w_register_font arialbd.ttf "Arial Bold"
+    w_register_font arialbi.ttf "Arial Bold Italic"
+    w_register_font ariali.ttf "Arial Italic"
+    w_register_font arial.ttf "Arial"
+    w_register_font timesbd.ttf "Times New Roman Bold"
+    w_register_font timesbi.ttf "Times New Roman Bold Italic"
+    w_register_font timesi.ttf "Times New Roman Italic"
+    w_register_font times.ttf "Times New Roman"
     w_register_font trebucbd.ttf "Trebuchet Bold"
     w_register_font trebucbi.ttf "Trebuchet Bold Italic"
     w_register_font trebucit.ttf "Trebuchet Italic"
     w_register_font trebuc.ttf "Trebuchet"
-    w_register_font Verdanab.ttf "Verdana Bold"
-    w_register_font Verdanai.ttf "Verdana Italian"
-    w_register_font Verdana.ttf "Verdana"
-    w_register_font Verdanaz.ttf "Verdana Bold Italic"
+    w_register_font verdanab.ttf "Verdana Bold"
+    w_register_font verdanai.ttf "Verdana Italian"
+    w_register_font verdana.ttf "Verdana"
+    w_register_font verdanaz.ttf "Verdana Bold Italic"
 }
 
 #----------------------------------------------------------------
@@ -10491,7 +10495,7 @@ load_fontfix()
             w_die "Please uninstall the Samyak/Oriya font, e.g. 'sudo dpkg -r ttf-oriya-fonts', then log out and log in again.  That font causes strange crashes in .net programs."
         fi
     else
-        w_warn "xlsfonts not found. If you have (older versions of) Samyak/Oriya fonts installed, you may get crashes/bugs. If so, uninstall, the logout/login again to resolve."
+        w_warn "xlsfonts not found. If you have (older versions of) Samyak/Oriya fonts installed, you may get crashes/bugs. If so, uninstall, then logout/login again to resolve."
     fi
 }
 
@@ -10508,12 +10512,11 @@ w_metadata ipamona fonts \
 
 load_ipamona()
 {
-    w_download "http://www.geocities.jp/ipa_mona/$file1" ab77beea3b051abf606cd8cd3badf6cb24141ef145c60f508fcfef1e3852bb9d
+    w_download "http://www.geocities.jp/ipa_mona/opfc-ModuleHP-1.1.1_withIPAMonaFonts-1.0.8.tar.gz" ab77beea3b051abf606cd8cd3badf6cb24141ef145c60f508fcfef1e3852bb9d
 
     w_try_cd "$W_TMP"
-
-    gunzip -dc "$W_CACHE/$W_PACKAGE/$file1" | tar -xf -
-    w_try mv ./*IPAMonaFonts*/fonts/*.ttf "$W_FONTSDIR_UNIX"
+    w_try tar -zxf "$W_CACHE/$W_PACKAGE/$file1" "${file1%.tar.gz}/fonts"
+    w_try_cp_font_files "${file1%.tar.gz}/fonts" "$W_FONTSDIR_UNIX"
 
     w_register_font ipagui-mona.ttf "IPAMonaUIGothic"
     w_register_font ipag-mona.ttf "IPAMonaGothic"
@@ -10530,29 +10533,29 @@ w_metadata liberation fonts \
     year="2008" \
     media="download" \
     file1="liberation-fonts-ttf-1.07.4.tar.gz" \
-    installed_file1="$W_FONTSDIR_WIN/LiberationMono-BoldItalic.ttf"
+    installed_file1="$W_FONTSDIR_WIN/liberationmono-bolditalic.ttf"
 
 load_liberation()
 {
     # https://pagure.io/liberation-fonts
-    w_download https://releases.pagure.org/liberation-fonts/liberation-fonts-ttf-1.07.4.tar.gz 61a7e2b6742a43c73e8762cdfeaf6dfcf9abdd2cfa0b099a9854d69bc4cfee5c
-    w_try_cd "$W_TMP"
-    # FIXME: w_try doesn't work here, presumably because of the pipe?
-    gunzip -dc "$W_CACHE/$W_PACKAGE/$file1" | tar -xf -
-    w_try mv liberation-fonts-ttf-1.07.4/*.ttf "$W_FONTSDIR_UNIX"
+    w_download "https://releases.pagure.org/liberation-fonts/liberation-fonts-ttf-1.07.4.tar.gz" 61a7e2b6742a43c73e8762cdfeaf6dfcf9abdd2cfa0b099a9854d69bc4cfee5c
 
-    w_register_font LiberationMono-BoldItalic.ttf "LiberationMono-BoldItalic"
-    w_register_font LiberationMono-Bold.ttf "LiberationMono-Bold"
-    w_register_font LiberationMono-Italic.ttf "LiberationMono-Italic"
-    w_register_font LiberationMono-Regular.ttf "LiberationMono-Regular"
-    w_register_font LiberationSans-BoldItalic.ttf "LiberationSans-BoldItalic"
-    w_register_font LiberationSans-Bold.ttf "LiberationSans-Bold"
-    w_register_font LiberationSans-Italic.ttf "LiberationSans-Italic"
-    w_register_font LiberationSans-Regular.ttf "LiberationSans-Regular"
-    w_register_font LiberationSerif-BoldItalic.ttf "LiberationSerif-BoldItalic"
-    w_register_font LiberationSerif-Bold.ttf "LiberationSerif-Bold"
-    w_register_font LiberationSerif-Italic.ttf "LiberationSerif-Italic"
-    w_register_font LiberationSerif-Regular.ttf "LiberationSerif-Regular"
+    w_try_cd "$W_TMP"
+    w_try tar -zxf "$W_CACHE/$W_PACKAGE/$file1"
+    w_try_cp_font_files "${file1%.tar.gz}" "$W_FONTSDIR_UNIX"
+
+    w_register_font liberationmono-bolditalic.ttf "LiberationMono-BoldItalic"
+    w_register_font liberationmono-bold.ttf "LiberationMono-Bold"
+    w_register_font liberationmono-italic.ttf "LiberationMono-Italic"
+    w_register_font liberationmono-regular.ttf "LiberationMono-Regular"
+    w_register_font liberationsans-bolditalic.ttf "LiberationSans-BoldItalic"
+    w_register_font liberationsans-bold.ttf "LiberationSans-Bold"
+    w_register_font liberationsans-italic.ttf "LiberationSans-Italic"
+    w_register_font liberationsans-regular.ttf "LiberationSans-Regular"
+    w_register_font liberationserif-bolditalic.ttf "LiberationSerif-BoldItalic"
+    w_register_font liberationserif-bold.ttf "LiberationSerif-Bold"
+    w_register_font liberationserif-italic.ttf "LiberationSerif-Italic"
+    w_register_font liberationserif-regular.ttf "LiberationSerif-Regular"
 }
 
 #----------------------------------------------------------------
@@ -10567,8 +10570,9 @@ w_metadata lucida fonts \
 
 load_lucida()
 {
-    w_download ftp://ftp.fu-berlin.de/pc/security/ms-patches/winnt/usa/NT40TSE/hotfixes-postSP3/Euro-fix/eurofixi.exe 41f272a33521f6e15f2cce9ff1e049f2badd5ff0dc327fc81b60825766d5b6c7
-    w_try_cabextract -d "$W_FONTSDIR_UNIX" -L -F 'lucon.ttf' "$W_CACHE"/lucida/eurofixi.exe
+    w_download "ftp://ftp.fu-berlin.de/pc/security/ms-patches/winnt/usa/NT40TSE/hotfixes-postSP3/Euro-fix/eurofixi.exe" 41f272a33521f6e15f2cce9ff1e049f2badd5ff0dc327fc81b60825766d5b6c7
+    w_try_cabextract -d "$W_TMP" -F "lucon.ttf" "$W_CACHE"/lucida/eurofixi.exe
+    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX"
     w_register_font lucon.ttf "Lucida Console"
 }
 
@@ -10587,12 +10591,12 @@ load_opensymbol()
     # The OpenSymbol fonts are a replacement for the Windows Wingdings font from OpenOffice.org.
     # Need to w_download Debian since I can't find a standalone download from OpenOffice
     # Note: The source download package on debian is for _all_ of OpenOffice, which is 266 MB.
-    w_download http://security.debian.org/debian-security/pool/updates/main/libr/libreoffice/fonts-opensymbol_102.2+LibO3.5.4+dfsg2-0+deb7u9_all.deb 11f272c3de3f2d891dfd067f467263ff361c08566a1a0ee5e5d64cbee459ee22
+    w_download "http://security.debian.org/debian-security/pool/updates/main/libr/libreoffice/fonts-opensymbol_102.2+LibO3.5.4+dfsg2-0+deb7u9_all.deb" 11f272c3de3f2d891dfd067f467263ff361c08566a1a0ee5e5d64cbee459ee22
 
     w_try_cd "$W_TMP"
     w_try_ar "$W_CACHE/$W_PACKAGE/$file1" data.tar.xz
-    w_try tar Jvxf "$W_TMP/data.tar.xz" ./usr/share/fonts/truetype/openoffice/opens___.ttf
-    w_try mv "$W_TMP/usr/share/fonts/truetype/openoffice/opens___.ttf" "$W_FONTSDIR_UNIX"
+    w_try tar -Jxf "$W_TMP/data.tar.xz" ./usr/share/fonts/truetype/openoffice/opens___.ttf
+    w_try_cp_font_files "usr/share/fonts/truetype/openoffice" "$W_FONTSDIR_UNIX"
     w_register_font opens___.ttf "OpenSymbol"
 }
 
@@ -10610,18 +10614,14 @@ load_tahoma()
 {
     # Formerly at https://download.microsoft.com/download/office97pro/fonts/1/w95/en-us/tahoma32.exe
     # Mirror list: http://www.filewatcher.com/_/?q=tahoma32.exe
-    w_download ftp://ftp.uevora.pt/pub/windows/Microsoft/Euro/Euro-Compatible%20Tahoma%20Font/tahoma32.exe 57496fb91d1629d2b6f313aaa6ebcdbcfd09c269b6462fe490420c786c089a40
+    w_download "ftp://ftp.uevora.pt/pub/windows/Microsoft/Euro/Euro-Compatible%20Tahoma%20Font/tahoma32.exe" 57496fb91d1629d2b6f313aaa6ebcdbcfd09c269b6462fe490420c786c089a40
 
-    w_try_cabextract --directory="${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${file1}"
-    w_try cp -f "${W_TMP}/Tahoma.TTF" "${W_FONTSDIR_UNIX}/tahoma.ttf"
-    w_try cp -f "${W_TMP}/Tahomabd.TTF" "${W_FONTSDIR_UNIX}/tahomabd.ttf"
+    w_try_cabextract -d "$W_TMP" "$W_CACHE/$W_PACKAGE/$file1"
+    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "*.TTF"
 
     # FIXME: Wine seems to nuke the registry entries for Tahoma. Why? Font Xplorer always lists it as 'not installed'.
     w_register_font tahoma.ttf "Tahoma"
     w_register_font tahomabd.ttf "Tahoma Bold"
-
-    # FIXME: ? does some app assume it can overwrite these, or is this a leftover from before we had install checks?
-    chmod +w "${W_FONTSDIR_UNIX}"/tahoma*.ttf
 }
 
 #----------------------------------------------------------------
@@ -10632,23 +10632,22 @@ w_metadata takao fonts \
     year="2010" \
     media="download" \
     file1="takao-fonts-ttf-003.02.01.zip" \
-    installed_file1="$W_FONTSDIR_WIN/TakaoGothic.ttf"
+    installed_file1="$W_FONTSDIR_WIN/takaogothic.ttf"
 
 load_takao()
 {
-    # The Takao font provides Japanese glyphs.  May also be needed with fakejapanese function above.
+    # The Takao font provides Japanese glyphs. May also be needed with fakejapanese function above.
     # See https://launchpad.net/takao-fonts for project page
-    w_download https://launchpad.net/takao-fonts/trunk/003.02.01/+download/takao-fonts-ttf-003.02.01.zip 2f526a16c7931958f560697d494d8304949b3ce0aef246fb0c727fbbcc39089e
-    cp -f "$W_CACHE"/takao/takao-fonts-ttf-003.02.01.zip "$W_TMP"
-    w_try_unzip "$W_TMP" "$W_TMP"/takao-fonts-ttf-003.02.01.zip
-    w_try cp -f "$W_TMP"/takao-fonts-ttf-003.02.01/*.ttf "$W_FONTSDIR_UNIX"
+    w_download "https://launchpad.net/takao-fonts/trunk/003.02.01/+download/takao-fonts-ttf-003.02.01.zip" 2f526a16c7931958f560697d494d8304949b3ce0aef246fb0c727fbbcc39089e
+    w_try_unzip "$W_TMP" "$W_CACHE"/takao/takao-fonts-ttf-003.02.01.zip
+    w_try_cp_font_files "$W_TMP/takao-fonts-ttf-003.02.01" "$W_FONTSDIR_UNIX"
 
-    w_register_font TakaoGothic.ttf "TakaoGothic"
-    w_register_font TakaoPGothic.ttf "TakaoPGothic"
-    w_register_font TakaoMincho.ttf "TakaoMincho"
-    w_register_font TakaoPMincho.ttf "TakaoPMincho"
-    w_register_font TakaoExGothic.ttf "TakaoExGothic"
-    w_register_font TakaoExMincho.ttf "TakaoExMincho"
+    w_register_font takaogothic.ttf "TakaoGothic"
+    w_register_font takaopgothic.ttf "TakaoPGothic"
+    w_register_font takaomincho.ttf "TakaoMincho"
+    w_register_font takaopmincho.ttf "TakaoPMincho"
+    w_register_font takaoexgothic.ttf "TakaoExGothic"
+    w_register_font takaoexmincho.ttf "TakaoExMincho"
 }
 
 #----------------------------------------------------------------
@@ -10659,20 +10658,19 @@ w_metadata uff fonts \
     year="2010" \
     media="download" \
     file1="ubuntu-font-family-0.70.1.zip" \
-    installed_file1="$W_FONTSDIR_WIN/Ubuntu-R.ttf" \
+    installed_file1="$W_FONTSDIR_WIN/ubuntu-r.ttf" \
     homepage="https://launchpad.net/ubuntu-font-family"
 
 load_uff()
 {
-    w_download http://font.ubuntu.com/download/ubuntu-font-family-0.70.1.zip c3737665b85e48664feabb8448957bdf17eab26cc320270f1641d9f98b7ea22e
-    w_try_cd "$W_TMP"
-    w_try_unzip . "$W_CACHE"/uff/ubuntu-font-family-0.70.1.zip
-    mv ubuntu-font-family-0.70.1/*.ttf "$W_FONTSDIR_UNIX"
+    w_download "http://font.ubuntu.com/download/ubuntu-font-family-0.70.1.zip" c3737665b85e48664feabb8448957bdf17eab26cc320270f1641d9f98b7ea22e
+    w_try_unzip "$W_TMP" "$W_CACHE"/uff/ubuntu-font-family-0.70.1.zip
+    w_try_cp_font_files "$W_TMP/ubuntu-font-family-0.70.1" "$W_FONTSDIR_UNIX"
 
-    w_register_font Ubuntu-R.ttf "Ubuntu"
-    w_register_font Ubuntu-I.ttf "Ubuntu Italic"
-    w_register_font Ubuntu-B.ttf "Ubuntu Bold"
-    w_register_font Ubuntu-BI.ttf "Ubuntu Bold Italic"
+    w_register_font ubuntu-r.ttf "Ubuntu"
+    w_register_font ubuntu-i.ttf "Ubuntu Italic"
+    w_register_font ubuntu-b.ttf "Ubuntu Bold"
+    w_register_font ubuntu-bi.ttf "Ubuntu Bold Italic"
 }
 
 #----------------------------------------------------------------
@@ -10683,22 +10681,19 @@ w_metadata vlgothic fonts \
     year="2014" \
     media="download" \
     file1="VLGothic-20141206.tar.xz" \
-    installed_file1="$W_FONTSDIR_WIN/VL-Gothic-Regular.ttf" \
+    installed_file1="$W_FONTSDIR_WIN/vl-gothic-regular.ttf" \
     homepage="https://ja.osdn.net/projects/vlgothic"
 
 load_vlgothic()
 {
-    # $homepage is already assigned in w_do_call(), and works as expected:
-    # shellcheck disable=SC2154
-    w_download "$homepage/downloads/62375/$file1" 982040db2f9cb73d7c6ab7d9d163f2ed46d1180f330c9ba2fae303649bf8102d
+    w_download "https://ja.osdn.net/projects/vlgothic/downloads/62375/VLGothic-20141206.tar.xz" 982040db2f9cb73d7c6ab7d9d163f2ed46d1180f330c9ba2fae303649bf8102d
 
     w_try_cd "$W_TMP"
+    w_try tar -Jxf "$W_CACHE/vlgothic/VLGothic-20141206.tar.xz"
+    w_try_cp_font_files "$W_TMP/VLGothic" "$W_FONTSDIR_UNIX"
 
-    unxz -dc "$W_CACHE/$W_PACKAGE/$file1" | tar -xf -
-    w_try mv ./VLGothic/*.ttf "$W_FONTSDIR_UNIX"
-
-    w_register_font VL-Gothic-Regular.ttf "VL Gothic"
-    w_register_font VL-PGothic-Regular.ttf "VL PGothic"
+    w_register_font vl-gothic-regular.ttf "VL Gothic"
+    w_register_font vl-pgothic-regular.ttf "VL PGothic"
 }
 
 #----------------------------------------------------------------
@@ -10715,10 +10710,11 @@ load_wenquanyi()
 {
     # See http://wenq.org/enindex.cgi
     # Donate at http://wenq.org/enindex.cgi?Download(en)#MicroHei_Beta if you want to help support free CJK font development
-    w_download $WINETRICKS_SOURCEFORGE/wqy/wqy-microhei-0.2.0-beta.tar.gz 2802ac8023aa36a66ea6e7445854e3a078d377ffff42169341bd237871f7213e
-    w_try_cd "$W_TMP/"
-    gunzip -dc "$W_CACHE/wenquanyi/wqy-microhei-0.2.0-beta.tar.gz" | tar -xf -
-    w_try mv wqy-microhei/wqy-microhei.ttc "$W_FONTSDIR_UNIX"
+    w_download "https://downloads.sourceforge.net/wqy/wqy-microhei-0.2.0-beta.tar.gz" 2802ac8023aa36a66ea6e7445854e3a078d377ffff42169341bd237871f7213e
+    w_try_cd "$W_TMP"
+    w_try tar -zxf "$W_CACHE/$W_PACKAGE/$file1"
+    w_try_cp_font_files "$W_TMP/wqy-microhei" "$W_FONTSDIR_UNIX" "*.ttc"
+
     w_register_font wqy-microhei.ttc "WenQuanYi Micro Hei"
 }
 
@@ -10736,10 +10732,12 @@ load_unifont()
 {
     # The GNU Unifont provides glyphs for just about everything in common language.  It is intended for multilingual usage.
     # See http://unifoundry.com/unifont.html for project page
-    w_download http://unifoundry.com/unifont-5.1.20080907.zip 6ec1176f83769072b09de2bc1fff68ec5d802183304756a372e2419236f5b5ba
-    cp -f "$W_CACHE"/unifont/unifont-5.1.20080907.zip "$W_TMP"
-    w_try_unzip "$W_TMP" "$W_TMP"/unifont-5.1.20080907.zip
-    w_try cp -f "$W_TMP"/unifont-5.1.20080907.ttf "$W_FONTSDIR_UNIX/unifont.ttf"
+    w_download "http://unifoundry.com/unifont-5.1.20080907.zip" 6ec1176f83769072b09de2bc1fff68ec5d802183304756a372e2419236f5b5ba
+    w_try_unzip "$W_TMP" "$W_CACHE/$W_PACKAGE/unifont-5.1.20080907.zip"
+
+    w_try mv -f "$W_TMP/unifont-5.1.20080907.ttf" "$W_TMP/unifont.ttf"
+
+    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX"
 
     w_register_font unifont.ttf "Unifont"
     w_register_font_replacement "Arial Unicode MS" "Unifont"


### PR DESCRIPTION
This is an attempt to partially address #865 and clean up some inconsistencies in the font-related verbs.

- Add verb `w_try_cp_font_files`, which makes sure that we don't get the same font file but with different casing under `C:\windows\Fonts`. It also forces lower case for font names to help alleviate duplication issues.
- Cache PowerPointViewer.exe in "$W_CACHE/PowerPointViewer" for consistency.
- Remove "# FIXME: why is this commented out? Should be removed or enabled." comment. This was referring to the Andalé Mono font, which is [no longer distributed with Windows](https://en.wikipedia.org/wiki/Andal%C3%A9_Mono#Distribution). If you wish, I can create a separate verb for it since it's available [here](https://mirrors.kernel.org/gentoo/distfiles/andale32.exe), but I think we don't need it at all, since it's almost identical to [Courier](https://en.wikipedia.org/wiki/Courier_(typeface)).
- Remove `chmod +w "${W_FONTSDIR_UNIX}"/tahoma*.ttf` since no app should be allowed to overwrite fonts. I'd rather have this posted as a workaround on https://appdb.winehq.org/ instead of maintaining it in Winetricks.
- Place font package URLs in quotes and leave them hardcoded in the verb body because they're much easier to grep for and replace that way.
- `w_try_cabextract` already passes `-q` to cabextract.

Note: Since eufonts [only updates trebucbd.ttf](https://github.com/Winetricks/winetricks/blob/389d1ed6810cab5a54be2d68c2c6b4752a04f272/src/winetricks#L10271), allfonts will skip installing eufonts after this PR, since trebucbd.ttf is installed in advance by corefonts. #885 needs to be addressed in order to fix this.

Note2: eufonts is an update to some of the fonts installed by corefonts, so corefonts should always be installed first. Luckily, allfonts installs them in the right order.

As a reference, here is the difference between installed font files based on this PR:
[original_font_files.txt](https://github.com/Winetricks/winetricks/files/1539318/original_font_files.txt)
[updated_font_files.txt](https://github.com/Winetricks/winetricks/files/1539320/updated_font_files.txt)

And here is the difference in registry entries:
[original_windows_nt.txt](https://github.com/Winetricks/winetricks/files/1539346/orig_windows_nt.txt)
[updated_windows_nt.txt](https://github.com/Winetricks/winetricks/files/1539350/updated_windows_nt.txt)

The observed differences in the registry are due to the fact that eufonts was not installed as explained above.

As described in CONTRIBUTING.md (#871), I ran `./tests/shell-checks` successfully and I skipped `winetricks-test`, since it didn't work as described. See [here](https://github.com/Winetricks/winetricks/pull/871#discussion_r155545701).