### PR TITLE
w_register_font: Register TTC fonts as TrueType

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -2801,8 +2801,8 @@ w_register_font()
     shift
     W_font=$1
 
-    case "$W_file" in
-        *.TTF|*.ttf) W_font="$W_font (TrueType)";;
+    case $(echo "$W_file" | tr "[:upper:]" "[:lower:]") in
+        *.ttf|*.ttc) W_font="$W_font (TrueType)";;
     esac
 
     # Kludge: use _r to avoid \r expansion in w_try


### PR DESCRIPTION
This fixes #880.

Bonus: It seems to make Font Xplorer ([available as a verb](https://github.com/Winetricks/winetricks/blob/a864b065339551995b9ecdfd9ea3a4be85c5da93/files/verbs/apps.txt#L15)) happy when inspecting the Cambria font. Before this fix, it was claiming that Cambria is not installed. There are some other fonts that exhibit this behaviour, but I haven't yet investigated why (and I hope to not have to :P).