### PR TITLE
w_try_cp_font_files: Prevent registry writes race

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -554,6 +554,9 @@ w_try_cp_font_files()
         w_try cp -f "$_W_src_file" "$_W_dest_dir/$_W_file_name"
     done
 
+    # Wait for Wine to add the new font to the registry under HKCU\Software\Wine\Fonts\Cache
+    w_wineserver -w
+
     unset _W_src_files _W_dest_dir _W_src_file _W_file_name
 }
 


### PR DESCRIPTION
This is a potential fix for #896.

The latest wine-devel (wine-3.0-rc2) as well as previous versions seem to forget to lock the registry when inserting entries automagically into `HKCU\Software\Wine\Fonts\Cache`, after a font file has been copied in `.wine/drive_c/windows/Fonts/`. From my tests, this change seems to address this issue, although it does slow down font installation a bit.

Note: This issue was happening even before `w_try_cp_font_files` got added.