### PR TITLE
load_cambria: Register Cambria Math

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -10170,7 +10170,7 @@ load_cambria()
     w_try_cabextract -d "$W_TMP" -F "ppviewer.cab" "$W_CACHE/PowerPointViewer/$file1"
     w_try_cabextract -d "$W_TMP" -F "CAMBRIA*.TT*" "$W_TMP/ppviewer.cab"
     w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "CAMBRIA*.TT*"
-    w_register_font cambria.ttc "Cambria"
+    w_register_font cambria.ttc "Cambria & Cambria Math"
     w_register_font cambriab.ttf "Cambria Bold"
     w_register_font cambriai.ttf "Cambria Italic"
     w_register_font cambriaz.ttf "Cambria Bold Italic"


### PR DESCRIPTION
This fixes #881, and it's probably relevant only for apps which list fonts manually from the registry. Wine seems to return the fonts that are under `HKCU\Software\Wine\Fonts\Cache` when calling `EnumFontFamiliesEx` and it creates both `Cambria` and `Cambria Math` entries automatically, which is great because it seems to support TTC files quite well:

<img width="592" alt="screen shot 2017-12-19 at 23 33 42" src="https://user-images.githubusercontent.com/788216/34184374-47cd1f0e-e517-11e7-9a5a-e6f960cf4f47.png">
<img width="594" alt="screen shot 2017-12-19 at 23 35 33" src="https://user-images.githubusercontent.com/788216/34184377-49edfbf0-e517-11e7-8338-3037964dc600.png">

