### PR TITLE
w_register_font: Revert 2c2b44e because it's not needed

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -2808,12 +2808,6 @@ w_register_font()
         *.ttf|*.ttc) W_font="$W_font (TrueType)";;
     esac
 
-    # See https://github.com/Winetricks/winetricks/issues/896
-    if [ ! -f "$W_file" ] && [ -f "${W_FONTSDIR_UNIX}/${W_file}" ]; then
-       W_file_unescaped="${W_FONTSDIR_WIN}\\${W_file}"
-       W_file="$(echo "$W_file_unescaped" | sed -e 's!\\!\\\\!g')"
-    fi
-
     # Kludge: use _r to avoid \r expansion in w_try
     cat > "$W_TMP"/_register-font.reg <<_EOF_
 REGEDIT4


### PR DESCRIPTION
I think it's best to revert this fix, because [according to Huw](https://www.winehq.org/pipermail/wine-devel/2017-December/120684.html):
> Fonts without a path correspond to c:\windows\fonts.  These files
> should be installed into that directory.

Also, it doesn't seem to work well on my Ubuntu installation. See #902.