### PR TITLE
Font replacements related fixes

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -10282,6 +10282,7 @@ w_metadata meiryo fonts \
     publisher="Microsoft" \
     year="2009" \
     media="download" \
+    conflicts="fakejapanese_vlgothic" \
     file1="PowerPointViewer.exe" \
     installed_file1="$W_FONTSDIR_WIN/meiryo.ttc"
 
@@ -10566,6 +10567,7 @@ load_fakejapanese_ipamona()
 w_metadata fakejapanese_vlgothic fonts \
     title="Creates aliases for Japanese Meiryo fonts using VLGothic fonts" \
     publisher="Project Vine / Daisuke Suzuki" \
+    conflicts="meiryo" \
     year="2014"
 
 load_fakejapanese_vlgothic()

--- a/src/winetricks
+++ b/src/winetricks
@@ -10132,6 +10132,7 @@ load_cjkfonts()
 {
     w_call fakechinese
     w_call fakejapanese
+    w_call fakejapanese_vlgothic
     w_call fakekorean
     w_call unifont
 }

--- a/src/winetricks
+++ b/src/winetricks
@@ -10908,7 +10908,12 @@ load_allfonts()
     do
         cmd=$(basename "$file" .vars)
         case $cmd in
-            allfonts|cjkfonts) ;;
+            # "fake*" verbs need to be skipped because
+            # this "allfonts" verb is intended to only install real fonts and
+            # adding font replacements at the same time may invalidate the replacements
+            # "pptfonts" can be skipped because it only calls other verbs for installing fonts
+            # See https://github.com/Winetricks/winetricks/issues/899
+            allfonts|cjkfonts|fake*|pptfonts) ;;
             *) w_call "$cmd";;
         esac
     done


### PR DESCRIPTION
* allfonts: don't call verbs for font replacements (fake*) or "pptfonts" metapackage
    * This prevents `allfonts` from adding font replacements
    * `pptfonts` can be skipped because it only calls other verbs for installing fonts
* cjkfonts: call fakejapanese_vlgothic
    * Now it adds font replacements for Meiryo
* fakejapanese_vlgothic, meiryo: conflict each other
    * Wine uses Meiryo when both are installed

winetricks.log after installing patched `allfonts`:
```baekmuk
calibri
cambria
candara
consolas
constantia
corbel
corefonts
droid
eufonts
ipamona
liberation
lucida
meiryo
opensymbol
tahoma
takao
uff
unifont
vlgothic
wenquanyi
allfonts
```

winetricks.log after installing patched `cjkfonts`:
```wenquanyi
fakechinese
takao
fakejapanese
vlgothic
fakejapanese_vlgothic
baekmuk
fakekorean
unifont
cjkfonts
```