### PR TITLE
autostart_winedbg: new verb

### DIFF
--- a/files/verbs/all.txt
+++ b/files/verbs/all.txt
@@ -372,6 +372,8 @@ alldlls=builtin          Override most common DLLs to builtin
 alldlls=default          Remove all DLL overrides
 ao=disabled              Disable AlwaysOffscreen (default)
 ao=enabled               Enable AlwaysOffscreen
+autostart_winedbg=enable Automatically launch winedbg when an unhandled exception occurs (default)
+autostart_winedbg=disable Prevent winedbg from launching when an unhandled exception occurs
 bad                      Fake verb that always returns false
 cfc=disable              Disable CheckFloatConstants (default)
 cfc=enabled              Enable CheckFloatConstants

--- a/files/verbs/settings.txt
+++ b/files/verbs/settings.txt
@@ -3,6 +3,8 @@ alldlls=builtin          Override most common DLLs to builtin
 alldlls=default          Remove all DLL overrides
 ao=disabled              Disable AlwaysOffscreen (default)
 ao=enabled               Enable AlwaysOffscreen
+autostart_winedbg=enable Automatically launch winedbg when an unhandled exception occurs (default)
+autostart_winedbg=disable Prevent winedbg from launching when an unhandled exception occurs
 bad                      Fake verb that always returns false
 cfc=disable              Disable CheckFloatConstants (default)
 cfc=enabled              Enable CheckFloatConstants

--- a/src/winetricks
+++ b/src/winetricks
@@ -18389,7 +18389,6 @@ _EOF_
 
 #----------------------------------------------------------------
 # Other settings
-
 #----------------------------------------------------------------
 
 w_metadata alldlls=default settings \
@@ -18406,6 +18405,37 @@ load_alldlls()
         builtin) w_override_all_dlls ;;
     esac
 }
+
+#----------------------------------------------------------------
+
+w_metadata autostart_winedbg=enable settings \
+    title="Automatically launch winedbg when an unhandled exception occurs (default)"
+w_metadata autostart_winedbg=disable settings \
+    title="Prevent winedbg from launching when an unhandled exception occurs"
+
+load_autostart_winedbg()
+{
+    case "$arg" in
+        enable) _W_debugger_value="winedbg --auto %ld %ld";;
+        disable) _W_debugger_value="false";;
+        *) w_die "Unexpected argument '$arg'. Should be enable/disable";;
+    esac
+
+    echo "Setting HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug\\Debugger to '$arg'"
+    cat > "$W_TMP"/autostart_winedbg.reg <<_EOF_
+REGEDIT4
+
+[HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug]
+"Debugger"="${_W_debugger_value}"
+_EOF_
+
+    w_try_regedit "$W_TMP_WIN"\\autostart_winedbg.reg
+    w_backup_reg_file "$W_TMP"/autostart_winedbg.reg
+
+    unset _W_debugger_value
+}
+
+#----------------------------------------------------------------
 
 w_metadata fontsmooth=disable settings \
     title_uk="Вимкнути згладжування шрифту" \

--- a/src/winetricks
+++ b/src/winetricks
@@ -2817,7 +2817,6 @@ REGEDIT4
 _EOF_
     # too verbose
     w_try_regedit "$W_TMP_WIN"\\_register-font.reg
-    # shellcheck disable=SC1037
     w_backup_reg_file "$W_TMP"/_register-font.reg
 
     # Wine also updates the win9x fonts key, so let's do that, too
@@ -2828,7 +2827,6 @@ REGEDIT4
 "$W_font"="$W_file"
 _EOF_
     w_try_regedit "$W_TMP_WIN"\\_register-font.reg
-    # shellcheck disable=SC1037
     w_backup_reg_file "$W_TMP"/_register-font.reg
 
     unset W_file W_font


### PR DESCRIPTION
In a server environment, we usually need a process to restart automatically if it crashes. Having winedbg start on each process crash will flood the server with hanged processes.

This new verb allows users to disable this behaviour and I use it in combination with `nocrashdialog`, because I am running a process in headless mode under Docker (using Xvfb).

Relevant documentation: https://wiki.winehq.org/Wine_Developer%27s_Guide/Debugging_Wine#Windows_Debugging_configuration