### PR TITLE
travis.yml: switch to Ubuntu Artful (17.10)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ addons:
 # Note: if statements cannot go across multiple lines. Combine into one, or move to a shell script!
 
 # On Ubuntu, shellcheck is not in trusty, but is in trusty-backports, but those aren't available in TravisCI..)
-# Using zesty to get 0.4.4, which has support for disabling a check globally within a file
+# Using artful to get 0.4.6, which has support for disabling a check globally within a file
 before_install:
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then echo "deb http://archive.ubuntu.com/ubuntu/ zesty universe" | sudo tee -a /etc/apt/sources.list ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then echo "deb http://archive.ubuntu.com/ubuntu/ artful universe" | sudo tee -a /etc/apt/sources.list ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then time sudo apt-get -q update ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then time sudo apt-get install python-bashate shellcheck ; fi
 


### PR DESCRIPTION
Ubuntu Zesty (17.04) reached End of Life on January 13, 2018.
We need to switch to Artful (17.10).

See also: https://wiki.ubuntu.com/Releases

Note: Xenial (16.04 LTS, End of Life = April 2021) is available on Travis CI (experimental), but shellcheck is too old (0.3.7).