### PR TITLE
Pkexec

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: winetricks
 Section: contrib/otherosfs
 Priority: optional
-Maintainer: Dan Kegel <dank@kegel.com>
+Maintainer: Austin English <austinenglish@gmail.com>
 Standards-Version: 3.8.1
 Build-Depends: debhelper,
         devscripts
@@ -9,7 +9,7 @@ Build-Depends: debhelper,
 Package: winetricks
 Section: contrib/otherosfs
 Architecture: all
-Homepage: http://winetricks.org
+Homepage: https://winetricks.org
 Depends: binutils,
         cabextract,
         p7zip,

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,8 @@ Depends: binutils,
         wget
 Recommends: zenity | kdebase-bin,
         xdg-utils,
-        gksu | kde-cli-tools | kdesudo | policykit-1 | sudo,
+        policykit-1 | gksu | kde-cli-tools | kdesudo,
+        sudo,
         wine
 Description: Simple tool to work around common problems in Wine.
  Winetricks has a menu of supported games/apps for which it can do all the

--- a/src/winetricks
+++ b/src/winetricks
@@ -34,7 +34,7 @@ WINETRICKS_VERSION=20180217-next
 # - zenity is needed by the GUI, though it can limp along somewhat with kdialog/xmessage.
 # - xdg-open (if present) or open (for OS X) is used to open download pages
 #   for the user when downloads cannot be fully automated.
-# - pfexec, sudo, or kdesu (gksu/gksudo/kdesudo are deprecated upstream but also still supported)
+# - pkexec, sudo, or kdesu (gksu/gksudo/kdesudo are deprecated upstream but also still supported)
 #   are used to mount .iso images if the user cached them with -k option.
 # - perl is used to munge steam config files.
 # - torify is used with option "--torify" if sites are blocked in single countries.


### PR DESCRIPTION
p*f*exec exists, but it is not what we use here.

In the Debian dependencies prefer policykit-1 so that e.g. a removed gksu doesn't get replaced by e.g. kdesudo, but policykit-1 instead. (This is probably more a theoretical issue, since basically all systems should already have installed both sudo and their preferred graphical sudo helper). In the code itself the priorities seem to be correct.