### PR TITLE
Small fixes

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -1178,6 +1178,9 @@ w_download_to()
 
             w_try_cd "$_W_dl_olddir"
             unset _W_dl_olddir
+
+            # downloaded successfully, exit from loop
+            break
         elif test $tries = 2; then
             test -f "$_W_file" && rm "$_W_file"
             w_die "Downloading $_W_url failed"

--- a/src/winetricks
+++ b/src/winetricks
@@ -14094,7 +14094,7 @@ load_cod1()
             WinWait, Call of Duty, Start
             ControlClick Button1
         }
-        WinWait, Insert CD, Please insert the Call of Duty w_try_cd 2
+        WinWait, Insert CD, Please insert the Call of Duty cd 2
         "
 
     "$WINE" eject ${W_ISO_MOUNT_LETTER}:
@@ -14105,7 +14105,7 @@ load_cod1()
         if ( w_opt_unattended > 0 ) {
             Send {Enter}    ;continue installation
         }
-        WinWait, Insert CD, Please insert the Call of Duty w_try_cd 1
+        WinWait, Insert CD, Please insert the Call of Duty cd 1
     "
 
     "$WINE" eject ${W_ISO_MOUNT_LETTER}:


### PR DESCRIPTION
* cod1: fix typos (w_try_cd -> cd)
* w_download_to: exit from loop when download succeeded
    * Without this, `winetricks_dl_warning()` is called even if a file is successfully downloaded. This is meaningless.