### PR TITLE
verbs: CSMT enabled by default

### DIFF
--- a/files/verbs/settings.txt
+++ b/files/verbs/settings.txt
@@ -8,8 +8,8 @@ autostart_winedbg=enable Automatically launch winedbg when an unhandled exceptio
 bad                      Fake verb that always returns false
 cfc=disable              Disable CheckFloatConstants (default)
 cfc=enabled              Enable CheckFloatConstants
-csmt=off                 Disable Command Stream Multithreading (default)
-csmt=on                  Enable Command Stream Multithreading
+csmt=on                  Enable Command Stream Multithreading (default)
+csmt=off                 Disable Command Stream Multithreading
 ddr=gdi                  Set DirectDrawRenderer to gdi
 ddr=opengl               Set DirectDrawRenderer to opengl
 fontfix                  Check for broken fonts

--- a/src/winetricks
+++ b/src/winetricks
@@ -18519,11 +18519,11 @@ load_cfc()
 # CSMT settings
 
 w_metadata csmt=on settings \
-    title_uk="Увімкнути Command Stream Multithreading" \
-    title="Enable Command Stream Multithreading"
+    title_uk="Увімкнути Command Stream Multithreading (за замовчуванням)" \
+    title="Enable Command Stream Multithreading (default)"
 w_metadata csmt=off settings \
-    title_uk="Вимкнути Command Stream Multithreading (за замовчуванням)" \
-    title="Disable Command Stream Multithreading (default)"
+    title_uk="Вимкнути Command Stream Multithreading"\
+    title="Disable Command Stream Multithreading"
 
 load_csmt()
 {


### PR DESCRIPTION
Since Wine 3.3, CSMT is enabled by default (see https://www.winehq.org/announce/3.3).
However, the setting options CSMT is by default disabled according to
the Winetricks settings menu. This commit updates the titles for these
options to the correct ones. It also swaps the order of the CSMT options,
since in most cases the default option is the top setting.