### PR TITLE
adobeair, shockwave: update sha256sum

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -5367,7 +5367,7 @@ helper_win7sp1_x64()
 w_metadata adobeair dlls \
     title="Adobe AIR" \
     publisher="Adobe" \
-    year="2017" \
+    year="2018" \
     media="download" \
     file1="AdobeAIRInstaller.exe" \
     installed_file1="$W_COMMONFILES_X86_WIN/Adobe AIR/Versions/1.0/Adobe AIR.dll" \
@@ -5377,7 +5377,8 @@ load_adobeair()
 {
     # 2017/03/14: 20.0.0.260 (strings 'Adobe AIR.dll' | grep 20\\. ) sha256sum 318770b9a18e59ca4a721a1f5c2b0235cffdbe77a043e99cb2af32074d61de45
     # 2018/01/30: 28.0.0.127 (strings 'Adobe AIR.dll' | grep 28\\. ) sha256sum 9076489e273652089a4a53a1d38c6631e8b7477e39426a843e0273f25bfb109f
-    w_download https://airdownload.adobe.com/air/win/download/latest/AdobeAIRInstaller.exe 9076489e273652089a4a53a1d38c6631e8b7477e39426a843e0273f25bfb109f
+    # 2018/03/16: 29.0.0.112 (strings 'Adobe AIR.dll' | grep -E "^29\..+\..+" ) sha256sum 5186b54682644a30f2be61c9b510de9a9a76e301bc1b42f0f1bc50bd809a3625
+    w_download https://airdownload.adobe.com/air/win/download/latest/AdobeAIRInstaller.exe 5186b54682644a30f2be61c9b510de9a9a76e301bc1b42f0f1bc50bd809a3625
     w_try_cd "$W_CACHE/$W_PACKAGE"
 
     # See https://bugs.winehq.org/show_bug.cgi?id=43506

--- a/src/winetricks
+++ b/src/winetricks
@@ -9238,7 +9238,7 @@ load_setupapi()
 w_metadata shockwave dlls \
     title="Shockwave" \
     publisher="Adobe" \
-    year="2017" \
+    year="2018" \
     media="download" \
     file1="sw_lic_full_installer.msi" \
     installed_file1="$W_SYSTEM32_DLLS_WIN/Adobe/Shockwave 12/shockwave_Projector_Loader.dcr"
@@ -9248,7 +9248,8 @@ load_shockwave() {
     # 2017/03/15: 58f2152bf726d52f08fb41f904c62ff00fdf748c8ce413e8c8547da3a21922ba
     # 2017/08/03: bebebaef1644a994179a2e491ce3f55599d768f7c6019729f21e7029b1845b9c
     # 2017/12/12: 0a9813ac55a8718440518dc2f5f410a3a065b422fe0618c073bfc631b9abf12c
-    w_download https://fpdownload.macromedia.com/get/shockwave/default/english/win95nt/latest/sw_lic_full_installer.msi 0a9813ac55a8718440518dc2f5f410a3a065b422fe0618c073bfc631b9abf12c
+    # 2018/03/16: 4d7b408cf5b65a522b071d7d9ddbc5f6964911a7d55c418e31f393e6055cf796
+    w_download https://fpdownload.macromedia.com/get/shockwave/default/english/win95nt/latest/sw_lic_full_installer.msi 4d7b408cf5b65a522b071d7d9ddbc5f6964911a7d55c418e31f393e6055cf796
 
     w_try_cd "$W_CACHE/$W_PACKAGE"
     w_try "$WINE" msiexec /i sw_lic_full_installer.msi $W_UNATTENDED_SLASH_Q


### PR DESCRIPTION
* `adobeair` (`29.0.0.112`): `5186b54682644a30f2be61c9b510de9a9a76e301bc1b42f0f1bc50bd809a3625`
* `shockwave` (`12.3.2.202`): `4d7b408cf5b65a522b071d7d9ddbc5f6964911a7d55c418e31f393e6055cf796`