### PR TITLE
fix upstream issue Winetricks/winetricks/issues/955

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -10096,10 +10096,10 @@ load_windowscodecs()
     fi
 
     # Avoid a file existence check.
-    w_try rm -f "$W_SYSTEM32_DLLS"/windowscodecs.dll "$W_SYSTEM32_DLLS"/windowscodecsext.dll "$W_SYSTEM32_DLLS"/photometadatahandler.dll
+    w_try rm -f "$W_SYSTEM32_DLLS"/windowscodecs.dll "$W_SYSTEM32_DLLS"/windowscodecsext.dll "$W_SYSTEM32_DLLS"/photometadatahandler.dll "$W_SYSTEM32_DLLS"/wmphoto.dll
 
     if [ "$W_ARCH" = "win64" ]; then
-         w_try rm -f "$W_SYSTEM64_DLLS"/windowscodecs.dll "$W_SYSTEM64_DLLS"/windowscodecsext.dll "$W_SYSTEM64_DLLS"/photometadatahandler.dll
+         w_try rm -f "$W_SYSTEM64_DLLS"/windowscodecs.dll "$W_SYSTEM64_DLLS"/windowscodecsext.dll "$W_SYSTEM64_DLLS"/photometadatahandler.dll "$W_SYSTEM64_DLLS"/wmphoto.dll
     fi
 
     # AF says in AppDB entry for .NET 3.0 that windowscodecs has to be native only


### PR DESCRIPTION
Fixes winetricks/issues/955 - allows windowscodecs verb to finish without error