### PR TITLE
travis.yml: install bashate with .deb files for Ubuntu 18.04 LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,23 +16,43 @@ dist: trusty
 addons:
   apt:
     packages:
+    # for bashate
+    - python-tz
     # for checkbashisms
     - devscripts
 
 # Note: if statements cannot go across multiple lines. Combine into one, or move to a shell script!
 
-# On Ubuntu, shellcheck is not in trusty, but is in trusty-backports, but those aren't available in TravisCI..)
-# Using artful to get 0.4.6, which has support for disabling a check globally within a file
+# Ubuntu notes:
+#    * ShellCheck is already installed in TravisCI
+#    * bashate is not available on Trusty and we need to install it manually
+# macOS note:
+#    * Homebrew doesn't provide bashate, they don't package things
+#      that are on pypi
+#
+# We use a script that installs bashate by unpacking .deb files built for
+# Ubuntu Bionic (18.04) because:
+#   1. python-bashate 0.3.1-2 (for Artful) can be installed but
+#      Artful will not be supported after July 2018
+#   2. python-bashate 0.5.1-1 (for Bionic) can't be installed on Trusty
+#      because it contains "control.tar.xz"
+#      > dpkg-deb: error: archive '/var/cache/apt/archives/python-bashate_0.5.1-1_all.deb' has premature member 'control.tar.xz' before 'control.tar.gz', giving up
+#      > dpkg: error processing archive /var/cache/apt/archives/python-bashate_0.5.1-1_all.deb (--unpack):
+#      > subprocess dpkg-deb --control returned error exit status 2
+#   3. Adding apt-line for newer Ubuntu release breaks dependencies
+#      e.g. can't install Official Wine package on Ubuntu
+#      > The following packages have unmet dependencies:
+#      >  winehq-stable : Depends: wine-stable (= 3.0.0~trusty)
+#      > E: Unable to correct problems, you have held broken packages.
+#   4. Ubuntu Bionic is an LTS release and will be supported until April 2023
+#      This means that we can use version 0.5.1-1 until April 2023
+#   5. The installation via the script is quick
+#      (simply download and unpack files)
+#
+# If the script fails, install pip and use it to install bashate
 before_install:
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then echo "deb http://archive.ubuntu.com/ubuntu/ artful universe" | sudo tee -a /etc/apt/sources.list ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then time sudo apt-get -q update ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then time sudo apt-get install python-bashate shellcheck ; fi
-
+    - time sh ./misc/travis-install-bashate-deb.sh || time sh ./misc/travis-install-bashate-pip.sh
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]] ; then time brew update ; fi
-    # Travis decided to remove pip from the OSX image
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]] ; then time curl https://bootstrap.pypa.io/get-pip.py | sudo python ; fi
-    # Bashate isn't on homebrew, they don't package things that are on pypi, so we have to pip install it instead:
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]] ; then time sudo pip install bashate ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]] ; then time brew install checkbashisms shellcheck ; fi
 
 # Note if testing on a branch, you can replace this with your desired command, e.g.,:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,12 @@ addons:
 # If the script fails, install pip and use it to install bashate
 before_install:
     - time sh ./misc/travis-install-bashate-deb.sh || time sh ./misc/travis-install-bashate-pip.sh
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]] ; then time brew update ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]] ; then time brew install checkbashisms shellcheck ; fi
+      # "brew update" (or auto-update when installing) takes long time
+      # checkbashisms and shellcheck can be installed without this
+      # So installing with "HOMEBREW_NO_AUTO_UPDATE=1" considerably reduces
+      # job time on macOS
+      # If it fails retry with auto-update
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]] ; then time env HOMEBREW_NO_AUTO_UPDATE=1 brew install checkbashisms shellcheck || time brew install checkbashisms shellcheck ; fi
 
 # Note if testing on a branch, you can replace this with your desired command, e.g.,:
 # script: time sh ./src/winetricks -q comctl32

--- a/misc/travis-install-bashate-deb.sh
+++ b/misc/travis-install-bashate-deb.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+#
+# This script is public domain.
+
+# This script installs bashate by unpacking .deb files built for Ubuntu 18.04.
+# This is intended to install/use bashate in TravisCI.
+
+# Usage (.travis.yml):
+#   ...
+#   os:
+#     - linux
+#     - ...
+#   sudo: required
+#   dist: trusty
+#   ...
+#   addons:
+#     apt:
+#       packages:
+#       - python-tz
+#       - ...
+#   ...
+#   before_install:
+#       - time sh ./misc/travis-install-bashate-deb.sh
+#       - ...
+
+set -eux
+
+# "us-central1.gce.archive.ubuntu.com" is used by "apt" addon
+# (See "Installing APT Packages" in logs), assuming it's fast
+UBUNTU_POOL=http://us-central1.gce.archive.ubuntu.com/ubuntu/pool
+DEB_BABEL_LOCALEDATA=$UBUNTU_POOL/main/p/python-babel/python-babel-localedata_2.4.0+dfsg.1-2ubuntu1_all.deb
+DEB_BABEL=$UBUNTU_POOL/main/p/python-babel/python-babel_2.4.0+dfsg.1-2ubuntu1_all.deb
+DEB_BASHATE=$UBUNTU_POOL/universe/p/python-bashate/python-bashate_0.5.1-1_all.deb
+DEB_PBR=$UBUNTU_POOL/main/p/python-pbr/python-pbr_3.1.1-3ubuntu3_all.deb
+DEB_SIX=$UBUNTU_POOL/main/s/six/python-six_1.11.0-2_all.deb
+
+if which bashate >/dev/null; then
+    echo "bashate is already installed."
+    exit 1
+fi
+
+if test -d /Library; then
+    # macOS: "six" is already installed
+    curl --remote-name-all $DEB_BABEL_LOCALEDATA $DEB_BABEL $DEB_BASHATE $DEB_PBR
+    BINDIR=/usr/local/bin
+    PACKAGESDIR=/Library/Python/2.7/site-packages
+else
+    # Ubuntu
+    curl --remote-name-all $DEB_BABEL_LOCALEDATA $DEB_BABEL $DEB_BASHATE $DEB_PBR $DEB_SIX
+    BINDIR=/usr/bin
+    PACKAGESDIR=/usr/lib/python2.7/dist-packages
+fi
+
+for f in *.deb; do
+    ar p "$f" data.tar.xz | tar -Jvxf -
+done
+
+sudo cp -R usr/lib/python2.7/dist-packages/* $PACKAGESDIR/
+sudo install -m 755 usr/bin/python2-bashate $BINDIR/bashate

--- a/misc/travis-install-bashate-pip.sh
+++ b/misc/travis-install-bashate-pip.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# This script is public domain.
+#
+# This file is intended to install bashate via pip.
+
+set -ex
+
+if test -d /Library; then
+    # macOS
+    curl https://bootstrap.pypa.io/get-pip.py | sudo python
+else
+    # Ubuntu
+    sudo apt-get install python-pip
+fi
+sudo -H pip install bashate


### PR DESCRIPTION
The new script `travis-install-bashate.sh` installs bashate
by unpacking .deb files built for Ubuntu Bionic (18.04 LTS).
This also reduces job time.

Ubuntu Bionic will be supported until April 2023.

Also, ShellCheck is already available on Ubuntu image and
we don't need to install it.