### PR TITLE
remove_mono should also remove 64 bit mscoree.dll; fixes winetricks/i…

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -9135,6 +9135,9 @@ load_remove_mono()
     "${WINE_ARCH}" reg delete "HKLM\\Software\\Microsoft\\NET Framework Setup\\NDP\\v4" /f || true
 
     w_try rm -f "$W_WINDIR_UNIX/system32/mscoree.dll"
+    if [ "$W_ARCH" = "win64" ]; then
+        w_try rm -f "$W_WINDIR_UNIX/syswow64/mscoree.dll"
+    fi
 }
 
 #----------------------------------------------------------------


### PR DESCRIPTION
fixes Winetricks/winetricks/issues/972