### PR TITLE
Add winetricks.bash-completion BASH Completion Script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ install:
 	$(INSTALL_DATA) src/winetricks.appdata.xml $(DESTDIR)$(PREFIX)/share/metainfo/winetricks.appdata.xml
 	$(INSTALL) -d $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps
 	$(INSTALL_DATA) src/winetricks.svg $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/winetricks.svg
+	$(INSTALL) -d $(DESTDIR)$(PREFIX)/share/bash-completion/completions
+	$(INSTALL_DATA) src/winetricks.bash-completion $(DESTDIR)$(PREFIX)/share/bash-completion/completions/winetricks
 
 check:
 	echo 'This verifies that most DLL verbs, plus flash, install ok.'

--- a/src/winetricks
+++ b/src/winetricks
@@ -3129,16 +3129,23 @@ winetricks_print_version()
 # Handy place to put small workarounds
 winetricks_early_wine()
 {
-    # The sed works around https://bugs.winehq.org/show_bug.cgi?id=25838
-    # which unfortunately got released in wine-1.3.12
-    # We would like to use DISPLAY= to prevent virtual desktops from
-    # popping up, but that causes AutoHotKey's tray icon to not show up.
-    # We used to use WINEDLLOVERRIDES=mshtml= here to suppress the Gecko
-    # autoinstall, but that yielded wineprefixes that *never* autoinstalled
-    # Gecko (winezeug bug 223).
-    # The tr removes carriage returns so expanded variables don't have crud on the end
-    # The grep works around using new wineprefixes with old wine
-    WINEDEBUG=-all "$WINE" "$@" 2> "$W_TMP_EARLY"/early_wine.err.txt | ( sed 's/.*1h.=//' | tr -d '\r' | grep -v -e "Module not found" -e "Could not load wine-gecko" || true)
+    local saved_timestamp=""
+    if [ -f "$WINEPREFIX/.update-timestamp" ] && [ -f "$WINEPREFIX/system.reg" ] && [ -f "$WINEPREFIX/user.reg" ]; then
+        saved_timestamp="$(cat "$WINEPREFIX/.update-timestamp")"
+        echo disable >"$WINEPREFIX/.update-timestamp"
+        # We can use DISPLAY= here (e.g. to prevent virtual desktops from
+        # popping up and WINEPREFIX update notifications) as we know the current
+        # Wineprefix exists and we have temporarily disabled Wineprefix updates.
+        # The tr removes carriage returns so expanded variables don't have crud on the end
+        # The grep works around using new wineprefixes with old wine
+        DISPLAY="" WINEDEBUG=-all "$WINE" "$@" 2> "$W_TMP_EARLY"/early_wine.err.txt \
+            | ( tr -d '\r' | grep -v -e "Module not found" -e "Could not load wine-gecko" || true)
+        echo "${saved_timestamp}" >"$WINEPREFIX/.update-timestamp"
+    else 
+        # As above but the DISPLAY env var is enabled as we are creating the Wineprefix.
+        WINEDEBUG=-all "$WINE" "$@" 2> "$W_TMP_EARLY"/early_wine.err.txt \
+            | ( tr -d '\r' | grep -v -e "Module not found" -e "Could not load wine-gecko" || true)
+    fi
 }
 
 winetricks_detect_gui()
@@ -5342,7 +5349,8 @@ helper_winxpsp3()
     # https://www.microsoft.com/en-us/download/details.aspx?id=24
     # https://download.microsoft.com/download/d/3/0/d30e32d8-418a-469d-b600-f32ce3edf42d/WindowsXP-KB936929-SP3-x86-ENU.exe
     # Mirror list: http://www.filewatcher.com/m/WindowsXP-KB936929-SP3-x86-ENU.exe.331805736-0.html
-    w_download_to winxpsp3 ftp://ftp.gnome.org/mirror/archive/ftp.sunet.se/pub/security/vendor/microsoft/winxp/Service_Packs/WindowsXP-KB936929-SP3-x86-ENU.exe 62e524a552db9f6fd22d469010ea4d7e28ee06fa615a1c34362129f808916654
+    # 2018/04/04: http://www.download.windowsupdate.com/msdownload/update/software/dflt/2008/04/windowsxp-kb936929-sp3-x86-enu_c81472f7eeea2eca421e116cd4c03e2300ebfde4.exe
+    w_download_to winxpsp3 ftp://ftp.emacinc.com/LegacyProducts/SBC/drivers/vdx/WINXP/WindowsXP-KB936929-SP3-x86-ENU.exe 62e524a552db9f6fd22d469010ea4d7e28ee06fa615a1c34362129f808916654
 
     w_try_cabextract -d "$W_TMP" -L -F "$filename" "$W_CACHE"/winxpsp3/WindowsXP-KB936929-SP3-x86-ENU.exe
 }
@@ -12321,53 +12329,6 @@ _EOF_
 
 #----------------------------------------------------------------
 
-w_metadata picasa39 apps \
-    title="Picasa 3.9" \
-    publisher="Google" \
-    year="2014" \
-    file1="picasa39-setup.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Google/Picasa3/Picasa3.exe"
-
-load_picasa39()
-{
-    # 2016/01/02: 482c1a547d8d3aa25ee446d30ea986de63ef8c8d68b8d1109dd3d9b714e73e08
-
-    w_download https://dl.google.com/picasa/picasa39-setup.exe 482c1a547d8d3aa25ee446d30ea986de63ef8c8d68b8d1109dd3d9b714e73e08
-    if w_workaround_wine_bug 29434 "Picasa 3.9 fails to authenticate with Google"; then
-        w_warn "Picasa 3.9 authentication to the Google account is currently broken under wine. See https://bugs.winehq.org/show_bug.cgi?id=29434 for more details."
-    fi
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_ahk_do "
-        SetTitleMatchMode, 2
-        run picasa39-setup.exe
-        WinWait, Picasa 3 Setup
-        if ( w_opt_unattended > 0 ) {
-             Sleep 1000
-             ControlClick Button2 ;I Agree - License
-             Sleep 1000
-             WinWait, Picasa 3 Setup, Choose Install Location
-             ControlClick Button2 ;Install
-             Sleep 1000
-             WinWait, Picasa 3 Setup, Picasa 3 has been installed on your computer
-             Sleep 500
-             ControlClick Button5 ; Desktop Icon
-             Sleep 500
-             ControlClick Button6 ; Quick Launch
-             Sleep 500
-             ControlClick Button7 ; Default search off
-             Sleep 500
-             ControlClick Button8 ; Usage statistics sent
-             Sleep 500
-             ControlClick Button4 ; Run Picasa
-             Sleep 500
-             ControlClick Button2 ; Finish
-        }
-        WinWaitClose
-        "
-}
-
-#----------------------------------------------------------------
-
 w_metadata protectionid apps \
     title="Protection ID" \
     publisher="CDKiLLER & TippeX" \
@@ -16752,40 +16713,6 @@ load_penpenxmas()
 
     w_try_cd "$W_CACHE/$W_PACKAGE"
     "$WINE" PenPenXmasOlympics100.exe $W_UNATTENDED_SLASH_S
-}
-
-#----------------------------------------------------------------
-
-w_metadata plantsvszombies games \
-    title="Plants vs. Zombies" \
-    publisher="PopCap Games" \
-    year="2009" \
-    media="download" \
-    file1="PlantsVsZombiesSetup.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/PopCap Games/Plants vs. Zombies/PlantsVsZombies.exe"
-
-load_plantsvszombies()
-{
-    w_download "https://downloads.popcap.com/www/popcap_downloads/PlantsVsZombiesSetup.exe" 4b4bb4d19fb639e5698983e39d7ad061c7667bcec19056560532c7ad0d67d0e4
-
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_ahk_do "
-        run PlantsVsZombiesSetup.exe
-        winwait, Plants vs. Zombies Installer
-        if ( w_opt_unattended > 0 ) {
-            sleep 1000
-            send {Enter}
-            winwait, Plants vs. Zombies License Agreement
-            ControlClick Button1
-        }
-        winwait, Plants vs. Zombies Installation Complete!
-        if ( w_opt_unattended > 0 ) {
-            sleep 1000
-            send {Space}{Enter}
-            ControlClick, x309 y278, Plants vs. Zombies Installation Complete!,,,, Pos
-        }
-        WinWaitClose
-    "
 }
 
 #----------------------------------------------------------------

--- a/src/winetricks.bash-completion
+++ b/src/winetricks.bash-completion
@@ -1,0 +1,579 @@
+#!/bin/bash
+# bash completion for winetricks script
+
+WINETRICKS="$(which winetricks)"
+
+readonly \
+	COUNTRY_CODE_URL="https://pkgstore.datahub.io/core/country-list/data_csv/data/d7c9d7cfb42cb69f4422dec222dbbaa8/data_csv.csv" \
+	INVERTABLE_OPTS="isolate" \
+	TERMINATING_OPTS="gui help update version" \
+	TERMINATING_LIST_COMMAND="list" \
+	VERB_WINVER="winver="
+	COMMAND_WINEPREFIX="prefix=" \
+	COMMAND_PREFIX_CATEGORY="prefix"
+
+readonly \
+	CATEGORY_SEPERATOR_REGEX="^===== [[:lower:]]+ =====$" \
+	COMMAND_START_REGEX="^Commands\\:$" \
+	VERB_REGEX="[\\-\\_\\=\\(\\)\\|[:alnum:]]+" \
+	LONG_OPTION_REGEX="\\-\\-${VERB_REGEX}"
+
+
+# Download a string of 2 ASCII uppercase character Global Country Codes.
+_store_country_codes()
+{
+	COUNTRY_CODES="$(wget -O - -q "${COUNTRY_CODE_URL}" 2>/dev/null \
+	| awk -F ',' \
+		'{
+			if ($2 ~ "^[[:upper:]][[:upper:]]")
+				printf("%s ",substr($2,1,2))
+		}'
+	)"
+}
+
+# _store_help()
+# > WINETRICKS_HELP
+#
+# Store winetricks help message in a variable (for later processing)
+_store_help()
+{
+	WINETRICKS_HELP="$("${WINETRICKS}" --help)"
+}
+
+# _store_list_all()
+# > WINETRICKS_LIST_ALL
+#
+# Store winetricks list-all verbs message in a variable (for later processing)
+_store_list_all()
+{
+	WINETRICKS_LIST_ALL="$("${WINETRICKS}" list-all)"
+}
+
+# _list_remove_item()
+# 1< regular-expression
+#  < stdin (list)
+#  > stdout (list)
+#
+# Takes a list of items on stdin and parses items to stdout.
+# First removing any items matching 'regular-expression'. 
+_list_remove_item()
+{
+	awk -vregex=" ${1:-} " \
+	'{
+		if (regex != "")
+			sub(regex, " ")
+		print $0
+	}'
+	
+}
+
+# _match_expression()
+#   1< regular-expression
+#  [2< is-text=0]
+# 	 < stdin
+#    > not match
+#
+# Match list of items on stdin with 'regular-expression'
+# (treated as text if is-text is set to 1).
+#
+# Return 0=match / 1=no match
+_match_expression()
+{
+	if [ "${#}" -lt 1 ] || [ -z "${1}" ]; then
+		return
+	fi
+	awk -vregex="${1}" -vis_text="${2:-0}" \
+	'function text2regex(regex,
+                endmarker,startmarker)
+	{
+        startmarker=sub("^\\^", "", regex)
+        endmarker=sub("\\$$", "", regex)
+        # Escape all control regex characters
+        gsub("\\\\", "\x5c\x5c&", regex)
+        gsub("\\!|\\\"|\\#|\\$|\\%|\\&|\x27|\\(|\\)|\\+|\\,|\\-|\\.|\\/|\\:|\\;|\x3c|\\=|\x3e|\\?|\\@|\\[|\\]|\\{|\\|\\}|\\~", "\x5c\x5c&", regex)
+        gsub("\x20", "[[:blank:]]+", regex)
+        gsub("\\*", ".*", regex)
+        regex=((startmarker ? "^" : "") regex (endmarker ? "$" : ""))
+        gsub("\\|", "\x5c\x5c&", regex)
+
+        return regex
+	}
+	
+	BEGIN{
+		if (is_text)
+			regex=text2regex(regex)
+	}
+	{
+		if ($0 ~ regex)
+			matched=1
+	}
+	END{
+		exit (!matched)
+	}'
+}
+
+# _get_duplicate_options()
+# (< WINETRICKS_HELP, INVERTABLE_OPTS)
+#  > stdout
+#
+# For each long option determine if it has a matching short option or is
+# invertable (i.e. "--no-xxxx" vs "--xxxx")
+#
+# >
+# "[short-option|inverted-long-option] long-option
+#  ...
+#  [short-option|inverted-long-option] long-option"
+_get_duplicate_options()
+{
+	echo "${WINETRICKS_HELP}" | awk \
+		-vinvertable_options="${INVERTABLE_OPTS}" \
+		'BEGIN{
+			gsub(" ","|",invertable_options)
+		}
+		{
+			duplicate=""
+			for (f=1;f<=2;++f) {
+				sub(",$","",$f)
+				if ($f !~ "^\-") {
+					duplicate=""
+					break
+				}
+				duplicate=(duplicate " " $f)
+			}
+			if ((duplicate == "") && ($1 ~ invertable_options)) {
+				negated_duplicate=$1
+				sub("^\-\-no\-","--",negated_duplicate) ||
+					sub("^\-\-","--no-",negated_duplicate)
+				duplicate=(negated_duplicate " " $1)
+			}
+			if (duplicate != "")
+				printf(" %s \n", duplicate);
+		}'
+}
+
+# _get_commands()
+# (< WINETRICKS_HELP, COMMAND_WINEPREFIX, COMMAND_START_REGEX)
+#  > stdout
+#
+# Parse list of commands (excluding options) from winetricks help.
+# Also discard all 2 verb commands of the form: <prefix> list.
+#
+# >
+# "command
+#  ...
+#  command"
+_get_commands()
+{
+	echo "${WINETRICKS_HELP}" | awk -F '[[:blank:]][[:blank:]]+' \
+		-vwineprefix_command="${COMMAND_WINEPREFIX}" \
+		-vcommand_start_regex=${COMMAND_START_REGEX} \
+		'{
+			verb=$1
+			if (dump && !sub(" ","",verb)) {
+				sub(("^" wineprefix_command ".*$"),wineprefix_command,verb)
+				verbs=(verbs " " verb)
+			}
+			if ($0 ~ command_start_regex)
+				dump=1
+		}
+		END{
+			printf("%s \n", verbs)
+		}'
+}
+
+# _get_categories()
+# (< WINETRICKS_LIST_ALL, CATEGORY_SEPERATOR_REGEX)
+#  > stdout
+#
+# Parse winetricks list-all to get sets of all categories and
+# the verbs contained within that category.
+#
+# >
+# "category
+#  verb [... verb]
+#  category
+#  verb [... verb]
+#  ..."
+_get_categories()
+{
+	# shellcheck disable=SC1004
+	echo "${WINETRICKS_LIST_ALL}" | awk \
+		-vcategory_seperator_regex="${CATEGORY_SEPERATOR_REGEX}" \
+		'function insert_assignment_verb(verbs, verb,
+				verb_prefix, verb_suffix)
+		{
+			verb_suffix=verb_prefix=verb
+			sub("=.*$","",verb_prefix)
+			sub("^.*=","",verb_suffix)
+			match(verbs, verb_prefix)
+			if (RSTART)
+				verbs=(substr(verbs,1,RSTART+RLENGTH+1) \
+					verb_suffix "|" \
+					substr(verbs,RSTART+RLENGTH+2))
+			else
+				verbs=(verbs " " verb_prefix "=(" verb_suffix ")")
+			return verbs
+		}
+
+		function get_category(array_items, category,
+				i, verb, verbs)
+		{
+			for (i=1 ; i<array_items[category,0] ; ++i ) {
+				verb=array_items[category,i]
+				if (verb ~ "=") 
+					verbs=insert_assignment_verb(verbs, verb)
+				else
+					verbs=(verbs " " verb)
+			}
+			return (verbs)
+		}
+
+		{
+			if (category) 
+				array_items[category,++array_items[category,0]]=$1
+			if ($0 ~ category_seperator_regex) {
+				category=$2
+				array_categories[++array_categories[0]]=category
+			}
+		}
+		END{
+			for (i=1 ; i<=array_categories[0] ; ++i) {
+				category=array_categories[i]
+				printf("%s\n", category)
+				printf("%s\n", get_category(array_items, category))
+			}
+		}'
+}
+
+# _get_options()
+# (< WINETRICKS_HELP, COUNTRY_CODES, INVERTABLE_OPTS)
+#  > stdout
+#
+# Parse winetricks help to get a list of all available options.
+# Expand invertible options ("--no-xxxx" vs "--xxxx") with the alternate
+# version.
+#
+# >
+#  "[short-option|inverted-long-option] long-option ... [short-option|
+# inverted-long-option] long-option"
+_get_options()
+{
+	echo "${WINETRICKS_HELP}" | awk \
+		-vcountry_codes="${COUNTRY_CODES}" \
+		-vinvertable_options="${INVERTABLE_OPTS}" \
+		'BEGIN{
+			invertable_options_count=split(invertable_options, invertable_options_array)
+		}
+		{
+			for (f=1;f<=2;++f)
+			{
+				field=$f
+				sub(",$","",field)
+				if (field ~ "^\-\-") {
+					if (field ~ "=CC$") {
+						gsub(" ","|",country_codes)
+						sub("=.*$",("=(" country_codes ")"),field)
+					}
+					long=(long " " field)
+					for (i=1;i<=invertable_options_count;++i) {
+						if (field == ("--no-" invertable_options_array[i])) {
+							sub("^\-\-no\-","--",field)
+							long=(long " " field)
+							break
+						}
+						else if (field == ("--" invertable_options_array[i])) {
+							sub("^\-\-","--no-",field)
+							long=(long " " field)
+							break
+						}
+					}
+				}
+				else if (field ~ "^\-") {
+					short=(short " " field)
+					continue
+				}
+				next
+			}
+		}
+		END{
+			printf(" %s%s ", short, long)
+		}'
+}
+
+# _get_verb_category()
+# (< CATEGORIES_LIST)
+# 1< category
+#  > stdout
+#
+# For the specified category, print a line of all verbs in that category.
+# If no category is specified then print a line of all verbs, for all categories.
+#
+# >
+#  "verb [... verb]"
+_get_verb_category()
+{
+	echo "${CATEGORIES_LIST}" | awk -vcategory="${1:-}" \
+		'{
+			if (!index_value)
+				matched=((category=="") || (category==$1))
+			else if (matched) {
+				printf(" %s ", $0)
+				matched=0
+			}
+			index_value=!index_value
+		}
+		END{
+			printf(" \n")
+		}'
+}
+
+# _line_space()
+#  < stdin
+#  > stdout
+#
+# Insert a line space after each item in stdin.
+# Output to stdout.
+_line_space()
+{
+	awk '{ for(i=1;i<=NF;++i) { print $i } }'
+}
+
+# _assignment_strip_values()
+#  < stdin
+#  > stdout
+#
+# Takes a list of verbs or options and processes assignments,
+# which use the "=" assignment operator.
+# Remove the post-assignment regex values.
+#
+# <
+# "... videomem=(default|512|1024|2048) ..."
+# >
+# "... videomem= ..."
+_assignment_strip_values()
+{
+	awk '{ gsub("=\([^\)]*\)","="); print $0 }'
+}
+
+# _assignment_get_values()
+# 1< target
+#  < stdin
+#  > stdout
+#
+# Takes a list of verbs or options and processes a single specified target assignment.
+# Remove the prefix target name.
+# Convert the postfix regex values to a simple WS separated list.
+#
+# 1< target="videomem"
+# <
+# "... videomem=(default|512|1024|2048) ..."
+# >
+# "default 512 1024 2048"
+_assignment_get_values()
+{
+	if [ "${#}" -lt 1 ]; then
+		return
+	fi
+	awk -vtarget="${1}" \
+	'{
+		for (i=1 ; i <= NF ; ++i) {
+			if ($i !~ "=")
+				continue
+			verb_suffix=verb_prefix=$i
+			sub("=.*$","",verb_prefix)
+			sub("^.*=","",verb_suffix)
+			if (verb_prefix == target) {
+				sub("^\(","",verb_suffix)
+				sub("\)$","",verb_suffix)
+				gsub("\|"," ",verb_suffix)
+				printf("%s\n", verb_suffix)
+				exit
+			}
+		}
+	}'
+}
+
+# _get_alternate_opt()
+#    (< DUPLICATE_OPTS_LIST)
+#    1< option
+#     > stdout (alternate-option)
+#
+# Given the specified option find the alternate
+# (or inverse) operation - if one exists.
+# Print this to stdout.
+#
+# < option="--no-isolate"
+# >
+#   "--isolate"
+_get_alternate_opt()
+{
+	if [ "${#}" -lt 1 ]; then
+		return
+	fi
+
+	echo "${DUPLICATE_OPTS_LIST}" | awk -F'[ ]+' -vopt="${1}" \
+		'{
+			found=0
+			for (i=1;i<=NF;++i) {
+				if ($i == "")
+					continue
+				if ($i == opt)
+					found=1
+				else
+					alternate_opt=$i
+			}
+			if (found)
+				print alternate_opt
+		}'
+}
+
+# _get_matching_opts()
+#       (< OPTS, DUPLICATE_OPTS_LIST)
+# 1[..N] < regex [... regex]
+#        > stdout
+#
+# Takes a list of regular expressions.
+# Match all available options, including duplicate / inverse options,
+# against each regular expression.
+# Dump all matching options to stdout.
+#
+# < "help" "update"
+# >
+#  " -h --help --self-update --update-rollback "
+_get_matching_opts()
+{
+	if [ "${#}" -lt 1 ]; then
+		return
+	fi
+	local opts_list
+
+	# shellcheck disable=SC2207
+	opts_list="$( echo "${OPTS}" | _assignment_strip_values | _line_space )"
+	opts_list="${opts_list}
+${DUPLICATE_OPTS_LIST}"
+	while [ ! -z "${1}" ]; do
+		echo "${opts_list}" | awk \
+			-varg="${1}" \
+			'{
+				if ($0 ~ arg)
+					printf("%s ", $0)
+			}'
+		shift 1
+	done
+	printf " \\n"
+}
+
+_winetricks()
+{
+	local alernate_opt all_terminating curr i opt prefix_verbs test_curr test_prev reply temp_opts
+	curr="${COMP_WORDS[COMP_CWORD]}"
+	prev="${COMP_WORDS[COMP_CWORD-1]}"
+	COMPREPLY=( )
+
+	prefix_verbs="$( _get_verb_category "${COMMAND_PREFIX_CATEGORY}" )"
+
+	if echo "${prefix_verbs}" | _match_expression " ${prev} "; then
+		# shellcheck disable=SC2207
+		COMPREPLY=( $(compgen -W "${TERMINATING_LIST_COMMAND}" -- "${curr}") )
+		return 0
+	fi
+
+	for i in 1 2; do
+		if [ "${COMP_WORDS[COMP_CWORD-i]}=" = "${COMMAND_WINEPREFIX}" ]; then
+			_filedir -d
+			return 0
+		fi
+	done
+
+	# Disable tab expansion when a terminating option or command has been typed...
+	# shellcheck disable=SC2086
+	all_terminating="$(_get_matching_opts ${TERMINATING_OPTS})"
+	all_terminating=" ${all_terminating} ${COMMANDS} ${TERMINATING_LIST_COMMAND} "
+	if echo "${all_terminating}" | _match_expression " ${prev} " 1; then
+		# shellcheck disable=SC2207
+		COMPREPLY=( $(compgen -W "" -- "") )
+		return 0
+	fi
+
+	# When an option is specified disable both this option, and any duplicate/inverse options,
+	# from tab expansion on this command line entry...
+	temp_opts="${OPTS}"
+	for i in $(seq 2 $((COMP_CWORD))); do
+		opt="${COMP_WORDS[i-1]}"
+		if echo "${opt}" | _match_expression "-*" 1; then
+			alernate_opt="$( _get_alternate_opt "${opt}" )"
+			temp_opts="$( echo "${temp_opts}" | _list_remove_item "${opt}" | _list_remove_item "${alernate_opt}" )"
+		fi
+	done
+
+	CATEGORY_VERBS="$( _get_verb_category "" )"
+
+	# Parse assignment verbs and options
+	for i in $((COMP_CWORD-1)) $((COMP_CWORD)); do
+		if [ "${i}" -lt 1 ]; then
+			continue
+		fi
+
+		test_curr="${COMP_WORDS[i]}"
+		test_prev="${COMP_WORDS[i-1]}"
+
+		if [ "${test_curr}" != "=" ]; then
+			continue
+		fi
+
+		if [ "${test_prev}=" == "${VERB_WINVER}" ]; then
+			continue
+		fi
+		
+		case "${test_prev}" in
+			-*)
+				reply="${temp_opts}"
+				;;
+			*)
+				reply="${COMMANDS} ${CATEGORY_VERBS}"
+				;;
+		esac
+		reply="$( echo "${reply}" | _assignment_get_values "${test_prev}" )"
+		# shellcheck disable=SC2207
+		COMPREPLY=( $(compgen -W "${reply}" -- "${curr%=}") )
+		if echo "${COMPREPLY[0]}" | _match_expression "*=" 1; then
+			compopt -o nospace
+		fi
+		return 0
+	done
+		
+	# Parse general (non-assignment) verbs and options
+	case "${curr}" in
+		--*)
+			reply="$( echo "${temp_opts}" | _assignment_strip_values )"
+			;;
+		-*)
+			reply="$( echo "${temp_opts}" | _list_remove_item "${LONG_OPTION_REGEX}" )"
+			;;
+		*)
+			reply="$( echo "${COMMANDS}" "${CATEGORY_VERBS}" | _assignment_strip_values  )"
+			;;
+	esac
+
+	# shellcheck disable=SC2207
+	COMPREPLY=( $(compgen -W "${reply}" -- "${curr}") )
+	if [ "${COMPREPLY[0]}" == "${VERB_WINVER}" ]; then
+		return 0
+	fi
+	if echo "${COMPREPLY[0]}" | _match_expression "*=" 1; then
+		compopt -o nospace
+	fi
+	return 0
+}
+
+_store_country_codes
+_store_help
+_store_list_all
+
+OPTS="$(_get_options)"
+COMMANDS="$(_get_commands)"
+
+DUPLICATE_OPTS_LIST="$(_get_duplicate_options)"
+CATEGORIES_LIST="$(_get_categories)"
+
+complete -F _winetricks winetricks


### PR DESCRIPTION
This completion script is designed to be self-contained.
Uses the output from 2 standard winetricks commands:
```
winetricks list-all
winetricks --help
```
to extract all the verbs, commands and options - that
the associated version of winetricks currently supports.
Regular expressions and verbs, that are explicitly referenced
in the script, are broken out to global (read-only) variables
at the head of the script (to ease future updates).
The script is designed to be Posix compliant. Passes all
shellcheck and checkbashism's current tests.

Add DISPLAY="" to winetricks_early_wine() function
The DISPLAY env variable was incorrectly commented as
not useable - in this context.
However this wine wrapper function is only used for early
wine cli / non-gui command calls. The env variable won't
persist to affect subsquent calls, to wine, from winetricks
verbs.

Makefile updated.
Installs the winetricks.bashcomp BASH completion script
in the standard Linux distribution directory
for completion helper scripts.