### PR TITLE
DXVK fixes

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -6627,7 +6627,7 @@ load_dxvk()
         w_try mv "$W_TMP/$_W_dxvk_dir/x64/d3d11.dll" "$W_SYSTEM64_DLLS/"
         w_try mv "$W_TMP/$_W_dxvk_dir/x64/dxgi.dll" "$W_SYSTEM64_DLLS/"
     fi
-    w_override_dlls native d3d11.dll dxgi.dll
+    w_override_dlls native d3d11 dxgi
 }
 
 #----------------------------------------------------------------

--- a/src/winetricks
+++ b/src/winetricks
@@ -6628,6 +6628,8 @@ load_dxvk()
         w_try mv "$W_TMP/$_W_dxvk_dir/x64/dxgi.dll" "$W_SYSTEM64_DLLS/"
     fi
     w_override_dlls native d3d11 dxgi
+
+    unset _W_dxvk_dir
 }
 
 #----------------------------------------------------------------


### PR DESCRIPTION
This PR fixes the following:

* `w_override_dlls native d3d11.dll dxgi.dll` doesn't work because it contains `.dll`
* `_W_dxvk_dir` is not unset