### PR TITLE
Swap Tahoma version v2.26 for v2.60

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -11211,16 +11211,15 @@ load_opensymbol()
 w_metadata tahoma fonts \
     title="MS Tahoma font (not part of corefonts)" \
     publisher="Microsoft" \
-    year="2007" \
+    year="1999" \
     media="download" \
-    file1="tahoma32.exe" \
+    file1="IELPKTH.CAB" \
     installed_file1="$W_FONTSDIR_WIN/tahoma.ttf"
 
 load_tahoma()
 {
-    # Formerly at https://download.microsoft.com/download/office97pro/fonts/1/w95/en-us/tahoma32.exe
-    # Mirror list: http://www.filewatcher.com/_/?q=tahoma32.exe
-    w_download https://www.encodage-video.com/devprog/win/tahoma32.exe 57496fb91d1629d2b6f313aaa6ebcdbcfd09c269b6462fe490420c786c089a40
+    # Formerly at http://download.microsoft.com:80/download/ie55sp2/Install/5.5_SP2/WIN98Me/EN-US/IELPKTH.CAB
+    w_download http://downloads.sourceforge.net/corefonts/OldFiles/IELPKTH.CAB c1be3fb8f0042570be76ec6daa03a99142c88367c1bc810240b85827c715961a
 
     w_try_cabextract -d "$W_TMP" "$W_CACHE/$W_PACKAGE/$file1"
     w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "*.TTF"


### PR DESCRIPTION
Put simply the core fonts project have had the IELPKTH.CAB file laying around on their sourceforge account for ages, most Linux users when needing Tahoma probably find it (or a similar copy of IELPKTH.CAB) there first.

I have no rationale for wanting version 2.60 over 2.26 other than to say that if we were not interested in newer versioned fonts, then why does verb 'eufonts' exist when that's all that does?

Looking through FontForge the only thing I can see different between these versions is 10 more symbols... however both of them already have the euro symbol (so if that is the reason for the 'eufonts' verb to exist is for adding the euro symbol, that reason isn't applicable here).

Also it's worth noting that although the file currently being downloaded is called "tahoma32.exe" which looks similarly named to the other  with something32.exe named files from the 'Core fonts for the Web' effort... that naming is coincidental.  Tahoma is not a part of the 'Core fonts for the Web'.