### PR TITLE
Native font names replacements related improvements

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -11746,6 +11746,16 @@ load_fakechinese()
     w_register_font_replacement "NSimSun" "WenQuanYi Micro Hei"
     w_register_font_replacement "SimKai" "WenQuanYi Micro Hei"
     w_register_font_replacement "SimSun" "WenQuanYi Micro Hei"
+    w_register_font_replacement "宋体" "WenQuanYi Micro Hei"
+    w_register_font_replacement "新宋体" "WenQuanYi Micro Hei"
+    w_register_font_replacement "黑体" "WenQuanYi Micro Hei"
+    w_register_font_replacement "微软雅黑" "WenQuanYi Micro Hei"
+    w_register_font_replacement "仿宋" "WenQuanYi Micro Hei"
+    w_register_font_replacement "楷体" "WenQuanYi Micro Hei"
+    w_register_font_replacement "細明體" "WenQuanYi Micro Hei"
+    w_register_font_replacement "新細明體" "WenQuanYi Micro Hei"
+    w_register_font_replacement "微軟正黑體" "WenQuanYi Micro Hei"
+    w_register_font_replacement "標楷體" "WenQuanYi Micro Hei"
 }
 
 #----------------------------------------------------------------

--- a/src/winetricks
+++ b/src/winetricks
@@ -11852,19 +11852,28 @@ load_fakekorean()
     w_call baekmuk
     # Loads Baekmuk fonts and sets as an alias for Gulim, Dotum, and Batang for Korean language support
     # Aliases to set:
-    # Gulim --> Baekmuk Gulim
-    # GulimChe --> Baekmuk Gulim
-    # Batang --> Baekmuk Batang
-    # BatangChe --> Baekmuk Batang
-    # Dotum --> Baekmuk Dotum
-    # DotumChe --> Baekmuk Dotum
+    # Malgun Gothic (맑은 고딕) --> Baekmuk Gulim
+    # Gulim (굴림) --> Baekmuk Gulim
+    # GulimChe (굴림체) --> Baekmuk Gulim
+    # Batang (바탕) --> Baekmuk Batang
+    # BatangChe (바탕체) --> Baekmuk Batang
+    # Dotum (돋움) --> Baekmuk Dotum
+    # DotumChe (돋움체) --> Baekmuk Dotum
 
+    w_register_font_replacement "Malgun Gothic" "Baekmuk Gulim"
     w_register_font_replacement "Gulim" "Baekmuk Gulim"
     w_register_font_replacement "GulimChe" "Baekmuk Gulim"
     w_register_font_replacement "Batang" "Baekmuk Batang"
     w_register_font_replacement "BatangChe" "Baekmuk Batang"
     w_register_font_replacement "Dotum" "Baekmuk Dotum"
     w_register_font_replacement "DotumChe" "Baekmuk Dotum"
+    w_register_font_replacement "맑은 고딕" "Baekmuk Gulim"
+    w_register_font_replacement "굴림" "Baekmuk Gulim"
+    w_register_font_replacement "굴림체" "Baekmuk Gulim"
+    w_register_font_replacement "바탕" "Baekmuk Batang"
+    w_register_font_replacement "바탕체" "Baekmuk Batang"
+    w_register_font_replacement "돋움" "Baekmuk Dotum"
+    w_register_font_replacement "돋움체" "Baekmuk Dotum"
 }
 
 #----------------------------------------------------------------

--- a/src/winetricks
+++ b/src/winetricks
@@ -2951,13 +2951,16 @@ _EOF_
     unset W_file W_font
 }
 
+# Note: we use UTF-16 (little endian) in .reg file for native (non-English) font names.
 w_register_font_replacement()
 {
     _W_alias=$1
     shift
     _W_font=$1
+    # UTF-16 BOM (U+FEFF, "0xEF 0xBB 0xBF" in UTF-8)
+    printf "\357\273\277" | iconv -f UTF-8 -t UTF-16LE > "$W_TMP"/_register-font-replacements.reg
     # Kludge: use _r to avoid \r expansion in w_try
-    cat > "$W_TMP"/_register-font-replacements.reg <<_EOF_
+    iconv -f UTF-8 -t UTF-16LE >> "$W_TMP"/_register-font-replacements.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\Fonts\\Replacements]
@@ -11789,20 +11792,15 @@ load_fakejapanese_ipamona()
     # MS Mincho (ＭＳ 明朝) --> IPAMonaMincho
     # MS PMincho (ＭＳ Ｐ明朝) --> IPAMonaPMincho
 
-    jpname_msgothic="$(echo "ＭＳ ゴシック" | iconv -f utf8 -t cp932)"
-    jpname_mspgothic="$(echo "ＭＳ Ｐゴシック" | iconv -f utf8 -t cp932)"
-    jpname_msmincho="$(echo "ＭＳ 明朝" | iconv -f utf8 -t cp932)"
-    jpname_mspmincho="$(echo "ＭＳ Ｐ明朝" | iconv -f utf8 -t cp932)"
-
     w_register_font_replacement "MS UI Gothic" "IPAMonaUIGothic"
     w_register_font_replacement "MS Gothic" "IPAMonaGothic"
     w_register_font_replacement "MS PGothic" "IPAMonaPGothic"
     w_register_font_replacement "MS Mincho" "IPAMonaMincho"
     w_register_font_replacement "MS PMincho" "IPAMonaPMincho"
-    w_register_font_replacement "$jpname_msgothic" "IPAMonaGothic"
-    w_register_font_replacement "$jpname_mspgothic" "IPAMonaPGothic"
-    w_register_font_replacement "$jpname_msmincho" "IPAMonaMincho"
-    w_register_font_replacement "$jpname_mspmincho" "IPAMonaPMincho"
+    w_register_font_replacement "ＭＳ ゴシック" "IPAMonaGothic"
+    w_register_font_replacement "ＭＳ Ｐゴシック" "IPAMonaPGothic"
+    w_register_font_replacement "ＭＳ 明朝" "IPAMonaMincho"
+    w_register_font_replacement "ＭＳ Ｐ明朝" "IPAMonaPMincho"
 }
 
 #----------------------------------------------------------------
@@ -11821,11 +11819,9 @@ load_fakejapanese_vlgothic()
     # Meiryo UI --> VL Gothic
     # Meiryo (メイリオ) --> VL Gothic
 
-    jpname_meiryo="$(echo "メイリオ" | iconv -f utf8 -t cp932)"
-
     w_register_font_replacement "Meiryo UI" "VL Gothic"
     w_register_font_replacement "Meiryo" "VL Gothic"
-    w_register_font_replacement "$jpname_meiryo" "VL Gothic"
+    w_register_font_replacement "メイリオ" "VL Gothic"
 }
 
 #----------------------------------------------------------------

--- a/src/winetricks
+++ b/src/winetricks
@@ -11758,13 +11758,15 @@ w_metadata fakejapanese fonts \
 load_fakejapanese()
 {
     w_call takao
-    # Loads Takao fonts and sets aliases for MS Gothic, MS UI Gothic, and MS PGothic, mainly for Japanese language support
+    # Loads Takao fonts and sets aliases for MS UI Gothic, MS Gothic,
+    # MS PGothic, MS Mincho, and MS PMincho, mainly for Japanese language support
+
     # Aliases to set:
-    # MS Gothic --> TakaoGothic
     # MS UI Gothic --> TakaoGothic
-    # MS PGothic --> TakaoPGothic
-    # MS Mincho --> TakaoMincho
-    # MS PMincho --> TakaoPMincho
+    # MS Gothic (ＭＳ ゴシック) --> TakaoGothic
+    # MS PGothic (ＭＳ Ｐゴシック) --> TakaoPGothic
+    # MS Mincho (ＭＳ 明朝) --> TakaoMincho
+    # MS PMincho (ＭＳ Ｐ明朝) --> TakaoPMincho
     # These aliases were taken from what was listed in Ubuntu's fontconfig definitions.
 
     w_register_font_replacement "MS Gothic" "TakaoGothic"
@@ -11772,6 +11774,10 @@ load_fakejapanese()
     w_register_font_replacement "MS PGothic" "TakaoPGothic"
     w_register_font_replacement "MS Mincho" "TakaoMincho"
     w_register_font_replacement "MS PMincho" "TakaoPMincho"
+    w_register_font_replacement "ＭＳ ゴシック" "TakaoGothic"
+    w_register_font_replacement "ＭＳ Ｐゴシック" "TakaoPGothic"
+    w_register_font_replacement "ＭＳ 明朝" "TakaoMincho"
+    w_register_font_replacement "ＭＳ Ｐ明朝" "TakaoPMincho"
 }
 
 #----------------------------------------------------------------


### PR DESCRIPTION
Fixes #781 and potential problems in `fakejapanese*` verbs.

* ~~Set proper locale when running `regedit` (`w_register_font_replacement`)~~
* ~~Change existing variable names in `fakejapanese*`~~
* ~~Unset local variables in `fakejapanese*`~~
* Support native (non-English) font names in `w_register_font_replacement()` and pass native font names in `fakejapanese*`
* Add native font name replacements in `fakejapanese`
* Add Chinese and Korean native font name replacements