### PR TITLE
Improve graphical wineprefix management and bugfixes

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -3328,6 +3328,7 @@ winetricks_prefixmenu()
              _W_msg_games='Установить игру'
              _W_msg_benchmarks='Установить приложение для оценки производительности'
              _W_msg_default="Выберите путь для wine по умолчанию"
+             _W_msg_mkprefix="Создать новый путь wine"
              _W_msg_unattended0="Отключить автоматическую установку"
              _W_msg_unattended1="Включить автоматическую установку"
              _W_msg_showbroken0="Спрятать нерабочие программы (например, использующие DRM)"
@@ -3340,6 +3341,7 @@ winetricks_prefixmenu()
              _W_msg_games='Встановити гру'
              _W_msg_benchmarks='Встановити benchmark'
              _W_msg_default="Вибрати wineprefix за замовчуванням"
+             _W_msg_mkprefix="створити новий wineprefix"
              _W_msg_unattended0="Вимкнути автоматичне встановлення"
              _W_msg_unattended1="Увімкнути автоматичне встановлення"
              _W_msg_showbroken0="Сховати нестабільні додатки (наприклад з проблемами з DRM)"
@@ -3352,6 +3354,7 @@ winetricks_prefixmenu()
              _W_msg_games='安装一个游戏'
              _W_msg_benchmarks='安装一个基准测试软件'
              _W_msg_default="选择默认的 wine 容器"
+             _W_msg_mkprefix="创建新的 wine 容器"
              _W_msg_unattended0="禁用静默安装"
              _W_msg_unattended1="启用静默安装"
              _W_msg_showbroken0="隐藏有问题的程序 (例如那些有数字版权问题)"
@@ -3364,6 +3367,7 @@ winetricks_prefixmenu()
              _W_msg_games='安裝一個遊戲'
              _W_msg_benchmarks='安裝一個基准測試軟體'
              _W_msg_default="選取預設的 wine 容器"
+             _W_msg_mkprefix="创建新的 wine 容器"
              _W_msg_unattended0="禁用靜默安裝"
              _W_msg_unattended1="啟用靜默安裝"
              _W_msg_showbroken0="隱藏有問題的程式 (例如那些有數字版權問題)"
@@ -3376,6 +3380,7 @@ winetricks_prefixmenu()
              _W_msg_games='Ein Spiel installieren'
              _W_msg_benchmarks='Einen Benchmark-Test installieren'
              _W_msg_default="Standard wineprefix auswählen"
+             _W_msg_mkprefix="Neuen wineprefix erstellen"
              _W_msg_unattended0="Automatische Installation deaktivieren"
              _W_msg_unattended1="Automatische Installation aktivieren"
              _W_msg_showbroken0="Defekte Programme nicht anzeigen (z.B. solche mit DRM Problemen)"
@@ -3388,6 +3393,7 @@ winetricks_prefixmenu()
              _W_msg_games='Zainstalować grę'
              _W_msg_benchmarks='Zainstalować program sprawdzający wydajność komputera'
              _W_msg_default="Wybrać domyślny prefiks Wine"
+             _W_msg_mkprefix="Stwórz nowy prefiks Wine"
              _W_msg_unattended0="Wyłącz cichą instalację"
              _W_msg_unattended1="Włącz cichą instalację"
              _W_msg_showbroken0="Ukrywaj uszkodzone aplikacje (np. z problemami z DRM)"
@@ -3400,6 +3406,7 @@ winetricks_prefixmenu()
              _W_msg_games='Install a game'
              _W_msg_benchmarks='Install a benchmark'
              _W_msg_default="Select the default wineprefix"
+             _W_msg_mkprefix="Create new wineprefix"
              _W_msg_unattended0="Disable silent install"
              _W_msg_unattended1="Enable silent install"
              _W_msg_showbroken0="Hide broken apps (e.g. those with DRM problems)"
@@ -3434,6 +3441,7 @@ winetricks_prefixmenu()
                 FALSE benchmarks '$_W_msg_benchmarks' \
                 FALSE games      '$_W_msg_games' \
                 TRUE  main       '$_W_msg_default' \
+                FALSE mkprefix   '$_W_msg_mkprefix' \
                 " \
                 > "$WINETRICKS_WORKDIR"/zenity.sh
 
@@ -3474,6 +3482,7 @@ winetricks_prefixmenu()
                 benchmarks '$_W_msg_benchmarks' off \
                 apps       '$_W_msg_apps'       off \
                 main       '$_W_msg_default'    on  \
+                mkprefix   '$_W_msg_mkprefix'   off \
                 "
             if ls -d "$W_PREFIXES_ROOT"/*/dosdevices > /dev/null 2>&1; then
                 for prefix in "$W_PREFIXES_ROOT"/*/dosdevices
@@ -3495,6 +3504,41 @@ winetricks_prefixmenu()
             ;;
     esac
     unset _W_msg_help _W_msg_body _W_msg_title _W_msg_new _W_msg_default _W_msg_name
+}
+
+# Graphically create new custom wineprefix.
+# This returns two verbs: arch and prefix, e.g. "arch=32 prefix=test".
+winetricks_mkprefixmenu()
+{
+    case $LANG in
+        # TODO: translate to other languages
+        de)  _W_msg_title="Winetricks - Neues Wineprefix erstellen"
+             _W_msg_name="Name"
+             _W_msg_arch="Architektur"
+             ;;
+        *)   _W_msg_title="Winetricks - create new wineprefix"
+             _W_msg_name="Name"
+             _W_msg_arch="Architecture"
+             ;;
+    esac
+
+    case $WINETRICKS_GUI in
+        zenity)
+            zenity --forms --text="" --title "$_W_msg_title" \
+                --add-combo="$_W_msg_arch" --combo-values=32\|64 \
+                --add-entry="$_W_msg_name" \
+                | sed -e 's/^\s*|/64|/' -e 's/^/arch=/' -e 's/|/ prefix=/'
+            ;;
+        kdialog)
+            kdialog --title="$_W_msg_title" \
+                --radiolist="$_W_msg_arch" 32 32bit off 64 64bit on \
+                | sed -e 's/^$/64/' -e 's/^/arch=/'
+            kdialog --title="$_W_msg_title" --inputbox="$_W_msg_name" \
+                | sed -e 's/^/prefix=/'
+            ;;
+    esac
+
+    unset _W_msg_title _W_msg_name _W_msg_arch
 }
 
 # Display main menu, get which submenu the user wants
@@ -4248,7 +4292,7 @@ winetricks_list_all()
 {
     # Note: doh123 relies on 'winetricks list' to list main menu categories
     case $WINETRICKS_CURMENU in
-        prefix|main) echo "$WINETRICKS_CATEGORIES" | tr ' ' '\012' ; return;;
+        prefix|main|mkprefix) echo "$WINETRICKS_CATEGORIES" | sed 's/ mkprefix//' | tr ' ' '\012' ; return;;
     esac
 
     case $LANG in
@@ -5101,7 +5145,7 @@ winetricks_init()
     WINETRICKS_METADATA="$WINETRICKS_WORKDIR/metadata"
 
     # The list of categories is also hardcoded in winetricks_mainmenu() :-(
-    WINETRICKS_CATEGORIES="apps benchmarks dlls fonts games settings"
+    WINETRICKS_CATEGORIES="apps benchmarks dlls fonts games settings mkprefix"
     for _W_cat in $WINETRICKS_CATEGORIES
     do
         mkdir -p "$WINETRICKS_METADATA/$_W_cat"
@@ -20700,6 +20744,7 @@ then
                             unattended) winetricks_set_unattended 1 ; continue;;
                         esac
                         ;;
+                    mkprefix) verbs=$(winetricks_mkprefixmenu) ;;
                     settings) verbs=$(winetricks_settings_menu) ;;
                     *) verbs="$(winetricks_showmenu)" ;;
                 esac
@@ -20717,10 +20762,16 @@ then
                     winetricks_stats_init
                     # Otherwise user picked one or more real verbs.
                     case "$verbs" in
-                        prefix=*)
+                        prefix=*|arch=*)
                             # prefix menu is special, it only returns one verb, and the
-                            # verb can contain spaces
-                            execute_command "$verbs"
+                            # verb can contain spaces. If a 32bit wineprefix is created via
+                            # the GUI, this may have an "arch=* " prefix
+                            _W_arch=$(echo "$verbs" | grep -o 'arch=.*' | cut -d' ' -f1)
+                            _W_prefix=$(echo "$verbs" | grep -o 'prefix=.*')
+                            if [ -n "$_W_arch" ]; then
+                                execute_command "$_W_arch"
+                            fi
+                            execute_command "$_W_prefix"
                             # after picking a prefix, want to land in main.
                             WINETRICKS_CURMENU=main ;;
                         *)

--- a/src/winetricks
+++ b/src/winetricks
@@ -4872,6 +4872,20 @@ winetricks_print_wineprefix_info()
     done
 }
 
+# Force creation of 32 or 64bit wineprefix on 64 bit systems.
+# On 32bit systems, trying to create a 64bit wineprefix will fail.
+# This must be called prior to winetricks_set_wineprefix()
+winetricks_set_winearch()
+{
+    if [ "$1" = "32" ] || [ "$1" = "win32" ]; then
+        export WINEARCH=win32
+    elif [ "$1" = "64" ] || [ "$1" = "win64" ]; then
+        export WINEARCH=win64
+    else
+        w_die "arch: Invalid architecture: $1"
+    fi
+}
+
 # Usage: winetricks_set_wineprefix [bottlename]
 # Bottlename must not contain spaces, slashes, or other special characters
 # If bottlename is omitted, the default bottle (~/.wine) is used.
@@ -5024,6 +5038,11 @@ winetricks_set_wineprefix()
         WINE_ARCH="${WINE}"
         WINE_MULTI="${WINE}"
     fi
+
+    # Unset WINEARCH which might be set from winetricks_set_winearch().
+    # It is no longer necessary after the new wineprefix was created
+    # and even may cause trouble when using 64bit wineprefixes afterwards.
+    unset WINEARCH
 }
 
 winetricks_annihilate_wineprefix()
@@ -5319,6 +5338,9 @@ list-cached           Verben für bereits gecachte Installers auflisten
 list-download         Verben für automatisch herunterladbare Anwendungen auflisten
 list-manual-download  Verben für vom Benutzer herunterladbare Anwendungen auflisten
 list-installed        Bereits installierte Verben auflisten
+arch=32|64            Neues wineprefix mit 32 oder 64 bit erstellen, diese Option
+                      muss vor prefix=foobar angegeben werden und funktioniert
+                      nicht im Falle des Standard Wineprefix.
 prefix=foobar         WINEPREFIX=$W_PREFIXES_ROOT/foobar auswählen
 annihilate            ALLE DATEIEN UND PROGRAMME IN DIESEM WINEPREFIX Löschen
 _EOF_
@@ -5358,6 +5380,9 @@ list-cached           list cached-and-ready-to-install verbs
 list-download         list verbs which download automatically
 list-manual-download  list verbs which download with some help from the user
 list-installed        list already-installed verbs
+arch=32|64            create wineprefix with 32 or 64 bit, this option must be
+                      given before prefix=foobar and will not work in case of
+                      the default wineprefix.
 prefix=foobar         select WINEPREFIX=$W_PREFIXES_ROOT/foobar
 annihilate            Delete ALL DATA AND APPLICATIONS INSIDE THIS WINEPREFIX
 _EOF_
@@ -20556,6 +20581,7 @@ execute_command()
         attended) winetricks_set_unattended 0 ;;
         showbroken) W_OPT_SHOWBROKEN=1 ;;
         hidebroken) W_OPT_SHOWBROKEN=0 ;;
+        arch=*) winetricks_set_winearch "$arg" ;;
         prefix=*) winetricks_set_wineprefix "$arg" ;;
         annihilate) winetricks_annihilate_wineprefix ;;
         folder) w_open_folder "$WINEPREFIX" ;;

--- a/src/winetricks
+++ b/src/winetricks
@@ -3473,7 +3473,8 @@ winetricks_prefixmenu()
                 games      '$_W_msg_games'      off \
                 benchmarks '$_W_msg_benchmarks' off \
                 apps       '$_W_msg_apps'       off \
-                main       '$_W_msg_default'    on "
+                main       '$_W_msg_default'    on  \
+                "
             if ls -d "$W_PREFIXES_ROOT"/*/dosdevices > /dev/null 2>&1; then
                 for prefix in "$W_PREFIXES_ROOT"/*/dosdevices
                 do
@@ -3487,6 +3488,8 @@ winetricks_prefixmenu()
                     printf %s "prefix='$p' 'Select $_W_msg_name' off "
                 done
             fi
+            printf %s " $_W_cmd_unattended '$_W_msg_unattended' off"
+            printf %s " $_W_cmd_showbroken '$_W_msg_showbroken' off"
             ) > "$WINETRICKS_WORKDIR"/kdialog.sh
             sh "$WINETRICKS_WORKDIR"/kdialog.sh
             ;;

--- a/src/winetricks
+++ b/src/winetricks
@@ -3501,7 +3501,7 @@ winetricks_prefixmenu()
 winetricks_mainmenu()
 {
     case $LANG in
-        da*) _W_msg_title='Vælg en pakke-kategori'
+        da*) _W_msg_title="Vælg en pakke-kategori - Nuværende præfiks er \"$WINEPREFIX\""
              _W_msg_body='Hvad ønsker du at gøre?'
              _W_msg_dlls="Install a Windows DLL"
              _W_msg_fonts='Install a font'
@@ -3514,7 +3514,7 @@ winetricks_mainmenu()
              _W_msg_folder='Browse files'
              _W_msg_annihilate="Delete ALL DATA AND APPLICATIONS INSIDE THIS WINEPREFIX"
              ;;
-        de*) _W_msg_title='Pakettyp auswählen'
+        de*) _W_msg_title="Pakettyp auswählen - Aktueller Präfix ist \"$WINEPREFIX\""
              _W_msg_body='Was möchten Sie tun?'
              _W_msg_dlls="Windows-DLL installieren"
              _W_msg_fonts='Schriftart installieren'
@@ -3664,10 +3664,10 @@ winetricks_settings_menu()
 {
     # FIXME: these translations should really be centralized/reused:
     case $LANG in
-        da*) _W_msg_title='Vælg en pakke'
+        da*) _W_msg_title="Vælg en pakke - Nuværende præfiks er \"$WINEPREFIX\""
              _W_msg_body='Which settings would you like to change?'
              ;;
-        de*) _W_msg_title="Winetricks - Aktueller Prefix ist \"$WINEPREFIX\""
+        de*) _W_msg_title="Winetricks - Aktueller Präfix ist \"$WINEPREFIX\""
              _W_msg_body='Welche Einstellungen möchten Sie ändern?'
              ;;
         pl*) _W_msg_title="Winetricks - obecny prefiks to \"$WINEPREFIX\""

--- a/src/winetricks
+++ b/src/winetricks
@@ -3509,6 +3509,7 @@ winetricks_mainmenu()
              _W_msg_winecfg='Run winecfg'
              _W_msg_regedit='Run regedit'
              _W_msg_taskmgr='Run taskmgr'
+             _W_msg_explorer='Run explorer'
              _W_msg_uninstaller='Run uninstaller'
              _W_msg_shell='Run a commandline shell (for debugging)'
              _W_msg_folder='Browse files'
@@ -3522,6 +3523,7 @@ winetricks_mainmenu()
              _W_msg_winecfg='winecfg starten'
              _W_msg_regedit='regedit starten'
              _W_msg_taskmgr='taskmgr starten'
+             _W_msg_explorer='explorer starten'
              _W_msg_uninstaller='uninstaller starten'
              _W_msg_shell='Eine Kommandozeile zum debuggen starten'
              _W_msg_folder='Ordner durchsuchen'
@@ -3535,6 +3537,7 @@ winetricks_mainmenu()
              _W_msg_winecfg='Uruchomić winecfg'
              _W_msg_regedit='Uruchomić edytor rejestru'
              _W_msg_taskmgr='Uruchomić menedżer zadań'
+             _W_msg_explorer='Uruchomić explorer'
              _W_msg_uninstaller='Uruchomić program odinstalowujący'
              _W_msg_shell='Uruchomić powłokę wiersza poleceń (dla debugowania)'
              _W_msg_folder='Przeglądać pliki'
@@ -3548,6 +3551,7 @@ winetricks_mainmenu()
              _W_msg_winecfg='Запустить winecfg (редактор настроек wine)'
              _W_msg_regedit='Запустить regedit (редактор реестра)'
              _W_msg_taskmgr='Запустить taskmgr (менеджер задач)'
+             _W_msg_explorer='Запустить explorer'
              _W_msg_uninstaller='Запустить uninstaller (деинсталлятор)'
              _W_msg_shell='Запустить графический терминал (для отладки)'
              _W_msg_folder='Проводник файлов'
@@ -3561,6 +3565,7 @@ winetricks_mainmenu()
              _W_msg_winecfg='Запустити winecfg'
              _W_msg_regedit='Запустити regedit'
              _W_msg_taskmgr='Запустити taskmgr'
+             _W_msg_explorer='Запустити explorer'
              _W_msg_uninstaller='Встановлення/видалення програм'
              _W_msg_shell='Запуск командної оболонки (для налагодження)'
              _W_msg_folder='Перегляд файлів'
@@ -3574,6 +3579,7 @@ winetricks_mainmenu()
              _W_msg_winecfg='运行 winecfg'
              _W_msg_regedit='运行注册表'
              _W_msg_taskmgr='运行任务管理器'
+             _W_msg_explorer='运行资源管理器'
              _W_msg_uninstaller='运行卸载程序'
              _W_msg_shell='运行命令提示窗口 (作为调试)'
              _W_msg_folder='浏览容器中的文件'
@@ -3587,6 +3593,7 @@ winetricks_mainmenu()
              _W_msg_winecfg='執行 winecfg'
              _W_msg_regedit='執行註冊表'
              _W_msg_taskmgr='執行工作管理者'
+             _W_msg_explorer='執行資源經理'
              _W_msg_uninstaller='執行反安裝程式'
              _W_msg_shell='執行指令輔助說明視窗 (作為除錯)'
              _W_msg_folder='瀏覽容器中的檔案'
@@ -3600,6 +3607,7 @@ winetricks_mainmenu()
              _W_msg_winecfg='Run winecfg'
              _W_msg_regedit='Run regedit'
              _W_msg_taskmgr='Run taskmgr'
+             _W_msg_explorer='Run explorer'
              _W_msg_uninstaller='Run uninstaller'
              _W_msg_shell='Run a commandline shell (for debugging)'
              _W_msg_folder='Browse files'
@@ -3627,6 +3635,7 @@ winetricks_mainmenu()
                     FALSE winecfg     '$_W_msg_winecfg' \
                     FALSE regedit     '$_W_msg_regedit' \
                     FALSE taskmgr     '$_W_msg_taskmgr' \
+                    FALSE explorer    '$_W_msg_explorer' \
                     FALSE uninstaller '$_W_msg_uninstaller' \
                     FALSE shell       '$_W_msg_shell' \
                     FALSE folder      '$_W_msg_folder' \
@@ -3649,6 +3658,7 @@ winetricks_mainmenu()
                     winecfg     "$_W_msg_winecfg" off \
                     regedit     "$_W_msg_regedit" off \
                     taskmgr     "$_W_msg_taskmgr" off \
+                    explorer    "$_W_msg_explorer" off \
                     uninstaller "$_W_msg_uninstaller" off \
                     shell       "$_W_msg_shell" off \
                     folder      "$_W_msg_folder" off \
@@ -20552,6 +20562,7 @@ execute_command()
         winecfg) "$WINE" winecfg ;;
         regedit) "$WINE" regedit ;;
         taskmgr) "$WINE" taskmgr & ;;
+        explorer) "$WINE" explorer & ;;
         uninstaller) "$WINE" uninstaller ;;
         shell) winetricks_shell ;;
 


### PR DESCRIPTION
This pull request allows to graphically manage wineprefixes and graphically install/run custom applications which should be very helpful for new users who don't like to use the terminal.

This is realized by:
* Adding "Create new wineprefix" menu item in prefix-menu which shows a new dialog for naming the wineprefix and select its architecture (32|64 bit).
* Adding "run explorer" menu item to main-menu so that you can install/run any application graphically by double-click within the selected wineprefix.
* Adding the new verb "arch=32" which creates a new 32bit wineprefix on 64bit systems.

Bugfixes:
* Wineprefixes from "~/.local/share/wineprefixes" are missing in prefix-menu when using kdialog.
* "Show/Hide broken apps" and "Enable/diable silent install" is missing in prefix-menu when using kdialog.
* Fixed a typo in "de" translation.
* Fixed missing wineprefix path in "da" translation