### PR TITLE
Fix project_license in appdata.xml.

### DIFF
--- a/src/winetricks.appdata.xml
+++ b/src/winetricks.appdata.xml
@@ -2,7 +2,7 @@
 <!-- Copyright 2017 Daniel Rusek <mail@asciiwolf.com> -->
 <component type="desktop">
   <id>winetricks.desktop</id>
-  <project_license>GPL-2.1</project_license>
+  <project_license>LGPL-2.1+</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <name>Winetricks</name>
   <summary>Work around problems and install applications under Wine</summary>


### PR DESCRIPTION
The license of the Winetricks project is LGPL-2.1+, not GPL-2.1.