### PR TITLE
Gallium Nine bits

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -8708,6 +8708,24 @@ load_galliumnine02()
     helper_galliumnine "$file1"
 }
 
+w_metadata galliumnine dlls \
+    title="Gallium Nine Standalone (latest)" \
+    publisher="Gallium Nine Team" \
+    year="2019" \
+    media="download" \
+    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9-nine.dll" \
+    installed_file2="$W_SYSTEM32_DLLS_WIN/ninewinecfg.exe" \
+    homepage="https://github.com/iXit/wine-nine-standalone"
+
+load_galliumnine()
+{
+    w_download_to "${W_TMP_EARLY}" "https://api.github.com/repos/iXit/wine-nine-standalone/releases/latest" "" "release.json"
+    _W_galliumnine_version="$(grep -w tag_name ${W_TMP_EARLY}/release.json | cut -d '"' -f 4)"
+    w_linkcheck_ignore=1 w_download "https://github.com/iXit/wine-nine-standalone/releases/download/${_W_galliumnine_version}/gallium-nine-standalone-${_W_galliumnine_version}.tar.gz"
+    helper_galliumnine "gallium-nine-standalone-${_W_galliumnine_version}.tar.gz"
+    unset _W_galliumnine_version
+}
+
 #----------------------------------------------------------------
 
 w_metadata gdiplus dlls \

--- a/src/winetricks
+++ b/src/winetricks
@@ -7250,7 +7250,7 @@ load_dxvk()
     # There's no stable exe URL, but they do provide a RELEASE file that lets us build one:
     w_download_to "${W_TMP_EARLY}" "https://raw.githubusercontent.com/doitsujin/dxvk/master/RELEASE"
     dxvk_version="$(cat "${W_TMP_EARLY}/RELEASE")"
-    w_linkcheck=1_ignore w_download "https://github.com/doitsujin/dxvk/releases/download/v${dxvk_version}/dxvk-${dxvk_version}.tar.gz"
+    w_linkcheck_ignore=1 w_download "https://github.com/doitsujin/dxvk/releases/download/v${dxvk_version}/dxvk-${dxvk_version}.tar.gz"
     helper_dxvk "dxvk-${dxvk_version}.tar.gz" "d3d10_enabled" "3.19" "1.1.88"
     unset dxvk_version
 }

--- a/src/winetricks
+++ b/src/winetricks
@@ -8708,6 +8708,22 @@ load_galliumnine02()
     helper_galliumnine "$file1"
 }
 
+w_metadata galliumnine03 dlls \
+    title="Gallium Nine Standalone (v0.3)" \
+    publisher="Gallium Nine Team" \
+    year="2019" \
+    media="download" \
+    file1="gallium-nine-standalone-v0.3.tar.gz" \
+    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9-nine.dll" \
+    installed_file2="$W_SYSTEM32_DLLS_WIN/ninewinecfg.exe" \
+    homepage="https://github.com/iXit/wine-nine-standalone"
+
+load_galliumnine03()
+{
+    w_download "https://github.com/iXit/wine-nine-standalone/releases/download/v0.3/gallium-nine-standalone-v0.3.tar.gz" 8bb564073ab2198e5b9b870f7b8cac8d9bc20bc6accf66c4c798e4b450ec0c91
+    helper_galliumnine "$file1"
+}
+
 w_metadata galliumnine dlls \
     title="Gallium Nine Standalone (latest)" \
     publisher="Gallium Nine Team" \

--- a/src/winetricks
+++ b/src/winetricks
@@ -8670,6 +8670,28 @@ load_flash()
 
 #----------------------------------------------------------------
 
+# $1 - gallium nine standalone archive name (required)
+helper_galliumnine()
+{
+    _W_galliumnine_archive="${1}"
+    _W_galliumnine_tmp="$W_TMP/galliumnine"
+
+    w_try rm -rf "$_W_galliumnine_tmp"
+    w_try mkdir -p "$_W_galliumnine_tmp"
+    w_try tar -C "$_W_galliumnine_tmp" --strip-components=1 -zxf "$W_CACHE/$W_PACKAGE/$_W_galliumnine_archive"
+    w_try mv "$_W_galliumnine_tmp/lib32/d3d9-nine.dll.so" "$W_SYSTEM32_DLLS/d3d9-nine.dll"
+    w_try mv "$_W_galliumnine_tmp/bin32/ninewinecfg.exe.so" "$W_SYSTEM32_DLLS/ninewinecfg.exe"
+    if test "$W_ARCH" = "win64"; then
+        w_try mv "$_W_galliumnine_tmp/lib64/d3d9-nine.dll.so" "$W_SYSTEM64_DLLS/d3d9-nine.dll"
+        w_try mv "$_W_galliumnine_tmp/bin64/ninewinecfg.exe.so" "$W_SYSTEM64_DLLS/ninewinecfg.exe"
+    fi
+    w_try rm -rf "$_W_galliumnine_tmp"
+    # use ninewinecfg to enable gallium nine
+    WINEDEBUG=-all w_try "$WINE_MULTI" ninewinecfg -e
+
+    unset _W_galliumnine_tmp _W_galliumnine_archive
+}
+
 w_metadata galliumnine02 dlls \
     title="Gallium Nine Standalone (v0.2)" \
     publisher="Gallium Nine Team" \
@@ -8682,17 +8704,8 @@ w_metadata galliumnine02 dlls \
 
 load_galliumnine02()
 {
-    w_download "https://github.com/iXit/wine-nine-standalone/releases/download/v0.2/gallium-nine-standalone-v0.2.tar.gz"
-    w_try_cd "$W_TMP"
-    w_try tar -zxf "$W_CACHE/$W_PACKAGE/$file1"
-    w_try mv "$W_TMP/gallium-nine-standalone/lib32/d3d9-nine.dll.so" "$W_SYSTEM32_DLLS/d3d9-nine.dll"
-    w_try mv "$W_TMP/gallium-nine-standalone/bin32/ninewinecfg.exe.so" "$W_SYSTEM32_DLLS/ninewinecfg.exe"
-    if test "$W_ARCH" = "win64"; then
-        w_try mv "$W_TMP/gallium-nine-standalone/lib64/d3d9-nine.dll.so" "$W_SYSTEM64_DLLS/d3d9-nine.dll"
-        w_try mv "$W_TMP/gallium-nine-standalone/bin64/ninewinecfg.exe.so" "$W_SYSTEM64_DLLS/ninewinecfg.exe"
-    fi
-    # use ninewinecfg to enable gallium nine
-    WINEDEBUG=-all w_try "$WINE_MULTI" ninewinecfg -e
+    w_download "https://github.com/iXit/wine-nine-standalone/releases/download/v0.2/gallium-nine-standalone-v0.2.tar.gz" 6818fe890e343aa32d3d53179bfeb63df40977797bd7b6263e85e2bb57559313
+    helper_galliumnine "$file1"
 }
 
 #----------------------------------------------------------------


### PR DESCRIPTION
This splits the existing verb galliumnine02 into a helper and the verb using it, then adds a verb for the new v0.3, which is also using the helper (like dxvk).

Additionally, there's also a version independent verb added, which uses the github api to fetch the latest release. We get a json formatted response, which I currently 'parse' using `grep` and `cut`.

Thanks!