### PR TITLE
dxvk developer has reverted release dxvk release 1.1

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -7276,7 +7276,7 @@ load_dxvk()
     w_download_to "${W_TMP_EARLY}" "https://raw.githubusercontent.com/doitsujin/dxvk/latest-release/RELEASE"
     dxvk_version="$(cat "${W_TMP_EARLY}/RELEASE")"
     w_linkcheck_ignore=1 w_download "https://github.com/doitsujin/dxvk/releases/download/v${dxvk_version}/dxvk-${dxvk_version}.tar.gz"
-    helper_dxvk "dxvk-${dxvk_version}.tar.gz" "d3d10_enabled" "4.5" "1.1.88"
+    helper_dxvk "dxvk-${dxvk_version}.tar.gz" "d3d10_enabled" "3.19" "1.1.88"
     unset dxvk_version
 }
 

--- a/src/winetricks
+++ b/src/winetricks
@@ -7255,25 +7255,6 @@ load_dxvk102()
     helper_dxvk "$file1" "d3d10_enabled" "3.19" "1.1.88"
 }
 
-w_metadata dxvk110 dlls \
-    title="Vulkan-based D3D10/D3D11 implementation for Linux / Wine (1.1)" \
-    publisher="Philip Rebohle" \
-    year="2018" \
-    media="download" \
-    file1="dxvk-1.1.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
-
-load_dxvk110()
-{
-    # https://github.com/doitsujin/dxvk
-    w_download "https://github.com/doitsujin/dxvk/releases/download/v1.1/dxvk-1.1.tar.gz" cf1e6f848b14251bd7547af4a308646631d5899d278c24e919e6f082bbbaf671
-    helper_dxvk "$file1" "d3d10_enabled" "4.5" "1.1.88"
-}
-
 
 #----------------------------------------------------------------
 


### PR DESCRIPTION
**dxvk** release **1.1** had multiple issues (referenced on Discord) with Nvidia (??) graphics cards. 
As result **dxvk** release **1.1** has been reverted by Upstream.