### PR TITLE
Fixes MT4 platform installation

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -13635,18 +13635,20 @@ load_mt4()
     WINEDLLOVERRIDES="winebrowser.exe="
     export WINEDLLOVERRIDES
 
-    # No documented silent install option, unfortunately..
+    # No documented silent install option, unfortunately.
     w_try_cd "$W_CACHE/$W_PACKAGE"
     w_ahk_do "
         Run, ${file1}
-        WinWait, MetaTrader Setup, license agreement
+        SetTitleMatchMode, RegEx
+        WinWaitActive, 4 Setup
+        Sleep, 200
         ControlClick, Button1
-        Sleep 100
+        Sleep, 200
         ControlClick, Button3
-        WinWait, MetaTrader Setup, Installation successfully completed
-        ControlClick, Button4
-        Process, Wait, terminal.exe
-        Process, Close, terminal.exe
+        WinWaitClose ; Wait for installer to finish
+        Process, Wait, Terminal.exe
+        WinWaitActive, ahk_class #32770
+        Process, Close, Terminal.exe
     "
 }
 


### PR DESCRIPTION
The old version of AHK doesn't seems to install it correctly.

I've tested it in Docker, it seems to work fine. I can't test it on my local Ubuntu, as I've proxy popup instead.

The previous code was stuck at `WinWaitActive, Installation successfully completed`, it seems AHK didn't recognise this text when the installation finished.

I've tested and installer exists it-self after installation is completed, so there is no need to click the _Finish_ button. It exists automatically and it re-runs Terminal. So the code just waits 10 seconds for installer to complete. There is no point of closing terminal at the end, I've tried some code (which can be seen in the previous commits), but it was not perfect. So the current version is the simplest.

Attempt of closing terminal process always ended up in script hangs for me.

Here is the demo:
![MT4-winetricks-install mp4](https://user-images.githubusercontent.com/266306/57450097-760f1f80-7255-11e9-989b-9a2dd88d1165.gif)

