### PR TITLE
Use a helper to get github releases from github API

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -718,6 +718,26 @@ w_expand_env()
     winetricks_early_wine cmd.exe /c echo "%$1%"
 }
 
+# Get the latest tagged release from github.com API
+w_get_github_latest_release()
+{
+    # $1 - github organization
+    # $2 - github repository
+    # FIXME: can we get releases that aren't on master branch?
+
+    WINETRICKS_SUPER_QUIET=1 w_download_to "${W_TMP_EARLY}" "https://api.github.com/repos/$1/$2/releases/latest" "" "release.json" >/dev/null 2>&1
+
+    # aria2c condenses the json (https://github.com/aria2/aria2/issues/1389)
+    # but curl/wget don't, so handle both cases:
+    json_length="$(wc -l "${W_TMP_EARLY}/release.json")"
+    case "$json_length" in
+        0*) latest_version="$(sed -e "s/\",\"/|/g" "${W_TMP_EARLY}/release.json" | tr '|' '\n' | grep tag_name | sed 's@.*"@@')";;
+        *) latest_version="$(grep -w tag_name "${W_TMP_EARLY}/release.json" | cut -d '"' -f 4)";;
+    esac
+
+    echo "$latest_version"
+}
+
 # get sha1sum string and set $_W_gotsha1um to it
 w_get_sha1sum()
 {

--- a/src/winetricks
+++ b/src/winetricks
@@ -364,7 +364,10 @@ w_try()
     # This is a problem when trying to pass environment variables to e.g. wine.
     # Adding an explicit export here works around it, so add any we use.
     export WINEDLLOVERRIDES
-    printf '%s\n' "Executing $*"
+    # If $WINETRICKS_SUPER_QUIET is set, make w_try quiet
+    if [ -z "$WINETRICKS_SUPER_QUIET" ]; then
+        printf '%s\n' "Executing $*"
+    fi
 
     # On Vista, we need to jump through a few hoops to run commands in Cygwin.
     # First, .exe's need to have the executable bit set.

--- a/src/winetricks
+++ b/src/winetricks
@@ -8901,8 +8901,7 @@ w_metadata galliumnine dlls \
 
 load_galliumnine()
 {
-    w_download_to "${W_TMP_EARLY}" "https://api.github.com/repos/iXit/wine-nine-standalone/releases/latest" "" "release.json"
-    _W_galliumnine_version="$(grep -w tag_name ${W_TMP_EARLY}/release.json | cut -d '"' -f 4)"
+    _W_galliumnine_version="$(w_get_github_latest_release iXit wine-nine-standalone)"
     w_linkcheck_ignore=1 w_download "https://github.com/iXit/wine-nine-standalone/releases/download/${_W_galliumnine_version}/gallium-nine-standalone-${_W_galliumnine_version}.tar.gz"
     helper_galliumnine "gallium-nine-standalone-${_W_galliumnine_version}.tar.gz"
     unset _W_galliumnine_version

--- a/tests/shell-checks
+++ b/tests/shell-checks
@@ -96,5 +96,6 @@ for shellscript in $files_to_check; do
     # https://bugs.launchpad.net/bash8/+bug/1698088
     # E006=line length check
     # E010=do/while same line (in some embedded perl in winetricks)
-    w_try "$bashate" -i E006,E010 "${shellscript}"
+    # E044=Use [[ for non-POSIX comparisions
+    w_try "$bashate" -i E006,E010,E044 "${shellscript}"
 done


### PR DESCRIPTION
For #1207 et al

@bobwya I was thinking something like this to handle the aria2c issue. I'm not set on it, obviously my sed/tr stuff could be improved, but I think this approach is simpler than trying to have one regex to rule them all. It also avoids harcoding downloader names, so should be future-safe (and good for when other downloaders break it ;)).

This also lets us it for other verbs, i.e., dxvk/etc.

What do you think? @bobwya @dhewg 