### PR TITLE
docs: add xz-utils dependency

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -42,7 +42,7 @@ WINETRICKS_VERSION=20190310-next
 # On Ubuntu, the following lines can be used to install all the prerequisites:
 #    sudo add-apt-repository ppa:ubuntu-wine/ppa
 #    sudo apt-get update
-#    sudo apt-get install binutils cabextract p7zip-full unrar unzip wget wine zenity
+#    sudo apt-get install binutils cabextract p7zip-full unrar unzip wget wine xz-utils zenity
 # On Fedora, these commands can be used (RPM Fusion is used to install unrar):
 #    sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
 #    sudo dnf install binutils cabextract p7zip-plugins unrar unzip wget wine zenity


### PR DESCRIPTION
for tar -J. Perhaps Fedora needs a similar change, but I haven't tried.