### PR TITLE
dinput8, dsound: Don't try to register native DLLs.

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -6620,8 +6620,10 @@ load_dinput8()
 
     w_try_cabextract -d "$W_TMP" -L -F 'dxnt.cab' "$W_CACHE"/directx9/$DIRECTX_NAME
     w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dinput8.dll' "$W_TMP/dxnt.cab"
-    w_override_dlls native dinput8
+
+    # Don't try to register native dinput8; it doesn't export DllRegisterServer().
     w_try_regsvr dinput8
+    w_override_dlls native dinput8
 }
 
 #----------------------------------------------------------------
@@ -8807,8 +8809,9 @@ load_dsound()
     w_try_cabextract -d "$W_TMP" -L -F dxnt.cab "$W_CACHE"/directx9/$DIRECTX_NAME
     w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dsound.dll' "$W_TMP/dxnt.cab"
 
-    w_override_dlls native dsound
+    # Don't try to register native dsound; it doesn't export DllRegisterServer().
     w_try_regsvr dsound.dll
+    w_override_dlls native dsound
 }
 
 #----------------------------------------------------------------


### PR DESCRIPTION
I went and checked each individual verb that https://github.com/Winetricks/winetricks/commit/caa28d1af97ddd3d7b3e76ca7f51fb85fe1ce7eb affected, and these two indeed fail, so this patch reverts the change for those two.