### PR TITLE
Irfanview start menu icons

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -13668,6 +13668,8 @@ load_irfanview()
             Sleep 900
             ControlClick, Button7 ; Uncheck All
             Sleep 900
+            ControlClick, Button4 ; Create start menu icons
+            Sleep 900
             ControlClick, Button11 ; Next
             Sleep 900
             winwait, Setup, version


### PR DESCRIPTION
Add button click to irfanview automatic installation script.
This sets the option to generate start menu icons because there is no other way to start it from gui.