### PR TITLE
jscript: call wsh57 as wsh56 is deprecated.

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -21693,7 +21693,7 @@ execute_command()
         glsl-enable) w_warn "Calling glsl-enable is deprecated, please use glsl=enabled instead" ; w_call glsl=enabled ;;
         ie6_full) w_warn "Calling ie6_full is deprecated, please use ie6 instead" ; w_call ie6 ;;
         # FIXME: use wsh57 instead?
-        jscript) w_warn "Calling jscript is deprecated, please use wsh56js instead" ; w_call wsh56js ;;
+        jscript) w_warn "Calling jscript is deprecated, please use wsh57 instead" ; w_call wsh57 ;;
         npm-repack) w_warn "Calling npm-repack is deprecated, please use npm=repack instead" ; w_call npm=repack ;;
         oss) w_warn "Calling oss is deprecated, please use sound=oss instead" ; w_call sound=oss ;;
         python) w_warn "Calling python is deprecated, please use python26 instead" ; w_call python26 ;;


### PR DESCRIPTION
Fixes #1310 

wsh56 was deprecated in https://github.com/Winetricks/winetricks/commit/9dc7daac7dfe51f59e3886e39d3b61cd1f933720