### PR TITLE
tcscbl_uplay: init

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -20178,6 +20178,22 @@ load_wog()
 }
 
 #----------------------------------------------------------------
+# Uplay Games
+#----------------------------------------------------------------
+
+w_metadata tcscbl_uplay games \
+    title="Tom Clancy Splinter Cell: Blacklist (Uplay)" \
+    publisher="Ubisoft" \
+    year="2013" \
+    media="download" \
+    installed_exe1="$W_PROGRAMS_X86_WIN/Steam/steamapps/common/alien swarm/swarm.exe"
+
+load_tcscbl_uplay()
+{
+    w_uplay_install_game '91'
+}
+
+#----------------------------------------------------------------
 # Steam Games
 #----------------------------------------------------------------
 


### PR DESCRIPTION
Compatibility for 'Tom Clancy's Splinter Cell: Blacklist' for uplay

Tested using commits below

DEPENDS: https://github.com/Winetricks/winetricks/pull/1332
DEPENDS: https://github.com/Winetricks/winetricks/pull/1249

Signed-off-by: Jacob Hrbek <kreyren@rixotstudio.cz>