### PR TITLE
leagueoflegends: new verb

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -18426,6 +18426,7 @@ load_leagueoflegends()
   leagueoflegends_workaround_47198()
   {
     w_info "Applying workaround to winebug 47198 using precompiled WINE binary by mmtrt, skip this by using WINETRICKS_BLACKLIST variable if needed"
+    
     w_info "You can overwrite 'leagueoflegends_workaround_47198' variable to use different precompiled wine"
     [ -z "$leagueoflegends_workaround_47198" ] && export leagueoflegends_workaround_47198="$1"
 

--- a/src/winetricks
+++ b/src/winetricks
@@ -163,22 +163,6 @@ WINETRICKS_VERSION=20190912-next
 # - Pull Requests: https://github.com/Winetricks/winetricks/pulls
 #--------------------------------------------------------------------
 
-# FIXME: XDG_CACHE_HOME is defined twice, clean this up
-XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
-XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
-
-W_COUNTRY=""
-W_PREFIXES_ROOT="${WINE_PREFIXES:-$XDG_DATA_HOME/wineprefixes}"
-
-# For temp files before $WINEPREFIX is available:
-if [ -x "$(command -v mktemp 2>/dev/null)" ] ; then
-    W_TMP_EARLY="$(mktemp -d "${TMPDIR:-/tmp}/winetricks.XXXXXXXX")"
-elif [ -w "$TMPDIR" ] ; then
-    W_TMP_EARLY="$TMPDIR"
-else
-    W_TMP_EARLY="/tmp"
-fi
-
 #---- Public Functions ----
 
 # Ask permission to continue
@@ -260,6 +244,13 @@ w_warn()
     esac
 
     unset _W_timeout
+}
+
+# Output debug message to stdin if debug variable is non-zero
+w_debug()
+{
+    # shellcheck disable=SC2154
+    [ -n "$debug" ] && printf 'DEBUG: %s\n' "$1"
 }
 
 # Display warning message to stderr (since it is called inside redirected code)
@@ -375,14 +366,14 @@ w_try()
     # $1 would be 'wine'.
     case "$1" in
         *.exe)
-            chmod +x "$1" || true # don't care if it fails
+            [ ! -x "$1" ] && chmod +x "$1"
             cmd /c "$@"
             ;;
         *)
             "$@"
             ;;
     esac
-    status=$?
+    status="$?"
     if test $status -ne 0; then
         case $LANG in
             pl*) w_die "Informacja: poelcenie $* zwróciło status $status. Przerywam." ;;
@@ -532,8 +523,11 @@ w_try_regedit32()
 {
     # on windows, doesn't work without cmd /c
     case "$W_PLATFORM" in
-        windows_cmd|wine_cmd) cmdc="cmd /c";;
-        *) unset cmdc ;;
+        windows_cygwin|wine_cmd) cmdc="cmd /c" ;;
+        nix_linux|nix_freebsd|nix_darwin) unset cmdc ;;
+        nix_redox) w_die "Platform '$W_PLATFORM' is not implemented in w_try_regedit32()" ;;
+        windows_windows) w_die "Platform '$W_PLATFORM' is not implemented in w_try_regedit32()" ;;
+        *) w_die "Unknown platform '$W_PLATFORM' parsed in w_try_regedit32()"
     esac
 
     # shellcheck disable=SC2086
@@ -544,8 +538,11 @@ w_try_regedit64()
 {
     # on windows, doesn't work without cmd /c
     case "$W_PLATFORM" in
-        windows_cmd|wine_cmd) cmdc="cmd /c";;
-        *) unset cmdc ;;
+        windows_cygwin|wine_cmd) cmdc="cmd /c" ;;
+        nix_linux|nix_freebsd|nix_darwin) unset cmdc ;;
+        nix_redox) w_die "Platform '$W_PLATFORM' is not implemented in w_try_regedit64()" ;;
+        windows_windows) w_die "Platform '$W_PLATFORM' is not implemented in w_try_regedit64()" ;;
+        *) w_die "Unknown platform '$W_PLATFORM' parsed in w_try_regedit64()"
     esac
 
     # shellcheck disable=SC2086
@@ -699,16 +696,19 @@ winetricks_wintounix()
 w_pathconv()
 {
     case "$W_PLATFORM" in
-        windows_cmd)
+        windows_cygwin)
             # for some reason, cygpath turns some spaces into newlines?!
             cygpath "$@" | tr '\012' '\040' | sed 's/ $//'
             ;;
-        *)
+        windows_windows) w_die "FIXME: w_pathconv for $1 not implemented" ;;
+        nix_redox) w_die "FIXME: w_pathconv for $1 not implemented" ;;
+        nix_linux|nix_freebsd|nix_darwin)
             case "$@" in
                 -u?c:\\*|-u?C:\\*|-u?c:/*|-u?C:/*) winetricks_wintounix "$2" ;;
                 *) winetricks_early_wine winepath "$@" ;;
             esac
         ;;
+        *) w_die "Unknown platform in w_pathconv() : $W_PLATFORM"
     esac
 }
 
@@ -716,6 +716,15 @@ w_pathconv()
 w_expand_env()
 {
     winetricks_early_wine cmd.exe /c echo "%$1%"
+}
+
+# Check if $1 is executable (output custom message using w_debug if $2 is specified)
+w_check_exec()
+{
+  if ! command -v "$1" >/dev/null; then
+    [ -z "$2" ] && { printf "Command '%s' is not executable" "$1" && exit 1 ;} || printf '%s\n' "$2"
+  elif command -v "$1" >/dev/null; then w_debug "Command '$1' is executable"
+  fi
 }
 
 # Get the latest tagged release from github.com API
@@ -1500,6 +1509,41 @@ w_steam_getid()
     fi
 }
 
+# Usage: w_origin_install_game [prefix:ID]
+w_origin_install_game()
+{
+    # Install the origin client
+    ## TODO: Triggers origin install even when origin is installed
+    w_call 'origin'
+
+    # STUB: This doesn't work because reasons (launches wrong titles)
+    #"$WINE" 'start' "origin://launchgame/${1}&autoDownload=1"
+
+    # Check for login since origin won't launch expected title if end-user is not logged
+    ## reverse-engineered stages: winetricks/1320#issuecomment-531577914
+    if [ ! -d "${WINEPREFIX}/drive_c/users/${USER}/Application Data/Origin/CommonTitles" ]; then
+      w_warn "Please log-in origin to continue.."
+      w_warn "HELP_WANTED: Expected to not hang untill wineserver finishes so that we can push Action below, HOTFIX: Kill wineserver once logged in"
+      w_try "$WINE" 'start' 'origin://kreyren'
+
+      while [ ! -e "${WINEPREFIX}/drive_c/users/${USER}/Application Data/Origin/CatalogCache" ]; do
+        # Wait untill end-user is logged in
+        sleep 5
+      done
+    fi
+
+    # Action to download and launch
+    w_try "$WINE" 'start' "origin2://game/launch?offerIds=${1}&autoDownload=1"
+}
+
+# Usage: w_uplay_install_game [GAME_ID]
+## Relevant: https://github.com/Haoose/UPLAY_GAME_ID
+w_uplay_install_game()
+{
+    w_call 'uplay'
+    w_try "$WINE" 'start' "uplay://launch/$1"
+}
+
 # Usage:
 # w_steam_install_game steamidnum windowtitle
 w_steam_install_game()
@@ -1760,7 +1804,7 @@ _EOF_
 w_skip_windows()
 {
     case "$W_PLATFORM" in
-        windows_cmd)
+        windows_cygwin|windows_windows)
             echo "Skipping operation '$1' on Windows"
             return 0
             ;;
@@ -2546,10 +2590,10 @@ w_wine_version_in()
 # the environment variable WINETRICKS_BLACKLIST to disable it.
 w_workaround_wine_bug()
 {
-    if test "$WINE" = ""; then
-        echo "No need to work around wine bug $1 on Windows"
-        return 1
-    fi
+    case "$(winetricks_get_platform)" in
+        windows_*) echo "No need to work around wine bug $1 on Windows" ; return 1
+    esac
+
     case "$2" in
         [0-9]*) w_die "bug: want message in w_workaround_wine_bug arg 2, got $2" ;;
         "") _W_msg="";;
@@ -2595,6 +2639,25 @@ w_workaround_wine_bug()
 
 w_metadata()
 {
+  # Required to get platform variable
+  winetricks_get_platform >/dev/null
+
+  # Must initialize variables before calling w_metadata
+  if [ -z "$WINETRICKS_LIB" ]; then
+      WINETRICKS_SRCDIR="$(dirname "$0")"
+      WINETRICKS_SRCDIR="$(w_try_cd "$WINETRICKS_SRCDIR"; pwd)"
+
+      # Which GUI helper to use (none/zenity/kdialog).  See winetricks_detect_gui.
+      WINETRICKS_GUI=none
+      # Default to a shared prefix:
+      # WINETRICKS_OPT_SHAREDPREFIX=${WINETRICKS_OPT_SHAREDPREFIX:-1}
+
+      # Handle options before init, to avoid starting wine for --help or --version
+      while winetricks_handle_option "$1"; do
+          shift
+      done
+  fi
+
     case $WINETRICKS_OPT_VERBOSE in
         2) set -x ;;
         *) set +x ;;
@@ -2634,16 +2697,18 @@ w_metadata()
     # If the problem described above happens, you'd see errors like this:
     # /tmp/w.dank.4650/metadata/dlls/comctl32.vars: 6: Syntax error: Unterminated quoted string
     # so check for lines that aren't properly quoted.
-
+//
     # Do sanity check unless running on Cygwin, where it's way too slow.
     case "$W_PLATFORM" in
-        windows_cmd)
-            ;;
-        *)
+        windows_cygwin) w_warn "FIXME: Sanity check for w_metadata() is too slow, skipping.." ;;
+        windows_windows) w_die "FIXME: Platform $W_PLATFORM is not implemtented in w_metadata()" ;;
+        nix_redox) w_die "FIXME: Platform $W_PLATFORM is not implemtented in w_metadata()" ;;
+        nix_linux|nix_freebsd|nix_darwin)
             if grep '[^"]$' "$file"; then
                 w_die "bug: w_metadata $_W_md_cmd corrupt, might need forward slashes?"
             fi
-            ;;
+        ;;
+        *) w_die "Unknown W_PLATFORM '$W_PLATFORM' detected in w_metadata()"
     esac
     unset _W_md_cmd
 
@@ -2729,8 +2794,8 @@ w_do_call()
 
         # If needed, set the app's wineprefix
         case "$W_PLATFORM" in
-            windows_cmd|wine_cmd) ;;
-            *)
+            windows_cygwin|windows_windows|wine_cmd) ;;
+            nix_linux|nix_freebsd|nix_darwin)
                 # shellcheck disable=SC2154
                 case "${category}-${WINETRICKS_OPT_SHAREDPREFIX}" in
                     apps-0|benchmarks-0|games-0)
@@ -2742,6 +2807,8 @@ w_do_call()
                         ;;
                 esac
             ;;
+            nix_redox) w_die "FIXME: Platform '$W_PLATFORM' is not implemented in w_do_call()" ;;
+            *) w_die "Unknown platform detected in w_do_call() : $W_PLATFORM"
         esac
 
         test "$W_OPT_NOCLEAN" = 1 || rm -rf "$W_TMP"
@@ -2758,12 +2825,11 @@ w_do_call()
 
         # Don't install if already installed
         if test "$WINETRICKS_FORCE" != 1 && winetricks_is_installed "$1"; then
-            echo "$1 already installed, skipping"
-            return 0
+            w_die "Verb '$1' is already installed, skipping"
         fi
 
         # We'd like to get rid of W_PACKAGE, but for now, just set it as late as possible.
-        W_PACKAGE=$1
+        W_PACKAGE="$1"
         w_try "load_$cmd" "$arg"
         winetricks_stats_log_command "$@"
 
@@ -3025,20 +3091,65 @@ winetricks_get_sha256sum_prog() {
     fi
 }
 
+# Get running platform in W_PLATFORM and return it in a form of [nix|windows]_[kernel_used]
 winetricks_get_platform()
 {
-    if [ "${OS}" = "Windows_NT" ]; then
-        if [ -n "${WINELOADERNOEXEC}" ]; then
-            # Windows/Cygwin
-            export W_PLATFORM="windows_cmd"
-        else
-            # wineconsole/cmd under wine
-            export W_PLATFORM="wine_cmd"
-        fi
-    else
-        # Normal Unix shell
-        export W_PLATFORM="wine"
-    fi
+  # Linux - `uname` returns 'GNU/Linux'
+  if [ "$(uname)" = "Linux" ]; then
+    export W_PLATFORM="nix_linux"
+    printf "%s\n" "$W_PLATFORM"
+    return 0
+
+  # FreeBSD - `uname` returns 'FreeBSD'
+  elif [ "$(uname)" = "FreeBSD" ]; then
+    export W_PLATFORM="nix_freebsd"
+    printf "%s\n" "$W_PLATFORM"
+    return 0
+
+  # Redox - `uname` returns 'Redox'
+  elif [ "$(uname)" = "Redox" ]; then
+    export W_PLATFORM="nix_redox"
+    printf "%s\n" "$W_PLATFORM"
+    return 0
+
+  # Cygwin - `uname -o` returns 'Cygwin'
+  elif [ "$(uname -o)" = "Cygwin" ]; then
+    export W_PLATFORM="windows_cygwin"
+    printf "%s\n" "$W_PLATFORM"
+    return 0
+
+  # MacOS - `uname` returns 'Darwin'
+  elif [ "$(uname)" = "Darwin" ]; then
+    export W_PLATFORM="nix_darwin"
+    printf "%s\n" "$W_PLATFORM"
+    return 0
+
+  # Windows - Impossible to get?
+  elif [ "$(uname)" = "Windows" ]; then
+    w_warn "How did you execute POSIX shell on native Windows? File an issue for compatibility"
+    export W_PLATFORM="windows_windows"
+    printf "%s\n" "$W_PLATFORM"
+    return 0
+
+  # WineCMD/CMD
+  elif [ "$OS" = "Windows_NT" ] && [ -z "$(uname)" ]; then
+    export W_PLATFORM="wine_cmd"
+    printf "%s\n" "$W_PLATFORM"
+    return 0
+
+  else
+   # WSL - `uname -r` returns `4.4.0-18362-Microsoft` where 4.4.0 is kernel version and 18362 windows build(?)
+   ## $OS is blank on WSL (10/2019)
+   case "$(uname -r)" in
+     *-Microsoft)
+      export W_PLATFORM="windows_wsl"
+      printf "%s\n" "$W_PLATFORM"
+      return 0
+   esac
+  fi
+
+  # Logic-check
+  [ -z "$W_PLATFORM" ] && w_die "Function winetricks_get_platform is unable to get W_PLATFORM variable"
 }
 
 winetricks_latest_version_check()
@@ -4050,7 +4161,7 @@ winetricks_is_installed()
     fi
 
     case "$W_PLATFORM" in
-        windows_cmd|wine_cmd)
+        windows_cygwin|windows_windows|wine_cmd)
             # On Windows, there's no wineprefix, just check if file's there
             _W_file_unix="$(w_pathconv -u "$_W_file")"
             if test -f "$_W_file_unix"; then
@@ -4058,7 +4169,7 @@ winetricks_is_installed()
                 return 0  # installed
             fi
             ;;
-        *)
+        nix_linux|nix_freebsd|nix_darwin)
             # Compute wineprefix for this app
             case "${category}-${WINETRICKS_OPT_SHAREDPREFIX}" in
                 apps-0|benchmarks-0|games-0)
@@ -4085,6 +4196,8 @@ winetricks_is_installed()
              IFS="$_W_IFS"
             fi
             ;;
+        nix_redox) w_die "Platform '$W_PLATFORM' is not implemented in winetricks_is_installed()" ;;
+        *) w_die "Unknown platform '$W_PLATFORM' used in winetricks_is_installed"
     esac
     unset _W_file _W_prefix _W_IFS  # leak _W_file_unix for caller. Is this wise?
     return 1  # not installed
@@ -4812,10 +4925,13 @@ winetricks_set_wineprefix()
     esac
 
     case "$W_PLATFORM" in
-        windows_cmd)
+        windows_cygwin)
             W_DRIVE_C="/cygdrive/c" ;;
-        *)
+        windows_windows) w_die "FIXME: Platform '$W_PLATFORM' is not implemtented in winetricks_set_wineprefix()" ;;
+        nix_redox) w_die "FIXME: Platform '$W_PLATFORM' is not implemtented in winetricks_set_wineprefix()" ;;
+        nix_linux|nix_freebsd|nix_darwin)
             W_DRIVE_C="$WINEPREFIX/dosdevices/c:" ;;
+        *) w_die "Unknown platform '$W_PLATFORM' was used in winetricks_set_wineprefix()"
     esac
 
     # Kludge: use Temp instead of temp to avoid \t expansion in w_try
@@ -4831,8 +4947,8 @@ winetricks_set_wineprefix()
     fi
 
     case "$W_PLATFORM" in
-        "windows_cmd|wine_cmd") W_CACHE_WIN="$(w_pathconv -w "$W_CACHE")" ;;
-        *)
+        windows_cygwin|windows_windows|wine_cmd) W_CACHE_WIN="$(w_pathconv -w "$W_CACHE")" ;;
+        nix_linux|nix_freebsd|nix_darwin)
             # For case where Z: doesn't exist or / is writable (!),
             # make a drive letter for W_CACHE.  Clean it up on exit.
             test "$WINETRICKS_CACHE_SYMLINK" && rm -f "$WINETRICKS_CACHE_SYMLINK"
@@ -4847,6 +4963,8 @@ winetricks_set_wineprefix()
             done
             W_CACHE_WIN="${letter}:"
             ;;
+        nix_redox) w_die "Platform '$W_PLATFORM' is not implemented in winetricks_set_wineprefix()" ;;
+        *) w_die "Unknown platform ($W_PLATFORM) detected in winetricks_set_wineprefix()"
     esac
 
     W_COMMONFILES_X86_WIN="$(w_expand_env CommonProgramFiles)"
@@ -5037,7 +5155,8 @@ winetricks_init()
 
     winetricks_get_sha256sum_prog
 
-    winetricks_get_platform
+    # winetricks_get_platform got updated and in addition to W_PLATFORM export it outputs the platform which seems unexpected here
+    winetricks_get_platform 2>&1 /dev/null
 
     #---- Public Variables ----
 
@@ -5094,7 +5213,7 @@ winetricks_init()
 
     # System-specific variables
     case "$W_PLATFORM" in
-        windows_cmd)
+        windows_cygwin)
             WINE=""
             WINE64=""
             WINE_ARCH=""
@@ -5102,7 +5221,8 @@ winetricks_init()
             WINESERVER=""
             W_DRIVE_C="C:/"
             ;;
-        *)
+        windows_windows) w_die "Platform '$W_PLATFORM' is not implemented in winetricks_init()" ;;
+        nix_linux|nix_freebsd|nix_darwin)
             WINE="${WINE:-wine}"
             # Find wineserver.
             # Some distributions (Debian before wine 1.8-2) don't have it on the path.
@@ -5137,7 +5257,6 @@ winetricks_init()
                     break
                 fi
             done
-
                 case "$x" in
                     file-not-found) w_die "wineserver not found!" ;;
                     *) WINESERVER="$x" ;;
@@ -5154,9 +5273,9 @@ winetricks_init()
                 fi
                 unset _abswine
                 ;;
+        nix_redox) w_die "Platform '$W_PLATFORM' is not implemented in winetricks_init()" ;;
+        *) w_die "Unknown platform '$W_PLATFORM' used in winetricks_init()"
     esac
-
-    winetricks_set_wineprefix "$1"
 
     # Whether to automate installs (0=no, 1=yes)
     winetricks_set_unattended ${W_OPT_UNATTENDED:-0}
@@ -5302,7 +5421,7 @@ winetricks_handle_option()
 {
     case "$1" in
         --country=*) W_COUNTRY="${1##--country=}" ;;
-        --force) WINETRICKS_FORCE=1;;
+        --force|-f) WINETRICKS_FORCE=1;;
         --gui) winetricks_detect_gui;;
         -h|--help) winetricks_usage ; exit 0 ;;
         --isolate) WINETRICKS_OPT_SHAREDPREFIX=0 ;;
@@ -5325,36 +5444,6 @@ winetricks_handle_option()
     esac
     return 0
 }
-
-# Test whether temporary directory is valid - before initialising script
-[ -d "$W_TMP_EARLY" ] || w_die "temporary directory: '$W_TMP_EARLY' ; does not exist"
-[ -w "$W_TMP_EARLY" ] || w_die "temporary directory: '$W_TMP_EARLY' ; is not user writeable"
-
-# Must initialize variables before calling w_metadata
-if ! test "$WINETRICKS_LIB"
-then
-    WINETRICKS_SRCDIR=$(dirname "$0")
-    WINETRICKS_SRCDIR=$(w_try_cd "$WINETRICKS_SRCDIR"; pwd)
-
-    # Which GUI helper to use (none/zenity/kdialog).  See winetricks_detect_gui.
-    WINETRICKS_GUI=none
-    # Default to a shared prefix:
-    WINETRICKS_OPT_SHAREDPREFIX=${WINETRICKS_OPT_SHAREDPREFIX:-1}
-
-    # Handle options before init, to avoid starting wine for --help or --version
-    while winetricks_handle_option "$1"
-    do
-        shift
-    done
-
-    # Workaround for https://github.com/Winetricks/winetricks/issues/599
-    # If --isolate is used, pass verb to winetricks_init, so it can set the wineprefix using winetricks_set_wineprefix()
-    # Otherwise, an arch mismatch between ${WINEPREFIX:-$HOME/.wine} and the prefix to be made for the isolated app would cause it to fail
-    case $WINETRICKS_OPT_SHAREDPREFIX in
-        0) winetricks_init "$1" ;;
-        *) winetricks_init ;;
-    esac
-fi
 
 winetricks_install_app()
 {
@@ -8193,13 +8282,15 @@ load_dotnet30()
         esac
     fi
 
+    # Compatibility for Windows
     case "$W_PLATFORM" in
-        windows_cmd)
+        windows_cygwin)
             osver=$(cmd /c ver)
             case "$osver" in
                 *Version?6*) w_die "Vista and up bundle .NET 3.0, so you can't install it like this" ;;
             esac
             ;;
+        windows_windows) w_die "Platform '$W_PLATFORM' is not implemented in load_dotnet30()"
     esac
 
     # AF's workaround to avoid long pause
@@ -8312,9 +8403,11 @@ load_dotnet35()
         w_package_unsupported_win64
     fi
 
+    # Platform compatibility
     case "$W_PLATFORM" in
-        windows_cmd) ;;
-        *) w_warn "dotnet35 does not yet fully work or install on wine.  Caveat emptor." ;;
+        windows_cygwin|windows_windows) ;;
+        nix_linux|nix_freebsd|nix_darwin|nix_redox) w_warn "dotnet35 does not yet fully work or install on wine.  Caveat emptor." ;;
+        *) w_die "Unknown platform '$W_PLATFORM' parsed in load_dotnet35()"
     esac
 
     w_verify_cabextract_available
@@ -8367,8 +8460,9 @@ load_dotnet35sp1()
     fi
 
     case "$W_PLATFORM" in
-        windows_cmd) ;;
-        *) w_warn "dotnet35sp1 does not yet fully work or install on wine.  Caveat emptor." ;;
+        windows_cygwin|windows_windows) ;;
+        nix_linux|nix_freebsd|nix_darwin|nix_redox) w_warn "dotnet35sp1 does not yet fully work or install on wine.  Caveat emptor." ;;
+        *) w_die "Unknown platform parsed in load_dotnet35sp1()"
     esac
 
     w_verify_cabextract_available
@@ -8416,8 +8510,9 @@ load_dotnet40()
     w_package_warn_win64
 
     case "$W_PLATFORM" in
-        windows_cmd) ;;
-        *) w_warn "dotnet40 does not yet fully work or install on wine.  Caveat emptor." ;;
+        windows_cygwin|windows_windows) ;;
+        nix_linux|nix_freebsd|nix_darwin|nix_redox) w_warn "dotnet40 does not yet fully work or install on wine.  Caveat emptor." ;;
+        *) w_die "Unknown platform '$W_PLATFORM' used in load_dotnet40()"
     esac
 
     if [ "$W_ARCH" = "win64" ]; then
@@ -13207,6 +13302,190 @@ load_allfonts()
 }
 
 #######################
+# tools
+#######################
+
+# ----------------------------------------------------------------
+
+# TODO: Add tools metadata
+w_metadata wineappimagebuilder apps \
+    title="WINE AppImage builder" \
+    publisher="Kreyren" \
+    year="2019" \
+    media="tools"
+
+load_wineappimagebuilder()
+{
+    # Get wine source
+    [ -z "$wineappimagebuilder_workdir" ] && export wineappimagebuilder_workdir="$WINETRICKS_WORKDIR"
+    [ "$wineappimagebuilder_workdir" != "$WINETRICKS_WORKDIR" ] && [ ! -e "$wineappimagebuilder_workdir" ] && { mkdir "$wineappimagebuilder_workdir" && w_debug "Directory '$wineappimagebuilder_workdir' was created to be used for wineappimagebuilder_workdir" ;} || w_debug "Directory '$wineappimagebuilder_workdir' already exist to be used for wineappimagebuilder_workdir"
+
+    # Logic to grab WINEARCH if none is specified
+    [ -z "$WINEARCH" ] && case "$(uname -m)" in
+      x86_64)
+        export WINEARCH="win64"
+      ;;
+      x86)
+        export WINEARCH="win32"
+      ;;
+      *) w_die "Unexpected output of 'uname -m' ($(uname -m)) was provided for WINEARCH logic"
+    esac
+
+    # TODO: Always use latest if none is selected
+    [ -z "$wineappimagebuilder_wine_version" ] && export wineappimagebuilder_wine_version="wine-4.17"
+
+    # Logic to fetch expected WINE version
+    export wineappimagebuilder_wine_version_stripped="${wineappimagebuilder_wine_version#?????}"
+    case "$wineappimagebuilder_wine_version" in
+      # Attempt to provide future compatibility
+      # TODO: needs improvement supports wine-[3-9].0|wine-[3-9].[0-9] only instead of wine-[3-9].[0-9]*
+      wine-[3-9].0.*)
+        [ ! -e "$W_CACHE/$W_PACKAGE/$wineappimagebuilder_wine_version.tar.xz" ] && w_download "https://dl.winehq.org/wine/source/${wineappimagebuilder_wine_version_stripped%???}.0/$wineappimagebuilder_wine_version.tar.xz"
+      ;;
+      wine-[3-9].[0-9]*)
+        [ ! -e "$W_CACHE/$W_PACKAGE/$wineappimagebuilder_wine_version.tar.xz" ] && w_download "https://dl.winehq.org/wine/source/${wineappimagebuilder_wine_version_stripped%???}.x/$wineappimagebuilder_wine_version.tar.xz"
+      ;;
+      # Cherrypicked
+      wine-1.9.[0-9]|wine-1.9.[0-9][0-9])
+        [ ! -e "$W_CACHE/$W_PACKAGE/$wineappimagebuilder_wine_version.tar.xz" ] && w_download "https://dl.winehq.org/wine/source/1.9/$wineappimagebuilder_wine_version.tar.xz"
+      ;;
+      wine-1.8.[0-9]|wine-1.8.[0-9][0-9]|wine-1.8.[0-9]-rc*|wine-1.8.[0-9][0-9]-rc*)
+        [ ! -e "$W_CACHE/$W_PACKAGE/$wineappimagebuilder_wine_version.tar.xz" ] && w_download "https://dl.winehq.org/wine/source/1.8/$wineappimagebuilder_wine_version.tar.xz"
+      ;;
+      wine-1.7.[0-9]|wine-1.7.[0-9][0-9])
+        [ ! -e "$W_CACHE/$W_PACKAGE/$wineappimagebuilder_wine_version.tar.xz" ] && w_download "https://dl.winehq.org/wine/source/1.7/$wineappimagebuilder_wine_version.tar.xz"
+      ;;
+      wine-1.6.[0-9]|wine-1.6.[0-9][0-9]|wine-1.6.[0-9]-rc*|wine-1.6-rc*|wine-1.6.[0-9][0-9]-rc*)
+        [ ! -e "$W_CACHE/$W_PACKAGE/$wineappimagebuilder_wine_version.tar.xz" ] && w_download "https://dl.winehq.org/wine/source/1.6/$wineappimagebuilder_wine_version.tar.xz"
+      ;;
+      wine-1.5.[0-9]|wine-1.5.[0-9][0-9])
+        [ ! -e "$W_CACHE/$W_PACKAGE/$wineappimagebuilder_wine_version.tar.xz" ] && w_download "https://dl.winehq.org/wine/source/1.5/$wineappimagebuilder_wine_version.tar.xz"
+      ;;
+      wine-1.4.[0-9]|wine-1.4.[0-9][0-9]|wine-1.4.[0-9]-rc*|wine-1.4.[0-9][0-9]-rc*)
+        [ ! -e "$W_CACHE/$W_PACKAGE/$wineappimagebuilder_wine_version.tar.xz" ] && w_download "https://dl.winehq.org/wine/source/1.4/$wineappimagebuilder_wine_version.tar.xz"
+      ;;
+      wine-1.3.[0-9]|wine-1.3.[0-9][0-9])
+        [ ! -e "$W_CACHE/$W_PACKAGE/$wineappimagebuilder_wine_version.tar.xz" ] && w_download "https://dl.winehq.org/wine/source/1.3/$wineappimagebuilder_wine_version.tar.xz"
+      ;;
+      wine-1.2.[0-9]|wine-1.2.[0-9][0-9]|wine-1.2.[0-9]-rc*|wine-1.2-rc*|wine-1.2.[0-9][0-9]-rc*)
+        [ ! -e "$W_CACHE/$W_PACKAGE/$wineappimagebuilder_wine_version.tar.xz" ] && w_download "https://dl.winehq.org/wine/source/1.2/$wineappimagebuilder_wine_version.tar.xz"
+      ;;
+      wine-1.1.[0-9]|wine-1.1.[0-9][0-9])
+        [ ! -e "$W_CACHE/$W_PACKAGE/$wineappimagebuilder_wine_version.tar.xz" ] && w_download "https://dl.winehq.org/wine/source/1.1/$wineappimagebuilder_wine_version.tar.xz"
+      ;;
+      wine-1.0.[0-9]|wine-1.0.[0-9][0-9]|wine-1.0.[0-9]-rc*|wine-1.0-rc*|wine-1.0.[0-9][0-9]-rc*)
+        [ ! -e "$W_CACHE/$W_PACKAGE/$wineappimagebuilder_wine_version.tar.xz" ] && w_download "https://dl.winehq.org/wine/source/1.0/$wineappimagebuilder_wine_version.tar.xz"
+      ;;
+      wine-1.1.[0-9]|wine-1.1.[0-9][0-9])
+        [ ! -e "$W_CACHE/$W_PACKAGE/$wineappimagebuilder_wine_version.tar.xz" ] && w_download "https://dl.winehq.org/wine/source/1.0/$wineappimagebuilder_wine_version.tar.xz"
+      ;;
+      *) w_die "wineappimagebuilder doesn't support '$wineappimagebuilder_wine_version' in 'wineappimagebuilder_wine_version' variable"
+    esac
+
+    # Credit: https://stackoverflow.com/a/18963118
+    gcc_optimization() { gcc -### -E - -march=native 2>&1 | sed -r '/cc1/!d;s/(")|(^.* - )|( -mno-[^\ ]+)//g' ;}
+
+    # Abstract: Make compilation as fast as possible for those using it
+    export COMMON_FLAGS="$(gcc_optimization) --pipe"
+    [ -z "$CFLAGS" ] && export CFLAGS="$COMMON_FLAGS"
+    [ -z "$CXXFLAGS" ] && export CXXFLAGS="$COMMON_FLAGS"
+    [ -z "$FCFLAGS" ] && export FCLAGS="$COMMON_FLAGS"
+    [ -z "$FFLAGS" ] && export FFLAGS="$COMMON_FLAGS"
+    [ -z "$FCFLAGS" ] && export FCFLAGS="$COMMON_FLAGS"
+    [ -z "$MAKEOPTS" ] && export MAKEOPTS="$([ -n "$(nproc)" ] && printf '%s\n' "-j$(nproc)")"
+
+    # Fetch WINE source
+    # TODO: Allow fetching different versions of WINE
+    [ ! -e "$W_CACHE/$W_PACKAGE/$wineappimagebuilder_wine_version.tar.xz" ] && w_download "https://dl.winehq.org/wine/source/4.x/$wineappimagebuilder_wine_version.tar.xz"
+
+    # shellcheck disable=SC2015
+    [ ! -e "$wineappimagebuilder_workdir/$wineappimagebuilder_wine_version" ] && { mkdir "$wineappimagebuilder_workdir/$wineappimagebuilder_wine_version" || w_die "failed to make a new directory in '$wineappimagebuilder_workdir/$wineappimagebuilder_wine_version" ;} || w_debug "Directory '$wineappimagebuilder_workdir/$wineappimagebuilder_wine_version' already exists"
+
+    [ ! -e "$wineappimagebuilder_workdir/$wineappimagebuilder_wine_version/LICENSE" ] && tar -xf "$W_CACHE/$W_PACKAGE/$wineappimagebuilder_wine_version.tar.xz" -C "$wineappimagebuilder_workdir/"
+
+    # Compile WINE
+    w_check_exec 'flex'
+    w_check_exec 'bison'
+    w_check_exec 'make'
+
+    w_warn "Wine64 is built depending on WINEARCH variable"
+
+    ## We are fetching wine from official release -> no regression tests needed
+    (
+      # TODO: Avoid using cd
+      w_try_cd "$wineappimagebuilder_workdir/$wineappimagebuilder_wine_version"
+      w_warn "Generating Makefile, this could take a while.. (max 2min)"
+      [ ! -e "$wineappimagebuilder_workdir/$wineappimagebuilder_wine_version/Makefile" ] && w_try "$wineappimagebuilder_workdir/$wineappimagebuilder_wine_version/configure" --disable-tests --quiet --srcdir="$wineappimagebuilder_workdir/$wineappimagebuilder_wine_version/" "$([ "$WINEARCH" = "win64" ] && printf '%s\n' "--enable-win64")"
+    )
+    w_warn "We are about to build whole WINE from source to be packaged in AppImage, this make take a while (2h max per one thread)"
+    [ ! -e "$wineappimagebuilder_workdir/$wineappimagebuilder_wine_version/libs/wine/libwine.so.1.0" ] && w_warn "We are about to compile whole WINE, this is going to take some time.."
+    w_try make -C "$wineappimagebuilder_workdir/$wineappimagebuilder_wine_version/" "$MAKEOPTS"
+
+    # Get appimagetool
+    if [ "$WINEARCH" = 'win64' ]; then
+      [ ! -e "$W_CACHE/$W_PACKAGE/appimagetool-x86_64.AppImage" ] && w_download 'https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage'
+      [ ! -e "$wineappimagebuilder_workdir/appimagetool.AppImage" ] && [ -e "$W_CACHE/$W_PACKAGE/appimagetool-x86_64.AppImage" ] && cp -r "$W_CACHE/$W_PACKAGE/appimagetool-x86_64.AppImage" "$wineappimagebuilder_workdir"
+      # shellcheck disable=SC2015
+      [ ! -x "$wineappimagebuilder_workdir/appimagetool.AppImage" ] && { chmod +x "$wineappimagebuilder_workdir/appimagetool-x86_64.AppImage" || w_die "Unable to set executable permissions on '$wineappimagebuilder_workdir/appimagetool-x86_64.AppImage'" ;} || w_debug "File '$wineappimagebuilder_workdir/appimagetool-x86_64.AppImage' is already executable"
+
+      ## Export in workdir
+      [ ! -e "$wineappimagebuilder_workdir/appimagetool-x86_64.AppImage" ] && [ -e "$W_CACHE/$W_PACKAGE/appimagetool-x86_64.AppImage" ] && cp "$W_CACHE/$W_PACKAGE/appimagetool-x86_64.AppImage" "$wineappimagebuilder_workdir/"
+      [ ! -x "$wineappimagebuilder_workdir/appimagetool-x86_64.AppImage" ] && chmod +x "$wineappimagebuilder_workdir/appimagetool-x86_64.AppImage"
+
+      export wineappimagebuilder_appimagetool="appimagetool-x86_64.AppImage"
+    elif [ "$WINEARCH" = 'win32' ]; then
+      [ ! -e "$W_CACHE/$W_PACKAGE/appimagetool-i686.AppImage" ] && w_download 'https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-i686.AppImage'
+      [ ! -e "$wineappimagebuilder_workdir/appimagetool.AppImage" ] && [ -e "$W_CACHE/$W_PACKAGE/appimagetool-i686.AppImage" ] && cp -r "$W_CACHE/$W_PACKAGE/appimagetool-i686.AppImage" "$wineappimagebuilder_workdir"
+      [ ! -x "$wineappimagebuilder_workdir/appimagetool.AppImage" ] && { chmod +x "$wineappimagebuilder_workdir/appimagetool-i686.AppImage" || w_die "Unable to set executable permissions on '$wineappimagebuilder_workdir/appimagetool-i686.AppImage'" ;} || w_debug "File '$wineappimagebuilder_workdir/appimagetool-i686.AppImage' is already executable"
+
+      ## Export in workdir
+      [ ! -e "$wineappimagebuilder_workdir/appimagetool-i686.AppImage" ] && [ -e "$W_CACHE/$W_PACKAGE/appimagetool-i686.AppImage" ] && cp "$W_CACHE/$W_PACKAGE/appimagetool-i686.AppImage" "$wineappimagebuilder_workdir/"
+      [ ! -x "$wineappimagebuilder_workdir/appimagetool-i686.AppImage" ] && chmod +x "$wineappimagebuilder_workdir/appimagetool-i686.AppImage"
+
+      export wineappimagebuilder_appimagetool="appimagetool-i686.AppImage"
+    else w_die "Unsupported WINEARCH ($WINEARCH)"
+    fi
+
+    # Build AppImage
+    (
+      w_try_cd "$wineappimagebuilder_workdir"
+      [ ! -e "$wineappimagebuilder_workdir/squashfs-root/AppRun" ] && w_try "$wineappimagebuilder_workdir/$wineappimagebuilder_appimagetool" --appimage-extract
+    )
+
+    # Make appimage executable
+    [ ! -x "$wineappimagebuilder_workdir/squashfs-root/AppRun" ] && chmod +x "$wineappimagebuilder_workdir/squashfs-root/AppRun"
+
+    # APPLY PATCHES
+    # shellcheck disable=SC2015
+    [ -n "$(wineappimagebuilder_patches)" ] && { wineappimagebuilder_patches ;} || w_warn "No patches ware applied, define 'wineappimagebuilder_patches' in your verb to apply them"
+
+    # Configure AppImage
+    # Both .svg and .desktop are mandatory
+    [ ! -e "$wineappimagebuilder_workdir/$wineappimagebuilder_wine_version/appimagetool.svg" ] && { cp "$wineappimagebuilder_workdir/squashfs-root/appimagetool.svg" "$wineappimagebuilder_workdir/$wineappimagebuilder_wine_version/" || die "Unable to copy '$wineappimagebuilder_workdir/squashfs-root/appimagetool.svg' to '$wineappimagebuilder_workdir/$wineappimagebuilder_wine_version/'" ;}
+    printf '%s\n' \
+      '[Desktop Entry]' \
+      'Type=Application' \
+      "Name=$W_PACKAGE" \
+      'Exec=wine' \
+      'Comment=Created by winetricks' \
+      'Icon=appimagetool' \
+      'Categories=Development;' \
+      'Terminal=true' \
+    > "$wineappimagebuilder_workdir/$wineappimagebuilder_wine_version/appimagetool.desktop"
+
+    (
+      [ "$WINEARCH" = "win64" ] && export ARCH='x86_64'
+      # Blind ARCH=x86
+      [ "$WINEARCH" = "win32" ] && export ARCH='x86'
+      if [ ! -e "$W_CACHE/$W_PACKAGE/$W_PACKAGE.AppImage" ]; then
+        [ -e "$wineappimagebuilder_workdir/squashfs-root/AppRun" ] && w_try "$wineappimagebuilder_workdir/squashfs-root/AppRun" -u "gh-releases-zsync|$USER|Wine_Appimage|winetricks|wine-*winetricks.AppImage.zsync" "/home/kreyren/testing_wine/$wineappimagebuilder_wine_version/" "$W_CACHE/$W_PACKAGE/$W_PACKAGE.AppImage"
+      fi
+    )
+}
+
+#----------------------------------------------------------------
+
+#######################
 # apps
 #######################
 
@@ -14994,6 +15273,103 @@ load_sketchup()
 
 #----------------------------------------------------------------
 
+w_metadata origin apps \
+    title="Origin" \
+    publisher="Electronic Arts" \
+    year="2011" \
+    media="download" \
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Origin/Origin.exe"
+
+load_origin() {
+  # NOTICE: Qt5Svg.dll is required for C:\\Program Files (x86)\\Origin\\imageformats\\qsvg.dll
+  # NOTICE: Both legacy and non-legacy are using dx11 and dxgi libs, but doesn't depend on them
+  # NOTICE: CTRL+V doesn't work in non-legacy
+
+  # Sanitization for client already installed
+  ## Since this supports multiple versions of origin we are unable to use winetricks's function
+  [ -e "${WINEPREFIX}/drive_c/Program Files (x86)/Origin/Origin.exe" ] && return 0
+
+  # Logic for DXVK
+  if [ -n "$WINETRICKS_ORIGIN_USE_DXVK" ]; then
+
+    # https://github.com/KhronosGroup/MoltenVK/issues/203
+    [ "$(uname)" = 'Darwin' ] && w_die "DXVK is not supported on MacOS due to the missing extension on MoltenVK"
+
+    w_call 'dxvk'
+
+    # Installer fails without overrides to OriginClientService assuming missing function in WINE
+    # https://bugs.winehq.org/show_bug.cgi?id=47773
+    if [ -n "$WINETRICKS_USE_LEGACY_ORIGIN" ]; then
+      w_override_app_dlls 'OriginClientService.exe' 'disabled' 'd3d10'
+      w_override_app_dlls 'OriginClientService.exe' 'disabled' 'd3d10_1'
+      w_override_app_dlls 'OriginClientService.exe' 'disabled' 'd3d10core'
+      w_override_app_dlls 'OriginClientService.exe' 'disabled' 'd3d11'
+      w_override_app_dlls 'OriginClientService.exe' 'disabled' 'dxgi'
+    fi
+
+  elif [ -z "$WINETRICKS_ORIGIN_USE_DXVK" ]; then
+    w_info "DXVK was disabled for origin client, to enable set WINETRICKS_ORIGIN_USE_DXVK variable to non-zero"
+
+    # Disable dxvk libraries if variable above is not set
+    w_override_app_dlls 'Origin.exe' 'disabled' 'd3d10'
+    w_override_app_dlls 'Origin.exe' 'disabled' 'd3d10_1'
+    w_override_app_dlls 'Origin.exe' 'disabled' 'd3d10core'
+    w_override_app_dlls 'Origin.exe' 'disabled' 'd3d11'
+    w_override_app_dlls 'Origin.exe' 'disabled' 'dxgi'
+
+    w_override_app_dlls 'IGOProxy.exe' 'disabled' 'd3d10'
+    w_override_app_dlls 'IGOProxy.exe' 'disabled' 'd3d10_1'
+    w_override_app_dlls 'IGOProxy.exe' 'disabled' 'd3d10core'
+    w_override_app_dlls 'IGOProxy.exe' 'disabled' 'd3d11'
+    w_override_app_dlls 'IGOProxy.exe' 'disabled' 'dxgi'
+
+    w_override_app_dlls 'IGOProxy64.exe' 'disabled' 'd3d10'
+    w_override_app_dlls 'IGOProxy64.exe' 'disabled' 'd3d10_1'
+    w_override_app_dlls 'IGOProxy64.exe' 'disabled' 'd3d10core'
+    w_override_app_dlls 'IGOProxy64.exe' 'disabled' 'd3d11'
+    w_override_app_dlls 'IGOProxy64.exe' 'disabled' 'dxgi'
+  fi
+
+  # Logic for installer
+  if [ -n "$WINETRICKS_USE_LEGACY_ORIGIN" ]; then
+
+    # legacy download
+    w_download 'https://origin-a.akamaihd.net/Origin-Client-Download/origin/legacy/OriginThinSetup.exe' '' 'OriginThinSetupLegacy.exe'
+
+    w_warn "You should *uncheck* sharing hardware info"
+
+    # Installer
+    WINEDEBUG='fixme-all' w_try "$WINE" "${W_CACHE}/origin/OriginThinSetupLegacy.exe"
+
+    # Switch back to default environment
+    w_unset_winver
+
+  elif [ -z "$WINETRICKS_USE_LEGACY_ORIGIN" ]; then
+
+    w_warn "winbind is required for this wineapp to work"
+
+    w_download 'https://origin-a.akamaihd.net/Origin-Client-Download/origin/live/OriginThinSetup.exe'
+
+    w_warn "You should *uncheck* sharing hardware info"
+
+    WINEDEBUG='fixme-all' w_try "$WINE" "${W_CACHE}/origin/OriginThinSetup.exe"
+  fi
+
+  # Wait untill origin is installed
+  ## Reverse-engineered stages https://github.com/Winetricks/winetricks/pull/1320#issuecomment-531577914
+  while [ ! -e "${WINEPREFIX}/drive_c/Program Files (x86)/Origin/3RDPARTYLICENSES.HTML" ]; do
+    sleep 5
+  done
+
+  # Fixing directory for game download https://github.com/Winetricks/winetricks/pull/1318#issuecomment-531460777
+  [ -n "$WINETRICKS_USE_LEGACY_ORIGIN" ] && (if grep -qF "DownloadInPlaceDir" "${WINEPREFIX}/drive_c/users/${USER}/Application Data/Origin/local.xml.old" 2>/dev/null; then
+    sed -i 's@<Setting type="10" key="DownloadInPlaceDir" value=.*@<Setting type="10" key="DownloadInPlaceDir" value="C:\\Program Files (x86)\\Origin Games\\"/>@' "${WINEPREFIX}/drive_c/users/${USER}/Application Data/Origin/local.xml.old" || w_warn 'Workaround for Download path was not applied, because expected setting is not used.'
+  else true ; fi)
+
+}
+
+#----------------------------------------------------------------
+
 w_metadata steam apps \
     title="Steam" \
     publisher="Valve" \
@@ -15057,16 +15433,31 @@ w_metadata uplay apps \
     year="2013" \
     media="download" \
     file1="UplayInstaller.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Ubisoft/Ubisoft Game Launcher/Uplay.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Ubisoft/Ubisoft Game Launcher/Uplay.exe"
 
 load_uplay()
 {
-    # Changes too frequently, don't check anymore
-    w_download https://static3.cdn.ubi.com/orbit/launcher_installer/UplayInstaller.exe
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    # Changes too frequently, dont check anymore
+    w_download 'https://ubistatic3-a.akamaihd.net/orbit/releases/winxp/installer/UplayInstaller.exe'
+    # New installer has issues with rendering on wine <4.15
+    #w_download https://static3.cdn.ubi.com/orbit/launcher_installer/UplayInstaller.exe
+
+    # Get workarounds
+    w_call 'corefonts'
+    # Required for client to open #1249 (winetricks)
+    w_set_app_winver 'upc.exe' 'winvista'
+    w_set_app_winver 'UbisoftGameLauncher.exe' 'winvista'
+    w_set_app_winver 'UbisoftGameLauncher64.exe' 'winvista'
+    w_set_app_winver 'Uplay.exe' 'winvista'
+    w_set_app_winver 'UplayService.exe' 'winvista'
+    w_set_app_winver 'UplayWebCore.exe' 'winvista'
+    w_set_app_winver 'UWebCore.exe' 'winvista'
+    w_set_app_winver 'Ubisoft Game Launcupc.exe' 'winvista'
+
+    w_warn "Launcher will output critical error which is non-fatal, press \"OK\" and ignore it."
 
     # NSIS installer
-    w_try "$WINE" UplayInstaller.exe ${W_OPT_UNATTENDED:+ /S}
+    w_try "${WINE}" "${W_CACHE}/uplay/UplayInstaller.exe" "${W_OPT_UNATTENDED:+ /S}"
 }
 
 #----------------------------------------------------------------
@@ -17971,6 +18362,76 @@ load_hordesoforcs2_demo()
 
 #----------------------------------------------------------------
 
+# https://appdb.winehq.org/objectManager.php?sClass=version&iId=37229
+
+w_metadata mtg_arena games \
+    title="Magic: The Gathering arena" \
+    publisher="Wizards of the Coast" \
+    year="2019" \
+    media="download" \
+    installed_exe1="$W_PROGRAMS_X86_WIN/Wizards of the Coast/MTGA/MTGA.exe"
+
+load_mtg_arena()
+{
+  w_die "ping MTGA"
+  # https://bugs.winehq.org/show_bug.cgi?id=45937#c13
+  if w_workaround_wine_bug 45937; then
+    w_call 'usetakefocus=disabled'
+  fi
+
+  # https://bugs.winehq.org/show_bug.cgi?id=47820
+  if w_workaround_wine_bug 47820; then
+    # Credit: ZeroPointEnergy (https://appdb.winehq.org/objectManager.php?sClass=version&iId=37229)
+    w_warn "This may take a while to load"
+    w_download "https://mtgarena.downloads.wizards.com/Live/Windows32/versions/1790.733462/MTGAInstaller_0.1.1790.733462.msi"
+    export file1="MTGAInstaller_0.1.1790.733462.msi"
+    w_warn "Installer is going to complain about permssions set on windows, these doesn't seem to be related to WINE and doesn't affect the runtime of game"
+  elif ! w_workaround_wine_bug 47820; then
+    w_download "https://mtgarena.downloads.wizards.com/Live/Windows32/MTGAInstaller.exe"
+    export file1="MTGAInstaller.msi"
+  fi
+
+  # https://bugs.winehq.org/show_bug.cgi?id=45898
+  if w_workaround_wine_bug 45898; then
+    w_warn "Affected by https://bugs.winehq.org/show_bug.cgi?id=45898"
+  fi
+
+  # https://bugs.winehq.org/show_bug.cgi?id=45546
+  if w_workaround_wine_bug 45546; then
+    w_warn "We are using hack patch from 45546 which could cause a runtime issues, if this happends then you are encouraged to report this to winetricks"
+    if [ -n "$WINETRICKS_BUILD_WINE" ]; then
+      w_warn "We are about to build a wine from source and package it in AppImage"
+      wineappimagebuilder_patches() {
+        w_download "https://bugs.winehq.org/attachment.cgi?id=62956" '' "$W_CACHE/$W_PACKAGE/62956.diff"
+
+        if ! grep -qF "for (i = 0; i < 2000; i++)" "$wineappimagebuilder_workdir/wine-4.17/dlls/ntdll/thread.c"; then
+          patch "$wineappimagebuilder_workdir/wine-4.17/dlls/ntdll/thread.c" "$W_CACHE/$W_PACKAGE/62956.diff" || w_die "Failed to apply patch in '$wineappimagebuilder_workdir/wine-4.17/dlls/ntdll/thread.c'"
+        elif grep -qF "for (i = 0; i < 2000; i++)" "$wineappimagebuilder_workdir/wine-4.17/dlls/ntdll/thread.c"; then
+          w_debug "Patch for 45546 is already applied"
+        else w_die "Unexpected output in wineappimagebuilder_patches function"
+        fi
+      }
+      load_wineappimagebuilder
+    elif [ -z "$WINETRICKS_BUILD_WINE" ]; then
+      w_download "https://github.com/Kreyren/kreytricks/releases/download/7f230d2/MTGA.AppImage"
+
+      if [ -e "$W_CACHE/$W_PACKAGE/$W_PACKAGE.AppImage" ]; then export WINE="$W_CACHE/$W_PACKAGE/$W_PACKAGE.AppImage"
+      elif [ -e "$W_CACHE/$W_PACKAGE/MTGA.AppImage" ]; then export WINE="$W_CACHE/$W_PACKAGE/$W_PACKAGE.AppImage"
+      elif [ ! -e "$W_CACHE/$W_PACKAGE/$W_PACKAGE.AppImage" ] && [ ! -e "$W_CACHE/$W_PACKAGE/MTGA.AppImage" ]; then w_die "Precompiled WINE wasn't downloaded"
+      else w_die "Unexpected error for workaround 45546 in WINE logic"
+      fi
+    fi
+
+    # Sanitycheck for applied patches
+    [ "$WINE" != "$W_CACHE/$W_PACKAGE/MTGA.AppImage" ] && [ "$WINE" != "$W_CACHE/$W_PACKAGE/$W_PACKAGE.AppImage" ] && w_die "This installer requires patched wine named MTGA.AppImage' or '$W_PACKAGE.AppImage' from '$W_CACHE/$W_PACKAGE/' provide this path to the WINE variable and execute the script again. (You can also blacklist winebug 45546)"
+  fi
+
+  w_warn "It may take few seconds for installer to launch (max 50sec)"
+  (WINEDEBUG="fixme-all" w_try "$WINE" msiexec /i "$W_CACHE/$W_PACKAGE/$file1")
+}
+
+#----------------------------------------------------------------
+
 w_metadata mfsxde games \
     title="Microsoft Flight Simulator X: Deluxe Edition" \
     publisher="Microsoft" \
@@ -18429,7 +18890,7 @@ load_leagueoflegends()
           'SEA   - South East Asia' \
           '' \
           "Note that this can be overwritten by 'leagueoflegends_region' variable"
-        read -r leagueoflegends_region
+        read -r 'leagueoflegends_region'
       done
 
       ## Actual fetch
@@ -18519,13 +18980,12 @@ load_leagueoflegends()
           [ -z "$leagueoflegends_do_not_die_on_dxvk" ] && w_die "'$1' is not implemented for this game (uses dxd9), set 'leagueoflegends_do_not_die_on_dxvk' variable to non-zero to overwrite"
           w_call 'dxvk'
         ;;
-        dxv9)
-          w_die "FIXME: '$1' is not implemented for this game"
-          w_call 'dxv9'
+        d9vk)
+          w_call 'd9vk'
         ;;
         dgvoodoo2)
         # Get dgVoodoo2 only to wrap dxd9 to dxd10/11
-        [ -z "$leagueoflegends_force_dgvoodoo2" ] && case "$(winetricks_get_platform)" in nix_*) w_die "Verb '$1' is not supported on '$(winetricks_get_platform)' since dxd10/11 is not supported without DXVK, use 'leagueoflegends_force_dgvoodoo2' variable set on non-zero to overwrite" ; esac
+        [ -z "$leagueoflegends_force_dgvoodoo2" ] && case "$(winetricks_getplatform)" in nix*) w_die "Verb '$1' is not supported on '$(winetricks_get_platform)' since dxd10/11 is not supported without DXVK, use 'leagueoflegends_force_dgvoodoo2' variable set on non-zero to overwrite" ; esac
 
         # TODO: START - Fix duplicates
         [ ! -e "${W_CACHE}/leagueoflegends/dgVoodoo2_62.zip" ] && w_download 'http://www.dege.freeweb.hu/dgVoodoo2/dgVoodoo2_62.zip' 'dcb00b795e138af71f712bf6c276795786ef373165f28589b44f27b14b4c62c7'
@@ -18897,11 +19357,14 @@ load_masseffect2_demo()
 
     # Don't let self-extractor write into $W_CACHE
     case "$W_PLATFORM" in
-        windows_cmd|wine_cmd)
+        windows_cygwin|wine_cmd)
             cp "$W_CACHE/$W_PACKAGE/MassEffect2DemoEN.exe" "$W_TMP"
-            chmod +x "$W_TMP"/MassEffect2DemoEN.exe ;;
-        *)
-            ln -sf "$W_CACHE/$W_PACKAGE/MassEffect2DemoEN.exe" "$W_TMP" ;;
+            chmod +x "$W_TMP"/MassEffect2DemoEN.exe
+        ;;
+        windows_windows) w_die "Platform '$W_PLATFORM' is not implemented in load_masseffect2_demo()" ;;
+        nix_linux|nix_freebsd|nix_darwin) ln -sf "$W_CACHE/$W_PACKAGE/MassEffect2DemoEN.exe" "$W_TMP" ;;
+        nix_redox) w_die "Platform '$W_PLATFORM' is not implemented in load_masseffect2_demo()" ;;
+        *) w_die "Unknown platform '$W_PLATFORM' parsed in load_masseffect2_demo()"
     esac
     w_try_cd "$W_TMP"
     w_ahk_do "
@@ -20112,7 +20575,7 @@ w_metadata sammax301_demo games \
     year="2010" \
     media="manual_download" \
     file1="SamMax301_PC_Setup.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Telltale Games/Sam and Max - The Devil's Playhouse/The Penal Zone/SamMax301.exe"
+    installed_exe1="$W_PROGRAMS_X86_WIN/Telltale Games/Sam and Max - The Devil\'s Playhouse/The Penal Zone/SamMax301.exe"
 
 load_sammax301_demo()
 {
@@ -20525,6 +20988,62 @@ load_wog()
 }
 
 #----------------------------------------------------------------
+# Origin Games
+#----------------------------------------------------------------
+
+# https://appdb.winehq.org/appview.php?iVersionId=4242
+
+# Help-wanted: Dunno how to make metadata for this
+w_metadata cnc_redalert2yr_origin games \
+    title="Command & Conquer Red Alert 2 and Yuris Revenge" \
+    publisher="EA Games" \
+    year="2001" \
+    media="download" \
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Origin Games/Command and Conquer Red Alert II/RA2Launcher.exe"
+
+load_cnc_redalert2yr_origin()
+{
+    w_origin_install_game "OFB-EAST:52019"
+
+    # WINSOCK.dll
+    ## Sanity for directory in W_CACHE
+    [ ! -e "${W_CACHE}/cnc_redalert2yr_origin" ] && (mkdir "${W_CACHE}/cnc_redalert2yr_origin" || w_die "Unable to make a new directory in '${W_CACHE}/cnc_redalert2yr_origin'")
+
+    ## Fetch
+    if [ ! -e '/tmp/winetricks/ts_ra2_lanpatch_1_00 UDP no IPX win 7.zip' ]; then
+      wget 'https://www.sevenforums.com/attachments/gaming/88684d1280671096-command-conquer-red-alert-2-yuris-revenge-lan-ts_ra2_lanpatch_1_00-udp-no-ipx-win-7.zip' -O '/tmp/winetricks/ts_ra2_lanpatch_1_00 UDP no IPX win 7.zip' || w_die "Unable to download required libraries"
+    fi
+
+    ## Unzip to W_CACHE
+    [ ! -e "${W_CACHE}/cnc_redalert2yr_origin/wsock32.dll" ] && (unzip '/tmp/winetricks/ts_ra2_lanpatch_1_00 UDP no IPX win 7.zip' -d "${W_CACHE}/cnc_redalert2yr_origin/" || w_die "Unable to extract required files in '${W_CACHE}/cnc_redalert2yr_origin/' from '/tmp/winetricks/ts_ra2_lanpatch_1_00 UDP no IPX win 7.zip'")
+
+    ## Export of library
+    if [ -d "${W_PROGRAMS_X86_WIN}/Origin Games/Command and Conquer Red Alert II/" ] && [ -e "${W_CACHE}/cnc_redalert2yr_origin/wsock32.dll" ]; then
+      cp "${W_CACHE}/cnc_redalert2yr_origin/wsock32.dll" "${W_PROGRAMS_X86_WIN}/Origin Games/Command and Conquer Red Alert II/" || w_die "Unable to copy '${W_CACHE}/cnc_redalert2yr_origin/wsock32.dll' to '${W_PROGRAMS_X86_WIN}/Origin Games/Command and Conquer Red Alert II/' to use required library for game"
+    elif [ ! -d "${W_PROGRAMS_X86_WIN}/Origin Games/Command and Conquer Red Alert II/" ]; then
+      w_die "Unable to export required libraries, because game is not installed"
+    elif [ -e "${W_CACHE}/cnc_redalert2yr_origin/wsock32.dll" ]; then
+      w_warn "wsock.dll is alredy extracted, skipping..."
+    fi
+}
+
+#----------------------------------------------------------------
+# Uplay Games
+#----------------------------------------------------------------
+
+w_metadata splintercell_blacklist_uplay games \
+    title="Tom Clancy Splinter Cell: Blacklist (Uplay)" \
+    publisher="Ubisoft" \
+    year="2013" \
+    media="download" \
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Ubisoft/Ubisoft Game Launcher/games/Splinter Cell Blacklist/Blacklist_Launcher.exe"
+
+load_splintercell_blacklist_uplay() {
+    w_call dxvk
+    w_uplay_install_game '91'
+}
+
+#----------------------------------------------------------------
 # Steam Games
 #----------------------------------------------------------------
 
@@ -20605,6 +21124,22 @@ load_civ5_demo_steam()
         w_info "If you already own the full Civ 5 game on Steam, the installer won't even appear."
     w_steam_install_game 65900 "Sid Meier's Civilization V - Demo"
     kill -s HUP "$_job"   # just in case
+}
+
+#----------------------------------------------------------------
+
+w_metadata mafia2_steam games \
+    title="Mafia II (Steam, non-free)" \
+    publisher="2K Games" \
+    year="2009" \
+    media="download" \
+    installed_exe1="$W_PROGRAMS_X86_WIN/Steam/steamapps/common/Mafia II/launcher.exe"
+
+load_mafia2_steam()
+{
+    w_call 'vcrun2012'
+    w_call 'dxvk'
+    w_steam_install_game 50130 "Mafia II"
 }
 
 #----------------------------------------------------------------
@@ -21807,36 +22342,36 @@ winetricks_stats_init()
         case $WINETRICKS_GUI in
             zenity)
                 case $LANG in
-                de*)
-                    title="Einmalige Frage zur Hilfe an der Winetricks Entwicklung"
-                    question="Möchten Sie die Winetricks Entwicklung unterstützen indem Sie Winetricks Statistiken übermitteln lassen? Sie können die Übermittlung jederzeit mit 'winetricks --optout' ausschalten"
-                    thanks="Danke! Sie bekommen diese Frage nicht mehr gestellt. Sie können die Übermittlung jederzeit mit 'winetricks --optout' wieder ausschalten"
-                    declined="OK, Winetricks wird *keine* Statistiken übermitteln. Sie bekommen diese Frage nicht mehr gestellt."
-                    ;;
-                pl*)
-                    title="Jednorazowe pytanie dotyczące pomocy w rozwoju Winetricks"
-                    question="Czy chcesz pomóc w rozwoju Winetricks pozwalając na wysyłanie statystyk przez program? Możesz wyłączyć tą opcję w każdej chwili z użyciem komendy 'winetricks --optout'."
-                    thanks="Dziękujemy! Nie otrzymasz już tego pytania. Pamiętaj, ze możesz wyłączyć tą opcję komendą 'winetricks --optout'"
-                    declined="OK, Winetricks *nie* będzie wysyłać statystyk. Nie otrzymasz już tego pytania."
-                    ;;
-                ru*)
-                    title="Помощь в разработке Winetricks"
-                    question="Вы хотите помочь разработке winetricks, отправляя статистику? Вы можете отключить отправку статистики в любое время с помощью команды 'winetricks --optout'"
-                    thanks="Спасибо! Этот вопрос больше не появится. Помните: вы можете отключить отправку статистики в любое время с помощью команды 'winetricks --optout'"
-                    declined="OK, winetricks НЕ будет отправлять статистику. Этот вопрос больше не появится."
-                    ;;
-                uk*)
-                    title="Допомога в розробці Winetricks"
-                    question="Ви хочете допомогти в розробці Winetricks дозволивши звітувати статистику?\\nВи можете в будь-який час вимкнути цю опцію за допомогою команди 'winetricks --optout'"
-                    thanks="Дякуємо! Ви більше не отримуватиме це питання знову. Пам'ятайте, що ви можете будь-коли вимкнути звітність за допомогою команди 'winetricks --optout'"
-                    declined="Надсилання звітності Winetricks вимкнено. Ви більше не отримуватиме це питання знову."
-                    ;;
-                *)
-                    title="One-time question about helping Winetricks development"
-                    question="Would you like to help winetricks development by letting winetricks report statistics? You can turn reporting off at any time with the command 'winetricks --optout'"
-                    thanks="Thanks! You won't be asked this question again. Remember, you can turn reporting off at any time with the command 'winetricks --optout'"
-                    declined="OK, winetricks will *not* report statistics. You won't be asked this question again."
-                    ;;
+                    de*)
+                        title="Einmalige Frage zur Hilfe an der Winetricks Entwicklung"
+                        question="Möchten Sie die Winetricks Entwicklung unterstützen indem Sie Winetricks Statistiken übermitteln lassen? Sie können die Übermittlung jederzeit mit 'winetricks --optout' ausschalten"
+                        thanks="Danke! Sie bekommen diese Frage nicht mehr gestellt. Sie können die Übermittlung jederzeit mit 'winetricks --optout' wieder ausschalten"
+                        declined="OK, Winetricks wird *keine* Statistiken übermitteln. Sie bekommen diese Frage nicht mehr gestellt."
+                        ;;
+                    pl*)
+                        title="Jednorazowe pytanie dotyczące pomocy w rozwoju Winetricks"
+                        question="Czy chcesz pomóc w rozwoju Winetricks pozwalając na wysyłanie statystyk przez program? Możesz wyłączyć tą opcję w każdej chwili z użyciem komendy 'winetricks --optout'."
+                        thanks="Dziękujemy! Nie otrzymasz już tego pytania. Pamiętaj, ze możesz wyłączyć tą opcję komendą 'winetricks --optout'"
+                        declined="OK, Winetricks *nie* będzie wysyłać statystyk. Nie otrzymasz już tego pytania."
+                        ;;
+                    ru*)
+                        title="Помощь в разработке Winetricks"
+                        question="Вы хотите помочь разработке winetricks, отправляя статистику? Вы можете отключить отправку статистики в любое время с помощью команды 'winetricks --optout'"
+                        thanks="Спасибо! Этот вопрос больше не появится. Помните: вы можете отключить отправку статистики в любое время с помощью команды 'winetricks --optout'"
+                        declined="OK, winetricks НЕ будет отправлять статистику. Этот вопрос больше не появится."
+                        ;;
+                    uk*)
+                        title="Допомога в розробці Winetricks"
+                        question="Ви хочете допомогти в розробці Winetricks дозволивши звітувати статистику?\\nВи можете в будь-який час вимкнути цю опцію за допомогою команди 'winetricks --optout'"
+                        thanks="Дякуємо! Ви більше не отримуватиме це питання знову. Пам'ятайте, що ви можете будь-коли вимкнути звітність за допомогою команди 'winetricks --optout'"
+                        declined="Надсилання звітності Winetricks вимкнено. Ви більше не отримуватиме це питання знову."
+                        ;;
+                    *)
+                        title="One-time question about helping Winetricks development"
+                        question="Would you like to help winetricks development by letting winetricks report statistics? You can turn reporting off at any time with the command 'winetricks --optout'"
+                        thanks="Thanks! You won't be asked this question again. Remember, you can turn reporting off at any time with the command 'winetricks --optout'"
+                        declined="OK, winetricks will *not* report statistics. You won't be asked this question again."
+                        ;;
                 esac
                 if $WINETRICKS_GUI --question --text "$question" --title "$title"; then
                     $WINETRICKS_GUI --info --text "$thanks"
@@ -21852,14 +22387,11 @@ winetricks_stats_init()
 }
 
 # Retrieve a short string with the operating system name and version
+# Obsolete by winetricks_get_platform
 winetricks_os_description()
 {
-    (
-        case "$W_PLATFORM" in
-            windows_cmd) echo "windows" ;;
-            *)  echo "$WINETRICKS_WINE_VERSION" ;;
-        esac
-    ) | tr '\012' ' '
+    w_warn "Function 'winetricks_os_description' is obsolete by 'winetricks_get_platform'"
+    winetricks_get_platform
 }
 
 winetricks_stats_report()
@@ -21877,7 +22409,7 @@ winetricks_stats_report()
     WINETRICKS_STATS_BREADCRUMBS=$(tr '\012' ' ' < "$WINETRICKS_WORKDIR"/breadcrumbs)
     echo "You opted in, so reporting '$WINETRICKS_STATS_BREADCRUMBS' to the winetricks maintainer so he knows which winetricks verbs get used and which don't.  Use --optout to disable future reports."
 
-    report="os=$(winetricks_os_description)&winetricks=$WINETRICKS_VERSION&breadcrumbs=$WINETRICKS_STATS_BREADCRUMBS"
+    report="os=$(winetricks_get_platform)&winetricks=$WINETRICKS_VERSION&breadcrumbs=$WINETRICKS_STATS_BREADCRUMBS"
     report="$(echo "$report" | sed 's/ /%20/g')"
 
     # Just do a HEAD request with the raw command line.
@@ -21914,8 +22446,11 @@ winetricks_stats_log_command()
 
     # and for the user's own reference later, when figuring out what he did
     case "$W_PLATFORM" in
-        windows_cmd) _W_LOGDIR="$W_WINDIR_UNIX"/Temp ;;
-        *) _W_LOGDIR="$WINEPREFIX" ;;
+        windows_cygwin) _W_LOGDIR="$W_WINDIR_UNIX"/Temp ;;
+        windows_windows) w_die "Platform '$W_PLATFORM' is not implemented in winetricks_stats_log_command()" ;;
+        nix_linux|nix_freebsd|nix_darwin) _W_LOGDIR="$WINEPREFIX" ;;
+        nix_redox) w_die "Platform '$W_PLATFORM' is not implemented in winetricks_stats_log_command()" ;;
+        *) w_die "Unknown platform '$W_PLATFORM' parsed in winetricks_stats_log_command()"
     esac
 
     mkdir -p "$_W_LOGDIR"
@@ -22073,13 +22608,32 @@ execute_command()
             if winetricks_metadata_exists "$1"; then
                 w_call "$1"
             else
-                echo "Unknown arg $1"
                 winetricks_usage
-                exit 1
+                w_die "Unknown argument has been parsed: '$1'"
             fi
             ;;
     esac
 }
+
+# FIXME: XDG_CACHE_HOME is defined twice, clean this up
+XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+
+W_COUNTRY=""
+W_PREFIXES_ROOT="${WINE_PREFIXES:-$XDG_DATA_HOME/wineprefixes}"
+
+# For temp files before $WINEPREFIX is available:
+if [ -x "$(command -v mktemp 2>/dev/null)" ] ; then
+    W_TMP_EARLY="$(mktemp -d "${TMPDIR:-/tmp}/winetricks.XXXXXXXX")"
+elif [ -w "$TMPDIR" ] ; then
+    W_TMP_EARLY="$TMPDIR"
+else
+    W_TMP_EARLY="/tmp"
+fi
+
+# Test whether temporary directory is valid - before initialising script
+[ -d "$W_TMP_EARLY" ] || w_die "temporary directory: '$W_TMP_EARLY' ; does not exist"
+[ -w "$W_TMP_EARLY" ] || w_die "temporary directory: '$W_TMP_EARLY' ; is not user writeable"
 
 if ! test "$WINETRICKS_LIB"
 then
@@ -22095,6 +22649,7 @@ then
 
     case "$1" in
         die) w_die "we who are about to die salute you." ;;
+        kreyren) w_die "`winetricks_get_platform`" ;;
         volnameof=*)
             # Debug code.  Remove later?
             # Since Linux's volname command can't handle DVDs, winetricks has its own,
@@ -22108,13 +22663,13 @@ then
             ;;
         "")
             if [ -z "$DISPLAY" ]; then
-                if [ "$(uname -s)" = "Darwin" ]; then
-                    echo "Running on OSX, but DISPLAY is not set...probably using Mac Driver."
-                else
-                    echo "DISPLAY not set, not defaulting to gui"
-                    winetricks_usage
-                    exit 0
-                fi
+                case "$(winetricks_get_platform)" in
+                    nix_darwin) w_info "Running on OSX, but DISPLAY is not set...probably using Mac Driver." ;;
+                    *)
+                        w_info "DISPLAY not set, not defaulting to gui"
+                        winetricks_usage
+                        exit 0
+                esac
             fi
 
             # GUI case
@@ -22125,9 +22680,9 @@ then
             while true
             do
                 case $WINETRICKS_CURMENU in
-                    main) verbs=$(winetricks_mainmenu) ;;
+                    main) verbs="$(winetricks_mainmenu)" ;;
                     prefix)
-                        verbs=$(winetricks_prefixmenu);
+                        verbs="$(winetricks_prefixmenu)";
                         # Cheezy hack: choosing 'attended' or 'unattended' leaves you in same menu
                         case "$verbs" in
                             attended) winetricks_set_unattended 0 ; continue;;
@@ -22165,8 +22720,7 @@ then
                             # after picking a prefix, want to land in main.
                             WINETRICKS_CURMENU=main ;;
                         *)
-                            for verb in $verbs
-                            do
+                            for verb in $verbs; do
                                 execute_command "$verb"
                             done
 

--- a/src/winetricks
+++ b/src/winetricks
@@ -18378,6 +18378,95 @@ load_lswcs()
 
 #----------------------------------------------------------------
 
+# https://appdb.winehq.org/objectManager.php?sClass=application&iId=10436
+
+w_metadata leagueoflegends games \
+    title='League of Legends' \
+    publisher='Riot Games, Inc.' \
+    year='2009' \
+    media='download' \
+    file1="${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe"
+
+load_leagueoflegends()
+{
+  # Fetch installer
+  leagueoflegends_fetch()
+  {
+    # Game has multiple regions and this logic allows end-user to choose it's preffered
+    ## TODO: Add Logic for region selection if $W_OPT_UNATTENDED is parsed
+    [ -n "$W_OPT_UNATTENDED" ] && [ -n "$leagueoflegends_region" ] && w_warn "hotfixed, using EUNE region for download" && export leagueoflegends_region="EUNE"
+
+    until case "$leagueoflegends_region" in ( EUNE | EUW | NA | BR | LAN | LAS | OCE | RU | JP | SEA ) :;; ( * ) ! :; esac; do
+      printf "%s\n" \
+        'Select your region for League Of Legends installer:' \
+        'EUNE  - Europe Nordic and East' \
+        'NA    - North America' \
+        'EUW   - Europe West' \
+        'BR    - Brazil' \
+        'AN    - Latin America North' \
+        'LAS   - Latin America South' \
+        'OCE   - Oceania' \
+        'RU    - Russia' \
+        'TR    - Turkey' \
+        'JP    - Japan' \
+        'SEA   - South East Asia' \
+        '' \
+        "Note that this can be overwritten by 'leagueoflegends_region' variable"
+      read -r leagueoflegends_region
+    done
+
+    ## Actual fetch
+    [ ! -e "${W_CACHE}/leagueoflegends/League%20of%20Legends%20installer%20${leagueoflegends_region}.exe" ] && w_download "https://riotgamespatcher-a.akamaihd.net/releases/live/installer/deploy/League%20of%20Legends%20installer%20${leagueoflegends_region}.exe"
+  }
+
+  # Workaround for pakman violation after champion select using WINE precompiled binary
+  # https://bugs.winehq.org/show_bug.cgi?id=47198
+  # TODO: Use AHK to install the game automatically
+  # TODO: Login using AHK
+  leagueoflegends_workaround_47198()
+  {
+    w_info "Applying workaround to winebug 47198 using precompiled WINE binary by mmtrt, skip this by using WINETRICKS_BLACKLIST variable if needed"
+
+    ## Logic for WINE binary executable
+    # shellcheck disable=SC2154
+    case "$1" in
+      arch)
+        [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage'
+        export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage"
+      ;;
+      bionic) # Prefer bionic since that seems to be more reliable
+        [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-bionic.AppImage'
+        export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage"
+      ;;
+      *) w_die "Function leagueoflegends_workaround_47198 was called, but nothing was parsed"
+      ;;
+    esac
+
+    # Sanity check for executable permissions
+    [ ! -x "$WINE" ] && chmod +x "$WINE"
+  }
+
+  # Game won't launch due https://bugs.winehq.org/show_bug.cgi?id=47198
+  if w_workaround_wine_bug 47198 "Using patched wine binary" ; then leagueoflegends_workaround_47198 bionic ; fi
+
+  # Install
+  if [ ! -e "${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe" ]; then
+     leagueoflegends_fetch
+     (
+        [ -z "$WINEDEBUG" ] && export WINEDEBUG="fixme-all"
+        w_try "$WINE" "${W_CACHE}/leagueoflegends/League%20of%20Legends%20installer%20${leagueoflegends_region}.exe"
+     )
+     return 0
+
+  # Run if already installed
+  elif [ -e "${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe" ]; then
+    w_info "League Of Legends is already installed in $WINEPREFIX, executing.."
+    w_try "$WINE" "${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe"
+  fi
+}
+
+#----------------------------------------------------------------
+
 w_metadata lemonysnicket games \
     title="Lemony Snicket: A Series of Unfortunate Events" \
     publisher="Activision" \

--- a/src/winetricks
+++ b/src/winetricks
@@ -18380,15 +18380,32 @@ load_lswcs()
 
 # https://appdb.winehq.org/objectManager.php?sClass=application&iId=10436
 
+# TODO: Fetch this from wikipedia
 w_metadata leagueoflegends games \
     title='League of Legends' \
     publisher='Riot Games, Inc.' \
+    developer='Riot Games, Inc.' \
+    director='Tom Cadwell' \
     year='2009' \
-    media='download' \
-    file1="${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe"
+    media='download'
+
+    # file1="League%20of%20Legends%20installer%20EUNE.exe" \
+    # file2="League%20of%20Legends%20installer%20EUW.exe" \
+    # file3="League%20of%20Legends%20installer%20NA.exe" \
+    # file4="League%20of%20Legends%20installer%20BR.exe" \
+    # file5="League%20of%20Legends%20installer%20AN.exe" \
+    # file6="League%20of%20Legends%20installer%20LAS.exe" \
+    # file7="League%20of%20Legends%20installer%20OCE.exe" \
+    # file8="League%20of%20Legends%20installer%20RU.exe" \
+    # file9="League%20of%20Legends%20installer%20TR.exe" \
+    # file10="League%20of%20Legends%20installer%20JP.exe" \
+    # file11="League%20of%20Legends%20installer%20SEA.exe" \
+    # installed_exe1="${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe"
 
 load_leagueoflegends()
 {
+    # FUNCTIONS
+
     # Fetch installer
     leagueoflegends_fetch()
     {
@@ -18431,28 +18448,40 @@ load_leagueoflegends()
       w_info "You can overwrite 'leagueoflegends_workaround_47198' variable to use different precompiled wine"
       [ -z "$leagueoflegends_workaround_47198" ] && export leagueoflegends_workaround_47198="$1"
 
+      # Patch is meant to be used on win32
+      w_package_unsupported_win64
+
       ## Logic for WINE binary executable
       # shellcheck disable=SC2154
       case "$leagueoflegends_workaround_47198" in
         arch)
           # 24/09/2019: continous (sha256sum wine-staging-i386_lol-patched_x86_64-archlinux.AppImage) sha256sum 279e00ce270d4eac3a57a5441787dfd3c78ec26fedf5a9e2f29c5362f74aa75f
           [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage' '279e00ce270d4eac3a57a5441787dfd3c78ec26fedf5a9e2f29c5362f74aa75f'
-          export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage"
+          # FIX-ME: Winetricks doesn't allow seting this prior to making wineprefix
+          #export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage"
+          export used_wine="wine-staging-i386_lol-patched_x86_64-archlinux.AppImage"
         ;;
         arch-zsync)
           # 24/09/2019: continous (sha256sum wine-staging-i386_lol-patched_x86_64-archlinux.AppImage.zsync) sha256sum 8b74b6394e7db313375357c56195ba4680e47770d8253413eb641ff3db3cf6b9
           [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage.zsync" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage.zsync' '8b74b6394e7db313375357c56195ba4680e47770d8253413eb641ff3db3cf6b9'
-          export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage"
+          # FIX-ME: Winetricks doesn't allow seting this prior to making wineprefix
+          #export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage"
+          export used_wine="wine-staging-i386_lol-patched_x86_64-archlinux.AppImage.zsync"
         ;;
         bionic) # Prefer bionic since that seems to be more reliable
           # 24/09/2019: continous (sha256sum wine-staging-i386_lol-patched_x86_64-bionic.AppImage) sha256sum 01bcd44d10ba275336953347baa9578daca5830644ac67b2ab73564a46c2d70c
           [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-bionic.AppImage' '01bcd44d10ba275336953347baa9578daca5830644ac67b2ab73564a46c2d70c'
-          export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage"
+          # FIX-ME: Winetricks doesn't allow seting this prior to making wineprefix
+          #export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage"
+          export used_wine="wine-staging-i386_lol-patched_x86_64-bionic.AppImage"
         ;;
         bionic-zsync) # Prefer bionic since that seems to be more reliable
           # 24/09/2019: continous (sha256sum wine-staging-i386_lol-patched_x86_64-bionic.AppImage.zsync) sha256sum 8b74b6394e7db313375357c56195ba4680e47770d8253413eb641ff3db3cf6b9
           [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage.zsync" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-bionic.AppImage.zsync' '8b74b6394e7db313375357c56195ba4680e47770d8253413eb641ff3db3cf6b9'
-          export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage"
+          used_wine="wine-staging-i386_lol-patched_x86_64-bionic.AppImage.zsync"
+          # FIX-ME: Winetricks doesn't allow seting this prior to making wineprefix
+          #export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage"
+          export used_wine="wine-staging-i386_lol-patched_x86_64-bionic.AppImage"
         ;;
         none)
           w_info "workaround to winebug 47198 has been disabled by end-user"
@@ -18461,7 +18490,10 @@ load_leagueoflegends()
       esac
 
       # Sanity check for executable permissions
-      [ ! -x "$WINE" ] && chmod +x "$WINE"
+      [ ! -x "$used_wine" ] && chmod +x "$used_wine"
+
+      # HOTFIX: winetricks is unable to use different wine on startup
+      [ "$WINE" != "${W_CACHE}/leagueoflegends/$used_wine" ] && w_die "This installer requires patched wine, remove your current WINEPREFIX ($WINEPREFIX) if it was created using 64-bit wine and set WINE variable on '${W_CACHE}/leagueoflegends/$used_wine' and start again. (fix-me: allow winetricks to use different wine by default)"
     }
 
     # Default WINEPREFIX
@@ -18469,37 +18501,46 @@ load_leagueoflegends()
     leagueoflegends_default_wineprefix()
     {
       leagueoflegends_fetch # Get variables
-      [ -z "$leagueoflegends_region" ] && w_warn "Variable leagueoflegends_region was parsed as blank which is unexpected"
-      [ "$WINEPREFIX" = "${HOME}/.wine" ] || [ -z "$WINEPREFIX" ] && export WINEPREFIX="${HOME}/.local/share/wineprefixes/leagueoflegends-$leagueoflegends_region"
-    }; leagueoflegends_default_wineprefix
 
-    # Game won't launch due https://bugs.winehq.org/show_bug.cgi?id=47198
-    if w_workaround_wine_bug 47198 "Using patched wine binary" ; then leagueoflegends_workaround_47198 bionic ; fi
+      [ -z "$leagueoflegends_region" ] && w_die "Variable leagueoflegends_region was parsed as blank which is unexpected"
+
+      [ "$WINEPREFIX" = "${HOME}/.wine" ] || [ -z "$WINEPREFIX" ] && w_warn "Default WINEPREFIX is used where recommended prefix is '${HOME}/.local/share/wineprefixes/leagueoflegends-$leagueoflegends_region'"
+    }
 
     # Vulkan/DX11/DX10 wrapper
-    leagueoflegends_3D_wrapper()
+    leagueoflegends_d3d9_wrapper()
     {
       case "$1" in
         dxvk)
+          w_die "FIXME: '$1' is not implemented for this game"
           w_call 'dxvk'
         ;;
         dxv9)
+          w_die "FIXME: '$1' is not implemented for this game"
           w_call 'dxv9'
         ;;
         dxvk-dgwoodo)
+          w_die "FIXME: '$1' is not implemented for this game"
           w_call 'dxvk'
-          # TODO: export dgwoodo wrapper
+          # TODO: export dgwoodoo wrapper
         ;;
         gallium9|galliumnine)
+          w_die "FIXME: '$1' is not implemented for this game"
           # NOTE: might be worth combining with wrapper for DX10/11/Vulkan
           w_call 'galliumnine'
         ;;
-        none)
-          w_info "Disabled 3D wrapper"
+        ""|none)
+          w_info "DirectX 9 wrapper is not used, use leagueoflegends_d3d9_wrapper variable to overwrite"
         ;;
-        *) w_die "Unexpected argument "$1" in function leagueoflegends_3D_wrapper"
+        *) w_die "Unexpected argument '$1' in function leagueoflegends_3D_wrapper"
       esac
     }
+
+    # ACTION
+    leagueoflegends_default_wineprefix
+
+    # Game won't launch due https://bugs.winehq.org/show_bug.cgi?id=47198
+    if w_workaround_wine_bug 47198 "Using patched wine binary" ; then leagueoflegends_workaround_47198 bionic ; fi
 
     # Install
     if [ ! -e "${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe" ]; then
@@ -18513,7 +18554,8 @@ load_leagueoflegends()
             export WINEARCH="win32"
             [ -e "$WINEPREFIX" ] && [ ! -e "${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe" ] && mv "$WINEPREFIX" "/tmp/winetricks/$WINEPREFIX"
           fi
-          leagueoflegends_3D_wrapper 'dxvk'
+          # shellcheck disable=SC2154
+          leagueoflegends_d3d9_wrapper "$leagueoflegends_d3d9_wrapper"
           w_try "$WINE" "${W_CACHE}/leagueoflegends/League%20of%20Legends%20installer%20${leagueoflegends_region}.exe"
           return 0 # Stop here since leagueoflegends starts itself after installation
        )
@@ -18526,11 +18568,8 @@ load_leagueoflegends()
         [ -z "$WINEDEBUG" ] && export WINEDEBUG="fixme-all"
         if w_workaround_wine_bug '47198'; then
           leagueoflegends_workaround_47198 # get WINE
-          # HOTFIX: winetricks is creating 64-bit wineprefix by default
-          export WINEARCH="win32"
-          [ -e "$WINEPREFIX" ] && [ ! -e "${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe" ] && mv "$WINEPREFIX" "/tmp/winetricks/$WINEPREFIX"
         fi
-        leagueoflegends_3D_wrapper 'dxvk'
+        leagueoflegends_d3d9_wrapper "$leagueoflegends_d3d9_wrapper"
         w_try "$WINE" "${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe"
       )
     fi

--- a/src/winetricks
+++ b/src/winetricks
@@ -18397,7 +18397,7 @@ load_leagueoflegends()
       [ -n "$W_OPT_UNATTENDED" ] && [ -n "$leagueoflegends_region" ] && w_warn "hotfixed, using EUNE region for download" && export leagueoflegends_region="EUNE"
 
       until case "$leagueoflegends_region" in ( EUNE | EUW | NA | BR | LAN | LAS | OCE | RU | JP | SEA ) :;; ( * ) ! :; esac; do
-        printf "%s\n" \
+        printf '%s\n' \
           'Select your region for League Of Legends installer:' \
           'EUNE  - Europe Nordic and East' \
           'NA    - North America' \
@@ -18412,7 +18412,7 @@ load_leagueoflegends()
           'SEA   - South East Asia' \
           '' \
           "Note that this can be overwritten by 'leagueoflegends_region' variable"
-        read -r leagueoflegends_region
+        read -r 'leagueoflegends_region'
       done
 
       ## Actual fetch
@@ -18454,6 +18454,9 @@ load_leagueoflegends()
           [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage.zsync" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-bionic.AppImage.zsync' '8b74b6394e7db313375357c56195ba4680e47770d8253413eb641ff3db3cf6b9'
           export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage"
         ;;
+        none)
+          w_info "workaround to winebug 47198 has been disabled by end-user"
+        ;;
         *) w_die "Unexpected argument '$leagueoflegends_workaround_47198' in function 'leagueoflegends_workaround_47198'"
       esac
 
@@ -18461,22 +18464,71 @@ load_leagueoflegends()
       [ ! -x "$WINE" ] && chmod +x "$WINE"
     }
 
+    # Default WINEPREFIX
+    ## Expecting game to be configured in ${HOME}/.local/share/wineprefixes/leagueoflegends-$leagueoflegends_region if WINEPREFIX is not set instead of ${HOME}/.wine
+    leagueoflegends_default_wineprefix()
+    {
+      leagueoflegends_fetch # Get variables
+      [ -z "$leagueoflegends_region" ] && w_warn "Variable leagueoflegends_region was parsed as blank which is unexpected"
+      [ "$WINEPREFIX" = "${HOME}/.wine" ] || [ -z "$WINEPREFIX" ] && export WINEPREFIX="${HOME}/.local/share/wineprefixes/leagueoflegends-$leagueoflegends_region"
+    }; leagueoflegends_default_wineprefix
+
     # Game won't launch due https://bugs.winehq.org/show_bug.cgi?id=47198
     if w_workaround_wine_bug 47198 "Using patched wine binary" ; then leagueoflegends_workaround_47198 bionic ; fi
+
+    # Vulkan/DX11/DX10 wrapper
+    leagueoflegends_3D_wrapper()
+    {
+      case "$1" in
+        dxvk)
+          w_call 'dxvk'
+        ;;
+        dxv9)
+          w_call 'dxv9'
+        ;;
+        dxvk-dgwoodo)
+          w_call 'dxvk'
+          # TODO: export dgwoodo wrapper
+        ;;
+        none)
+          w_info "Disabled 3D wrapper"
+        ;;
+        *) w_die "Unexpected argument "$1" in function leagueoflegends_3D_wrapper"
+      esac
+    }
 
     # Install
     if [ ! -e "${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe" ]; then
        leagueoflegends_fetch
        (
+          leagueoflegends_default_wineprefix
           [ -z "$WINEDEBUG" ] && export WINEDEBUG="fixme-all"
+          if w_workaround_wine_bug '47198'; then
+            leagueoflegends_workaround_47198 # get WINE
+            # HOTFIX: winetricks is creating 64-bit wineprefix by default
+            export WINEARCH="win32"
+            [ -e "$WINEPREFIX" ] && [ ! -e "${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe" ] && mv "$WINEPREFIX" "/tmp/winetricks/$WINEPREFIX"
+          fi
+          leagueoflegends_3D_wrapper 'dxvk'
           w_try "$WINE" "${W_CACHE}/leagueoflegends/League%20of%20Legends%20installer%20${leagueoflegends_region}.exe"
+          return 0 # Stop here since leagueoflegends starts itself after installation
        )
-       return 0
 
     # Run if already installed
     elif [ -e "${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe" ]; then
       w_info "League Of Legends is already installed in $WINEPREFIX, executing.."
-      w_try "$WINE" "${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe"
+      (
+        leagueoflegends_default_wineprefix
+        [ -z "$WINEDEBUG" ] && export WINEDEBUG="fixme-all"
+        if w_workaround_wine_bug '47198'; then
+          leagueoflegends_workaround_47198 # get WINE
+          # HOTFIX: winetricks is creating 64-bit wineprefix by default
+          export WINEARCH="win32"
+          [ -e "$WINEPREFIX" ] && [ ! -e "${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe" ] && mv "$WINEPREFIX" "/tmp/winetricks/$WINEPREFIX"
+        fi
+        leagueoflegends_3D_wrapper 'dxvk'
+        w_try "$WINE" "${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe"
+      )
     fi
 }
 

--- a/src/winetricks
+++ b/src/winetricks
@@ -18416,6 +18416,7 @@ load_leagueoflegends()
     done
 
     ## Actual fetch
+    ## TODO: Checksum https://boards.na.leagueoflegends.com/en/c/general-discussion/tZ4uPccJ-checksum-for-league-of-legends-installer
     [ ! -e "${W_CACHE}/leagueoflegends/League%20of%20Legends%20installer%20${leagueoflegends_region}.exe" ] && w_download "https://riotgamespatcher-a.akamaihd.net/releases/live/installer/deploy/League%20of%20Legends%20installer%20${leagueoflegends_region}.exe"
   }
 
@@ -18426,7 +18427,7 @@ load_leagueoflegends()
   leagueoflegends_workaround_47198()
   {
     w_info "Applying workaround to winebug 47198 using precompiled WINE binary by mmtrt, skip this by using WINETRICKS_BLACKLIST variable if needed"
-    
+
     w_info "You can overwrite 'leagueoflegends_workaround_47198' variable to use different precompiled wine"
     [ -z "$leagueoflegends_workaround_47198" ] && export leagueoflegends_workaround_47198="$1"
 

--- a/src/winetricks
+++ b/src/winetricks
@@ -18426,14 +18426,20 @@ load_leagueoflegends()
   leagueoflegends_workaround_47198()
   {
     w_info "Applying workaround to winebug 47198 using precompiled WINE binary by mmtrt, skip this by using WINETRICKS_BLACKLIST variable if needed"
+    w_info "You can overwrite 'leagueoflegends_workaround_47198' variable to use different precompiled wine"
+    [ -z "$leagueoflegends_workaround_47198" ] && export leagueoflegends_workaround_47198="$1"
 
     ## Logic for WINE binary executable
     # shellcheck disable=SC2154
-    case "$1" in
+    case "$leagueoflegends_workaround_47198" in
       arch)
         # 24/09/2019: continous (sha256sum wine-staging-i386_lol-patched_x86_64-archlinux.AppImage) sha256sum 279e00ce270d4eac3a57a5441787dfd3c78ec26fedf5a9e2f29c5362f74aa75f
-        # 279e00ce270d4eac3a57a5441787dfd3c78ec26fedf5a9e2f29c5362f74aa75f  Downloads/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage
         [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage' '279e00ce270d4eac3a57a5441787dfd3c78ec26fedf5a9e2f29c5362f74aa75f'
+        export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage"
+      ;;
+      arch-zsync)
+        # 24/09/2019: continous (sha256sum wine-staging-i386_lol-patched_x86_64-archlinux.AppImage.zsync) sha256sum 8b74b6394e7db313375357c56195ba4680e47770d8253413eb641ff3db3cf6b9
+        [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage.zsync" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage.zsync' '8b74b6394e7db313375357c56195ba4680e47770d8253413eb641ff3db3cf6b9'
         export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage"
       ;;
       bionic) # Prefer bionic since that seems to be more reliable
@@ -18441,8 +18447,12 @@ load_leagueoflegends()
         [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-bionic.AppImage' '01bcd44d10ba275336953347baa9578daca5830644ac67b2ab73564a46c2d70c'
         export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage"
       ;;
-      *) w_die "Function leagueoflegends_workaround_47198 was called, but nothing was parsed"
+      bionic-zsync) # Prefer bionic since that seems to be more reliable
+        # 24/09/2019: continous (sha256sum wine-staging-i386_lol-patched_x86_64-bionic.AppImage.zsync) sha256sum 8b74b6394e7db313375357c56195ba4680e47770d8253413eb641ff3db3cf6b9
+        [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage.zsync" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-bionic.AppImage.zsync' '8b74b6394e7db313375357c56195ba4680e47770d8253413eb641ff3db3cf6b9'
+        export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage"
       ;;
+      *) w_die "Unexpected argument '$leagueoflegends_workaround_47198' in function 'leagueoflegends_workaround_47198'"
     esac
 
     # Sanity check for executable permissions

--- a/src/winetricks
+++ b/src/winetricks
@@ -18431,11 +18431,14 @@ load_leagueoflegends()
     # shellcheck disable=SC2154
     case "$1" in
       arch)
-        [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage'
+        # 24/09/2019: continous (sha256sum wine-staging-i386_lol-patched_x86_64-archlinux.AppImage) sha256sum 279e00ce270d4eac3a57a5441787dfd3c78ec26fedf5a9e2f29c5362f74aa75f
+        # 279e00ce270d4eac3a57a5441787dfd3c78ec26fedf5a9e2f29c5362f74aa75f  Downloads/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage
+        [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage' '279e00ce270d4eac3a57a5441787dfd3c78ec26fedf5a9e2f29c5362f74aa75f'
         export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage"
       ;;
       bionic) # Prefer bionic since that seems to be more reliable
-        [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-bionic.AppImage'
+        # 24/09/2019: continous (sha256sum wine-staging-i386_lol-patched_x86_64-bionic.AppImage) sha256sum 01bcd44d10ba275336953347baa9578daca5830644ac67b2ab73564a46c2d70c
+        [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-bionic.AppImage' '01bcd44d10ba275336953347baa9578daca5830644ac67b2ab73564a46c2d70c'
         export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage"
       ;;
       *) w_die "Function leagueoflegends_workaround_47198 was called, but nothing was parsed"

--- a/src/winetricks
+++ b/src/winetricks
@@ -18507,6 +18507,9 @@ load_leagueoflegends()
       [ "$WINEPREFIX" = "${HOME}/.wine" ] || [ -z "$WINEPREFIX" ] && w_warn "Default WINEPREFIX is used where recommended prefix is '${HOME}/.local/share/wineprefixes/leagueoflegends-$leagueoflegends_region'"
     }
 
+    # Grabbed from Kreypi since [ -x $(command -v name) ] is unreliable for false
+    w_check_exec() { if ! command -v "$1" >/dev/null; then w_die "Command '$1' is not executable on this system"; fi ; }
+
     # Vulkan/DX11/DX10 wrapper
     leagueoflegends_d3d9_wrapper()
     {
@@ -18519,10 +18522,106 @@ load_leagueoflegends()
           w_die "FIXME: '$1' is not implemented for this game"
           w_call 'dxv9'
         ;;
-        dxvk-dgwoodo)
-          w_die "FIXME: '$1' is not implemented for this game"
+        dxvk-dgvoodoo2)
+          # Credit: http://www.dege.freeweb.hu/
+
+          # Starting with version 2.6, dynamic shader compiling is available for Glide API components. DirectX components have their own internal shader code generator. To enable that, you need D3DCompiler_43.dll. Starting with 2.53 an updated compiler version, _47, is also supported. (http://www.dege.freeweb.hu/dgVoodoo2/dgVoodoo2.html)
+
+          # Fetch
+          [ ! -e "${W_CACHE}/leagueoflegends/dgVoodoo2_62.zip" ] && w_download 'http://www.dege.freeweb.hu/dgVoodoo2/dgVoodoo2_62.zip' 'dcb00b795e138af71f712bf6c276795786ef373165f28589b44f27b14b4c62c7'
+          #[ ! -e "${W_CACHE}/leagueoflegends/D3DCompiler_47.zip" ] && w_download 'http://www.dege.freeweb.hu/dgVoodoo2/D3DCompiler_47.zip' '41ab9a8c7519cd47142fd2edf9b08e222516a058d49885b74fb889838490ae59'
+          [ ! -e "${W_CACHE}/leagueoflegends/D3DCompiler_43.zip" ] && w_download 'http://www.dege.freeweb.hu/dgVoodoo2/D3DCompiler_43.zip' 'ae2ecaf368d3238ec1f027e36916a8415afe834df2d1fa813f0b4c3de3fd1159'
+
+          # Check for unzip
+          w_check_exec 'unzip'
+
+          chmod +w "${W_DRIVE_C}/Riot Games/League of Legends/Game/D3DCompiler_43.dll"
+          chmod +w "${W_DRIVE_C}/Riot Games/League of Legends/d3dcompiler_43.dll"
+          chmod +w "${W_DRIVE_C}/Riot Games/League of Legends/d3d9.dll"
+          chmod +w "${W_DRIVE_C}/Riot Games/League of Legends/Game/d3d9.dll"
+
+          # Unzip dgVoodoo2_62 and export in GAMEDIR
+          [ ! -e "${W_CACHE}/leagueoflegends/dgVoodoo2_62" ] && w_try unzip -n -d "${W_CACHE}/leagueoflegends/dgVoodoo2_62" "${W_CACHE}/leagueoflegends/dgVoodoo2_62.zip"
+          [ ! -e "${W_CACHE}/leagueoflegends/D3DCompiler_43" ] && w_try unzip -n -d "${W_CACHE}/leagueoflegends/D3DCompiler_43" "${W_CACHE}/leagueoflegends/D3DCompiler_43.zip"
+          w_try cp "${W_CACHE}/leagueoflegends/dgVoodoo2_62/MS/x86/D3D9.dll" "${W_DRIVE_C}/Riot Games/League of Legends/d3d9.dll"
+          w_try cp "${W_CACHE}/leagueoflegends/dgVoodoo2_62/MS/x86/DDraw.dll" "${W_DRIVE_C}/Riot Games/League of Legends/ddraw.dll"
+          w_try cp "${W_CACHE}/leagueoflegends/dgVoodoo2_62/MS/x86/D3DImm.dll" "${W_DRIVE_C}/Riot Games/League of Legends/d3dimm.dll"
+          w_try cp "${W_CACHE}/leagueoflegends/D3DCompiler_43/D3DCompiler_43.dll" "${W_DRIVE_C}/Riot Games/League of Legends/d3dcompiler_43.dll"
+
+
+          # Get them for Game itself to be used as builtin
+          w_try cp "${W_CACHE}/leagueoflegends/dgVoodoo2_62/MS/x86/D3D9.dll" "${W_DRIVE_C}/Riot Games/League of Legends/Game/d3d9.dll"
+          w_try cp "${W_CACHE}/leagueoflegends/dgVoodoo2_62/MS/x86/DDraw.dll" "${W_DRIVE_C}/Riot Games/League of Legends/Game/ddraw.dll"
+          w_try cp "${W_CACHE}/leagueoflegends/dgVoodoo2_62/MS/x86/D3DImm.dll" "${W_DRIVE_C}/Riot Games/League of Legends/Game/d3dimm.dll"
+          w_try cp "${W_CACHE}/leagueoflegends/D3DCompiler_43/D3DCompiler_43.dll" "${W_DRIVE_C}/Riot Games/League of Legends/Game/D3DCompiler_43.dll"
+
+          # Attempt to bite RiotUpdater's hand everytime it tries to touch my previous libraries
+          ## TODO: Spam Rioters untill they add shasum of dege's libs in whitelist
+          w_try chmod -w "${W_DRIVE_C}/Riot Games/League of Legends/Game/D3DCompiler_43.dll"
+          w_try chmod -w "${W_DRIVE_C}/Riot Games/League of Legends/d3dcompiler_43.dll"
+          w_try chmod -w "${W_DRIVE_C}/Riot Games/League of Legends/d3d9.dll"
+          w_try chmod -w "${W_DRIVE_C}/Riot Games/League of Legends/Game/d3d9.dll"
+
+
+          # Get DXVK
           w_call 'dxvk'
-          # TODO: export dgwoodoo wrapper
+
+          w_override_dlls 'native' 'dxgi'
+          w_override_dlls 'native' 'd3d10'
+          w_override_dlls 'native' 'd3d10_1'
+          w_override_dlls 'native' 'd3d10core'
+          w_override_dlls 'native' 'd3d11'
+
+          # Reference
+          # .wine/drive_c/Riot Games/League of Legends/jpatch.exe
+          # .wine/drive_c/Riot Games/League of Legends/BsSndRpt.exe
+          # .wine/drive_c/Riot Games/League of Legends/LeagueClient.exe
+          # .wine/drive_c/Riot Games/League of Legends/LeagueClientUx.exe
+          # .wine/drive_c/Riot Games/League of Legends/LeagueClientUxRender.exe
+          # .wine/drive_c/Riot Games/League of Legends/Uninstall League of Legends.exe
+          # .wine/drive_c/Riot Games/League of Legends/Game/BsSndRpt.exe
+          # .wine/drive_c/Riot Games/League of Legends/Game/League of Legends.exe
+          # .wine/drive_c/Riot Games/League of Legends/Game/LeagueCrashHandler.exe
+
+          # Dll overrites to use dgVoodoo2
+          w_override_app_dlls 'League of Legends.exe' 'builtin' 'd3d9.dll'
+          w_override_app_dlls 'League of Legends.exe' 'builtin' 'ddraw.dll'
+          w_override_app_dlls 'League of Legends.exe' 'builtin' 'd3dimm.dll'
+          w_override_app_dlls 'League of Legends.exe' 'builtin' 'D3DCompiler_43.dll'
+          w_override_app_dlls 'League of Legends.exe' 'native' 'dxgi.dll'
+          w_override_app_dlls 'League of Legends.exe' 'native' 'd3d10.dll'
+          w_override_app_dlls 'League of Legends.exe' 'native' 'd3d10_1.dll'
+          w_override_app_dlls 'League of Legends.exe' 'native' 'd3d10core.dll'
+          w_override_app_dlls 'League of Legends.exe' 'native' 'd3d11.dll'
+
+          w_override_app_dlls 'LeagueClient.exe' 'builtin' 'd3d9.dll'
+          w_override_app_dlls 'LeagueClient.exe' 'builtin' 'ddraw.dll'
+          w_override_app_dlls 'LeagueClient.exe' 'builtin' 'd3dimm.dll'
+          w_override_app_dlls 'LeagueClient.exe' 'native' 'd3d10.dll'
+          w_override_app_dlls 'LeagueClient.exe' 'native' 'd3d10_1.dll'
+          w_override_app_dlls 'LeagueClient.exe' 'native' 'd3d10core.dll'
+          w_override_app_dlls 'LeagueClient.exe' 'native' 'd3d11.dll'
+          w_override_app_dlls 'LeagueClient.exe' 'native' 'dxgi.dll'
+
+          w_override_app_dlls 'LeagueClientUx.exe' 'builtin' 'd3d9.dll'
+          w_override_app_dlls 'LeagueClientUx.exe' 'builtin' 'ddraw.dll'
+          w_override_app_dlls 'LeagueClientUx.exe' 'builtin' 'd3dimm.dll'
+          w_override_app_dlls 'LeagueClientUx.exe' 'builtin' 'd3d9.dll'
+          w_override_app_dlls 'LeagueClientUx.exe' 'disabled' 'd3d10.dll'
+          w_override_app_dlls 'LeagueClientUx.exe' 'disabled' 'd3d10_1.dll'
+          w_override_app_dlls 'LeagueClientUx.exe' 'disabled' 'd3d10core.dll'
+          w_override_app_dlls 'LeagueClientUx.exe' 'disabled' 'd3d11.dll'
+          w_override_app_dlls 'LeagueClientUx.exe' 'disabled' 'dxgi.dll'
+
+          w_override_app_dlls 'LeagueClientUxRender.exe' 'builtin' 'd3d9.dll'
+          w_override_app_dlls 'LeagueClientUxRender.exe' 'builtin' 'ddraw.dll'
+          w_override_app_dlls 'LeagueClientUxRender.exe' 'builtin' 'd3dimm.dll'
+          w_override_app_dlls 'LeagueClientUxRender.exe' 'builtin' 'd3d9.dll'
+          w_override_app_dlls 'LeagueClientUxRender.exe' 'disabled' 'd3d10.dll'
+          w_override_app_dlls 'LeagueClientUxRender.exe' 'disabled' 'd3d10_1.dll'
+          w_override_app_dlls 'LeagueClientUxRender.exe' 'disabled' 'd3d10core.dll'
+          w_override_app_dlls 'LeagueClientUxRender.exe' 'disabled' 'd3d11.dll'
+          w_override_app_dlls 'LeagueClientUxRender.exe' 'disabled' 'dxgi.dll'
         ;;
         gallium9|galliumnine)
           w_die "FIXME: '$1' is not implemented for this game"

--- a/src/winetricks
+++ b/src/winetricks
@@ -18429,7 +18429,7 @@ load_leagueoflegends()
           'SEA   - South East Asia' \
           '' \
           "Note that this can be overwritten by 'leagueoflegends_region' variable"
-        read -r 'leagueoflegends_region'
+        read -r leagueoflegends_region
       done
 
       ## Actual fetch
@@ -18524,7 +18524,7 @@ load_leagueoflegends()
         ;;
         dgvoodoo2)
         # Get dgVoodoo2 only to wrap dxd9 to dxd10/11
-        [ -z "$leagueoflegends_force_dgvoodoo2" ] && case "$(winetricks_get_platform)" in; nix_*) w_die "Verb '$1' is not supported on '$(winetricks_get_platform)' since dxd10/11 is not supported without DXVK, use 'leagueoflegends_force_dgvoodoo2' variable set on non-zero to overwrite" ; esac
+        [ -z "$leagueoflegends_force_dgvoodoo2" ] && case "$(winetricks_get_platform)" in nix_*) w_die "Verb '$1' is not supported on '$(winetricks_get_platform)' since dxd10/11 is not supported without DXVK, use 'leagueoflegends_force_dgvoodoo2' variable set on non-zero to overwrite" ; esac
 
         # TODO: START - Fix duplicates
         [ ! -e "${W_CACHE}/leagueoflegends/dgVoodoo2_62.zip" ] && w_download 'http://www.dege.freeweb.hu/dgVoodoo2/dgVoodoo2_62.zip' 'dcb00b795e138af71f712bf6c276795786ef373165f28589b44f27b14b4c62c7'

--- a/src/winetricks
+++ b/src/winetricks
@@ -18515,12 +18515,47 @@ load_leagueoflegends()
     {
       case "$1" in
         dxvk)
-          w_die "FIXME: '$1' is not implemented for this game"
+          [ -z $leagueoflegends_do_not_die_on_dxvk ] && w_die "'$1' is not implemented for this game (uses dxd9), set 'leagueoflegends_do_not_die_on_dxvk' variable to non-zero to overwrite"
           w_call 'dxvk'
         ;;
         dxv9)
           w_die "FIXME: '$1' is not implemented for this game"
           w_call 'dxv9'
+        ;;
+        dgvoodoo2)
+        # Get dgVoodoo2 only to wrap dxd9 to dxd10/11
+        [ -z "$leagueoflegends_force_dgvoodoo2" ] && case "$(winetricks_get_platform)" in; nix_*) w_die "Verb '$1' is not supported on '$(winetricks_get_platform)' since dxd10/11 is not supported without DXVK, use 'leagueoflegends_force_dgvoodoo2' variable set on non-zero to overwrite" ; esac
+
+        # TODO: START - Fix duplicates
+        [ ! -e "${W_CACHE}/leagueoflegends/dgVoodoo2_62.zip" ] && w_download 'http://www.dege.freeweb.hu/dgVoodoo2/dgVoodoo2_62.zip' 'dcb00b795e138af71f712bf6c276795786ef373165f28589b44f27b14b4c62c7'
+        #[ ! -e "${W_CACHE}/leagueoflegends/D3DCompiler_47.zip" ] && w_download 'http://www.dege.freeweb.hu/dgVoodoo2/D3DCompiler_47.zip' '41ab9a8c7519cd47142fd2edf9b08e222516a058d49885b74fb889838490ae59'
+        [ ! -e "${W_CACHE}/leagueoflegends/D3DCompiler_43.zip" ] && w_download 'http://www.dege.freeweb.hu/dgVoodoo2/D3DCompiler_43.zip' 'ae2ecaf368d3238ec1f027e36916a8415afe834df2d1fa813f0b4c3de3fd1159'
+
+        # Check for unzip
+        w_check_exec 'unzip'
+
+        # Unzip dgVoodoo2_62 and export in GAMEDIR
+        [ ! -e "${W_CACHE}/leagueoflegends/dgVoodoo2_62" ] && w_try unzip -n -d "${W_CACHE}/leagueoflegends/dgVoodoo2_62" "${W_CACHE}/leagueoflegends/dgVoodoo2_62.zip"
+        [ ! -e "${W_CACHE}/leagueoflegends/D3DCompiler_43" ] && w_try unzip -n -d "${W_CACHE}/leagueoflegends/D3DCompiler_43" "${W_CACHE}/leagueoflegends/D3DCompiler_43.zip"
+        w_try cp "${W_CACHE}/leagueoflegends/dgVoodoo2_62/MS/x86/D3D9.dll" "${W_DRIVE_C}/Riot Games/League of Legends/d3d9.dll"
+        w_try cp "${W_CACHE}/leagueoflegends/dgVoodoo2_62/MS/x86/DDraw.dll" "${W_DRIVE_C}/Riot Games/League of Legends/ddraw.dll"
+        w_try cp "${W_CACHE}/leagueoflegends/dgVoodoo2_62/MS/x86/D3DImm.dll" "${W_DRIVE_C}/Riot Games/League of Legends/d3dimm.dll"
+        w_try cp "${W_CACHE}/leagueoflegends/D3DCompiler_43/D3DCompiler_43.dll" "${W_DRIVE_C}/Riot Games/League of Legends/d3dcompiler_43.dll"
+
+
+        # Get them for Game itself to be used as builtin
+        w_try cp "${W_CACHE}/leagueoflegends/dgVoodoo2_62/MS/x86/D3D9.dll" "${W_DRIVE_C}/Riot Games/League of Legends/Game/d3d9.dll"
+        w_try cp "${W_CACHE}/leagueoflegends/dgVoodoo2_62/MS/x86/DDraw.dll" "${W_DRIVE_C}/Riot Games/League of Legends/Game/ddraw.dll"
+        w_try cp "${W_CACHE}/leagueoflegends/dgVoodoo2_62/MS/x86/D3DImm.dll" "${W_DRIVE_C}/Riot Games/League of Legends/Game/d3dimm.dll"
+        w_try cp "${W_CACHE}/leagueoflegends/D3DCompiler_43/D3DCompiler_43.dll" "${W_DRIVE_C}/Riot Games/League of Legends/Game/D3DCompiler_43.dll"
+
+        # Workaround to RiotUpdater overwriting libraries (2/2)
+        ## Attempt to bite RiotUpdater's hand everytime it tries to touch my previous libraries
+        w_try chmod -w "${W_DRIVE_C}/Riot Games/League of Legends/Game/D3DCompiler_43.dll"
+        w_try chmod -w "${W_DRIVE_C}/Riot Games/League of Legends/d3dcompiler_43.dll"
+        w_try chmod -w "${W_DRIVE_C}/Riot Games/League of Legends/d3d9.dll"
+        w_try chmod -w "${W_DRIVE_C}/Riot Games/League of Legends/Game/d3d9.dll"
+        # TODO: END - Fix duplicates
         ;;
         dxvk-dgvoodoo2)
           # Credit: http://www.dege.freeweb.hu/
@@ -18535,6 +18570,7 @@ load_leagueoflegends()
           # Check for unzip
           w_check_exec 'unzip'
 
+          # Workaround to RiotUpdater overwriting libraries (1/2)
           chmod +w "${W_DRIVE_C}/Riot Games/League of Legends/Game/D3DCompiler_43.dll"
           chmod +w "${W_DRIVE_C}/Riot Games/League of Legends/d3dcompiler_43.dll"
           chmod +w "${W_DRIVE_C}/Riot Games/League of Legends/d3d9.dll"
@@ -18555,13 +18591,12 @@ load_leagueoflegends()
           w_try cp "${W_CACHE}/leagueoflegends/dgVoodoo2_62/MS/x86/D3DImm.dll" "${W_DRIVE_C}/Riot Games/League of Legends/Game/d3dimm.dll"
           w_try cp "${W_CACHE}/leagueoflegends/D3DCompiler_43/D3DCompiler_43.dll" "${W_DRIVE_C}/Riot Games/League of Legends/Game/D3DCompiler_43.dll"
 
-          # Attempt to bite RiotUpdater's hand everytime it tries to touch my previous libraries
-          ## TODO: Spam Rioters untill they add shasum of dege's libs in whitelist
+          # Workaround to RiotUpdater overwriting libraries (2/2)
+          ## Attempt to bite RiotUpdater's hand everytime it tries to touch my previous libraries
           w_try chmod -w "${W_DRIVE_C}/Riot Games/League of Legends/Game/D3DCompiler_43.dll"
           w_try chmod -w "${W_DRIVE_C}/Riot Games/League of Legends/d3dcompiler_43.dll"
           w_try chmod -w "${W_DRIVE_C}/Riot Games/League of Legends/d3d9.dll"
           w_try chmod -w "${W_DRIVE_C}/Riot Games/League of Legends/Game/d3d9.dll"
-
 
           # Get DXVK
           w_call 'dxvk'
@@ -18624,12 +18659,25 @@ load_leagueoflegends()
           w_override_app_dlls 'LeagueClientUxRender.exe' 'disabled' 'dxgi.dll'
         ;;
         gallium9|galliumnine)
-          w_die "FIXME: '$1' is not implemented for this game"
           # NOTE: might be worth combining with wrapper for DX10/11/Vulkan
-          w_call 'galliumnine'
+          (WINETRICKS_FORCE='1' w_call 'galliumnine')
+          w_override_dlls 'disabled' 'dxgi'
+          w_override_dlls 'disabled' 'd3d10'
+          w_override_dlls 'disabled' 'd3d10_1'
+          w_override_dlls 'disabled' 'd3d10core'
+          w_override_dlls 'disabled' 'd3d11'
+          w_info "'$1' has been enabled"
         ;;
         ""|none)
-          w_info "DirectX 9 wrapper is not used, use leagueoflegends_d3d9_wrapper variable to overwrite"
+          # Required to force in case other workaround is used
+          (WINETRICKS_FORCE='1' w_call "d3dx9_43")
+          w_override_dlls 'disabled' 'dxgi'
+          w_override_dlls 'disabled' 'd3d10'
+          w_override_dlls 'disabled' 'd3d10_1'
+          w_override_dlls 'disabled' 'd3d10core'
+          w_override_dlls 'disabled' 'd3d11'
+
+          w_info "DirectX 9 wrapper is not used and other DirectX libraries has been disabled, use leagueoflegends_d3d9_wrapper variable to overwrite"
         ;;
         *) w_die "Unexpected argument '$1' in function leagueoflegends_3D_wrapper"
       esac

--- a/src/winetricks
+++ b/src/winetricks
@@ -18490,6 +18490,10 @@ load_leagueoflegends()
           w_call 'dxvk'
           # TODO: export dgwoodo wrapper
         ;;
+        gallium9|galliumnine)
+          # NOTE: might be worth combining with wrapper for DX10/11/Vulkan
+          w_call 'galliumnine'
+        ;;
         none)
           w_info "Disabled 3D wrapper"
         ;;

--- a/src/winetricks
+++ b/src/winetricks
@@ -19068,17 +19068,6 @@ load_leagueoflegends()
           w_override_dlls 'native' 'd3d10core'
           w_override_dlls 'native' 'd3d11'
 
-          # Reference
-          # .wine/drive_c/Riot Games/League of Legends/jpatch.exe
-          # .wine/drive_c/Riot Games/League of Legends/BsSndRpt.exe
-          # .wine/drive_c/Riot Games/League of Legends/LeagueClient.exe
-          # .wine/drive_c/Riot Games/League of Legends/LeagueClientUx.exe
-          # .wine/drive_c/Riot Games/League of Legends/LeagueClientUxRender.exe
-          # .wine/drive_c/Riot Games/League of Legends/Uninstall League of Legends.exe
-          # .wine/drive_c/Riot Games/League of Legends/Game/BsSndRpt.exe
-          # .wine/drive_c/Riot Games/League of Legends/Game/League of Legends.exe
-          # .wine/drive_c/Riot Games/League of Legends/Game/LeagueCrashHandler.exe
-
           # Dll overrites to use dgVoodoo2
           w_override_app_dlls 'League of Legends.exe' 'builtin' 'd3d9.dll'
           w_override_app_dlls 'League of Legends.exe' 'builtin' 'ddraw.dll'
@@ -19121,7 +19110,7 @@ load_leagueoflegends()
         ;;
         gallium9|galliumnine)
           # NOTE: might be worth combining with wrapper for DX10/11/Vulkan
-          (WINETRICKS_FORCE='1' w_call 'galliumnine')
+          (WINETRICKS_FORCE=1 w_call 'galliumnine')
           w_override_dlls 'disabled' 'dxgi'
           w_override_dlls 'disabled' 'd3d10'
           w_override_dlls 'disabled' 'd3d10_1'
@@ -19131,7 +19120,7 @@ load_leagueoflegends()
         ;;
         ""|none)
           # Required to force in case other workaround is used
-          (WINETRICKS_FORCE='1' w_call "d3dx9_43")
+          (WINETRICKS_FORCE=1 w_call "d3dx9_43")
           w_override_dlls 'disabled' 'dxgi'
           w_override_dlls 'disabled' 'd3d10'
           w_override_dlls 'disabled' 'd3d10_1'
@@ -19140,32 +19129,78 @@ load_leagueoflegends()
 
           w_info "DirectX 9 wrapper is not used and other DirectX libraries has been disabled, use leagueoflegends_d3d9_wrapper variable to overwrite"
         ;;
-        *) w_die "Unexpected argument '$1' in function leagueoflegends_3D_wrapper"
+        *) w_die "Unexpected argument '$1' in function leagueoflegends_d3d9_wrapper"
       esac
     }
 
     # ACTION
     leagueoflegends_default_wineprefix
 
+    # Hotfix untill https://github.com/Winetricks/winetricks/pull/1359 is finished
+    if [ -n "$(w_workaround_wine_bug '47198')" ] && [ "$WINEARCH" != "win32" ]; then w_die "HOTFIX: This is expected to be executed with WINEARCH set on win32"; fi
+
     # Game won't launch due https://bugs.winehq.org/show_bug.cgi?id=47198
-    if w_workaround_wine_bug 47198 "Using patched wine binary" ; then leagueoflegends_workaround_47198 bionic ; fi
+    if w_workaround_wine_bug 47198; then leagueoflegends_workaround_47198 'bionic'
+    elif [ -n "$(w_workaround_wine_bug 47198)" ] && [ -n "$WINETRICKS_BUILD_WINE" ]; then
+        w_warn "FIXME: Unable to apply patches to glibc-2.27 this way to work around winebug 47198"
+            export leagueoflegends_workaround_47198_choice="sc-segment"
+        wineappimagebuilder_patches()
+        {
+            case "$leagueoflegends_workaround_47198_choice" in
+              glibc)
+                  w_die "FIXME: Unable to apply patches to glibc-2.27 this way to work around winebug 47198"
+
+                  w_warn "Using WINEHACK to workaround 47198, credit: Andrew Wessie"
+
+                  # diff --git a/dlls/ntdll/thread.c b/dlls/ntdll/thread.c
+                  w_download 'https://bugs.winehq.org/attachment.cgi?id=64481' '' '64481.diff'
+                  if ! grep -qF "// FIXME All of this code is i386 Linux-specific. It may want to live in" "$wineappimagebuilder_workdir/wine-$wineappimagebuilder_wine_version_stripped/dlls/ntdll/thread.c"; then
+                    patch "$wineappimagebuilder_workdir/wine-$wineappimagebuilder_wine_version_stripped/dlls/ntdll/thread.c" "$W_CACHE/$W_PACKAGE/64481.diff"
+                  elif grep -qF "// FIXME All of this code is i386 Linux-specific. It may want to live in" "$wineappimagebuilder_workdir/wine-$wineappimagebuilder_wine_version_stripped/dlls/ntdll/thread.c"; then
+                    w_debug "Patch 64481 is already applied"
+                  fi
+
+                  # --- glibc-2.27.orig/nptl/descr.h
+                  # +++ glibc-2.27/nptl/descr.h
+                  w_download 'https://bugs.winehq.org/attachment.cgi?id=64482' '' '64482.diff'
+
+              ;;
+              sc-segment)
+                  w_warn "Using WINEHACK to workaround 47198, credit: Andrew Wessie"
+
+                  # diff --git a/dlls/ntdll/signal_i386.c b/dlls/ntdll/signal_i386.c
+                  w_download 'https://bugs.winehq.org/attachment.cgi?id=64507' '' '64507'
+                  if ! grep -qF '/* convert from straight ASCII to Unicode without depending on the current codepage */' "$wineappimagebuilder_workdir/wine-$wineappimagebuilder_wine_version_stripped/dlls/ntdll/signal_i386.c"; then
+                    patch "$wineappimagebuilder_workdir/wine-$wineappimagebuilder_wine_version_stripped/dlls/ntdll/signal_i386.c" "$W_CACHE/$W_PACKAGE/64481.diff"
+                  elif grep -qF '/* convert from straight ASCII to Unicode without depending on the current codepage */' "$wineappimagebuilder_workdir/wine-$wineappimagebuilder_wine_version_stripped/dlls/ntdll/signal_i386.c"; then
+                    w_debug "Patch 64507 is already applied"
+                  fi
+              ;;
+              *) w_die "Wrong value ($leagueoflegends_workaround_47198_choice) was parsed in wineappimagebuilder_patches()"
+            esac
+        }
+        w_call 'wineappimagebuilder'
+    fi
 
     # Install
     if [ ! -e "${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe" ]; then
        leagueoflegends_fetch
        (
-          leagueoflegends_default_wineprefix
-          [ -z "$WINEDEBUG" ] && export WINEDEBUG="fixme-all"
-          if w_workaround_wine_bug '47198'; then
-            leagueoflegends_workaround_47198 # get WINE
-            # HOTFIX: winetricks is creating 64-bit wineprefix by default
-            export WINEARCH="win32"
-            [ -e "$WINEPREFIX" ] && [ ! -e "${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe" ] && mv "$WINEPREFIX" "/tmp/winetricks/$WINEPREFIX"
-          fi
-          # shellcheck disable=SC2154
-          leagueoflegends_d3d9_wrapper "$leagueoflegends_d3d9_wrapper"
-          w_try "$WINE" "${W_CACHE}/leagueoflegends/League%20of%20Legends%20installer%20${leagueoflegends_region}.exe"
-          return 0 # Stop here since leagueoflegends starts itself after installation
+            leagueoflegends_default_wineprefix
+            [ -z "$WINEDEBUG" ] && export WINEDEBUG="fixme-all"
+            if w_workaround_wine_bug '47198'; then
+                leagueoflegends_workaround_47198 # get WINE
+
+                # HOTFIX: winetricks is creating 64-bit wineprefix by default on AMD64 when WINEARCH is not specified
+                case "$WINE" in
+                    "*/$used_wine") w_debug "Correct WINE is used ($used_wine)"
+                    *) w_die "Wrong WINE ($WINE) is used where expecting '$used_wine' from '$W_CACHE/$W_PACKAGE', export it manually and re-invoke"
+                esac
+            fi
+            # shellcheck disable=SC2154
+            leagueoflegends_d3d9_wrapper "$leagueoflegends_d3d9_wrapper"
+            w_try "$WINE" "${W_CACHE}/leagueoflegends/League%20of%20Legends%20installer%20${leagueoflegends_region}.exe"
+            return 0 # Stop here since leagueoflegends starts itself after installation
        )
 
     # Run if already installed

--- a/src/winetricks
+++ b/src/winetricks
@@ -18511,11 +18511,12 @@ load_leagueoflegends()
     w_check_exec() { if ! command -v "$1" >/dev/null; then w_die "Command '$1' is not executable on this system"; fi ; }
 
     # Vulkan/DX11/DX10 wrapper
+    # shellcheck disable=SC2154
     leagueoflegends_d3d9_wrapper()
     {
       case "$1" in
         dxvk)
-          [ -z $leagueoflegends_do_not_die_on_dxvk ] && w_die "'$1' is not implemented for this game (uses dxd9), set 'leagueoflegends_do_not_die_on_dxvk' variable to non-zero to overwrite"
+          [ -z "$leagueoflegends_do_not_die_on_dxvk" ] && w_die "'$1' is not implemented for this game (uses dxd9), set 'leagueoflegends_do_not_die_on_dxvk' variable to non-zero to overwrite"
           w_call 'dxvk'
         ;;
         dxv9)

--- a/src/winetricks
+++ b/src/winetricks
@@ -18389,95 +18389,95 @@ w_metadata leagueoflegends games \
 
 load_leagueoflegends()
 {
-  # Fetch installer
-  leagueoflegends_fetch()
-  {
-    # Game has multiple regions and this logic allows end-user to choose it's preffered
-    ## TODO: Add Logic for region selection if $W_OPT_UNATTENDED is parsed
-    [ -n "$W_OPT_UNATTENDED" ] && [ -n "$leagueoflegends_region" ] && w_warn "hotfixed, using EUNE region for download" && export leagueoflegends_region="EUNE"
+    # Fetch installer
+    leagueoflegends_fetch()
+    {
+      # Game has multiple regions and this logic allows end-user to choose it's preffered
+      ## TODO: Add Logic for region selection if $W_OPT_UNATTENDED is parsed
+      [ -n "$W_OPT_UNATTENDED" ] && [ -n "$leagueoflegends_region" ] && w_warn "hotfixed, using EUNE region for download" && export leagueoflegends_region="EUNE"
 
-    until case "$leagueoflegends_region" in ( EUNE | EUW | NA | BR | LAN | LAS | OCE | RU | JP | SEA ) :;; ( * ) ! :; esac; do
-      printf "%s\n" \
-        'Select your region for League Of Legends installer:' \
-        'EUNE  - Europe Nordic and East' \
-        'NA    - North America' \
-        'EUW   - Europe West' \
-        'BR    - Brazil' \
-        'AN    - Latin America North' \
-        'LAS   - Latin America South' \
-        'OCE   - Oceania' \
-        'RU    - Russia' \
-        'TR    - Turkey' \
-        'JP    - Japan' \
-        'SEA   - South East Asia' \
-        '' \
-        "Note that this can be overwritten by 'leagueoflegends_region' variable"
-      read -r leagueoflegends_region
-    done
+      until case "$leagueoflegends_region" in ( EUNE | EUW | NA | BR | LAN | LAS | OCE | RU | JP | SEA ) :;; ( * ) ! :; esac; do
+        printf "%s\n" \
+          'Select your region for League Of Legends installer:' \
+          'EUNE  - Europe Nordic and East' \
+          'NA    - North America' \
+          'EUW   - Europe West' \
+          'BR    - Brazil' \
+          'AN    - Latin America North' \
+          'LAS   - Latin America South' \
+          'OCE   - Oceania' \
+          'RU    - Russia' \
+          'TR    - Turkey' \
+          'JP    - Japan' \
+          'SEA   - South East Asia' \
+          '' \
+          "Note that this can be overwritten by 'leagueoflegends_region' variable"
+        read -r leagueoflegends_region
+      done
 
-    ## Actual fetch
-    ## TODO: Checksum https://boards.na.leagueoflegends.com/en/c/general-discussion/tZ4uPccJ-checksum-for-league-of-legends-installer
-    [ ! -e "${W_CACHE}/leagueoflegends/League%20of%20Legends%20installer%20${leagueoflegends_region}.exe" ] && w_download "https://riotgamespatcher-a.akamaihd.net/releases/live/installer/deploy/League%20of%20Legends%20installer%20${leagueoflegends_region}.exe"
-  }
+      ## Actual fetch
+      ## TODO: Checksum https://boards.na.leagueoflegends.com/en/c/general-discussion/tZ4uPccJ-checksum-for-league-of-legends-installer
+      [ ! -e "${W_CACHE}/leagueoflegends/League%20of%20Legends%20installer%20${leagueoflegends_region}.exe" ] && w_download "https://riotgamespatcher-a.akamaihd.net/releases/live/installer/deploy/League%20of%20Legends%20installer%20${leagueoflegends_region}.exe"
+    }
 
-  # Workaround for pakman violation after champion select using WINE precompiled binary
-  # https://bugs.winehq.org/show_bug.cgi?id=47198
-  # TODO: Use AHK to install the game automatically
-  # TODO: Login using AHK
-  leagueoflegends_workaround_47198()
-  {
-    w_info "Applying workaround to winebug 47198 using precompiled WINE binary by mmtrt, skip this by using WINETRICKS_BLACKLIST variable if needed"
+    # Workaround for pakman violation after champion select using WINE precompiled binary
+    # https://bugs.winehq.org/show_bug.cgi?id=47198
+    # TODO: Use AHK to install the game automatically
+    # TODO: Login using AHK
+    leagueoflegends_workaround_47198()
+    {
+      w_info "Applying workaround to winebug 47198 using precompiled WINE binary by mmtrt, skip this by using WINETRICKS_BLACKLIST variable if needed"
 
-    w_info "You can overwrite 'leagueoflegends_workaround_47198' variable to use different precompiled wine"
-    [ -z "$leagueoflegends_workaround_47198" ] && export leagueoflegends_workaround_47198="$1"
+      w_info "You can overwrite 'leagueoflegends_workaround_47198' variable to use different precompiled wine"
+      [ -z "$leagueoflegends_workaround_47198" ] && export leagueoflegends_workaround_47198="$1"
 
-    ## Logic for WINE binary executable
-    # shellcheck disable=SC2154
-    case "$leagueoflegends_workaround_47198" in
-      arch)
-        # 24/09/2019: continous (sha256sum wine-staging-i386_lol-patched_x86_64-archlinux.AppImage) sha256sum 279e00ce270d4eac3a57a5441787dfd3c78ec26fedf5a9e2f29c5362f74aa75f
-        [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage' '279e00ce270d4eac3a57a5441787dfd3c78ec26fedf5a9e2f29c5362f74aa75f'
-        export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage"
-      ;;
-      arch-zsync)
-        # 24/09/2019: continous (sha256sum wine-staging-i386_lol-patched_x86_64-archlinux.AppImage.zsync) sha256sum 8b74b6394e7db313375357c56195ba4680e47770d8253413eb641ff3db3cf6b9
-        [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage.zsync" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage.zsync' '8b74b6394e7db313375357c56195ba4680e47770d8253413eb641ff3db3cf6b9'
-        export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage"
-      ;;
-      bionic) # Prefer bionic since that seems to be more reliable
-        # 24/09/2019: continous (sha256sum wine-staging-i386_lol-patched_x86_64-bionic.AppImage) sha256sum 01bcd44d10ba275336953347baa9578daca5830644ac67b2ab73564a46c2d70c
-        [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-bionic.AppImage' '01bcd44d10ba275336953347baa9578daca5830644ac67b2ab73564a46c2d70c'
-        export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage"
-      ;;
-      bionic-zsync) # Prefer bionic since that seems to be more reliable
-        # 24/09/2019: continous (sha256sum wine-staging-i386_lol-patched_x86_64-bionic.AppImage.zsync) sha256sum 8b74b6394e7db313375357c56195ba4680e47770d8253413eb641ff3db3cf6b9
-        [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage.zsync" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-bionic.AppImage.zsync' '8b74b6394e7db313375357c56195ba4680e47770d8253413eb641ff3db3cf6b9'
-        export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage"
-      ;;
-      *) w_die "Unexpected argument '$leagueoflegends_workaround_47198' in function 'leagueoflegends_workaround_47198'"
-    esac
+      ## Logic for WINE binary executable
+      # shellcheck disable=SC2154
+      case "$leagueoflegends_workaround_47198" in
+        arch)
+          # 24/09/2019: continous (sha256sum wine-staging-i386_lol-patched_x86_64-archlinux.AppImage) sha256sum 279e00ce270d4eac3a57a5441787dfd3c78ec26fedf5a9e2f29c5362f74aa75f
+          [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage' '279e00ce270d4eac3a57a5441787dfd3c78ec26fedf5a9e2f29c5362f74aa75f'
+          export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage"
+        ;;
+        arch-zsync)
+          # 24/09/2019: continous (sha256sum wine-staging-i386_lol-patched_x86_64-archlinux.AppImage.zsync) sha256sum 8b74b6394e7db313375357c56195ba4680e47770d8253413eb641ff3db3cf6b9
+          [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage.zsync" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage.zsync' '8b74b6394e7db313375357c56195ba4680e47770d8253413eb641ff3db3cf6b9'
+          export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-archlinux.AppImage"
+        ;;
+        bionic) # Prefer bionic since that seems to be more reliable
+          # 24/09/2019: continous (sha256sum wine-staging-i386_lol-patched_x86_64-bionic.AppImage) sha256sum 01bcd44d10ba275336953347baa9578daca5830644ac67b2ab73564a46c2d70c
+          [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-bionic.AppImage' '01bcd44d10ba275336953347baa9578daca5830644ac67b2ab73564a46c2d70c'
+          export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage"
+        ;;
+        bionic-zsync) # Prefer bionic since that seems to be more reliable
+          # 24/09/2019: continous (sha256sum wine-staging-i386_lol-patched_x86_64-bionic.AppImage.zsync) sha256sum 8b74b6394e7db313375357c56195ba4680e47770d8253413eb641ff3db3cf6b9
+          [ ! -e "${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage.zsync" ] && w_download 'https://github.com/mmtrt/Wine_Appimage/releases/download/continuous/wine-staging-i386_lol-patched_x86_64-bionic.AppImage.zsync' '8b74b6394e7db313375357c56195ba4680e47770d8253413eb641ff3db3cf6b9'
+          export WINE="${W_CACHE}/leagueoflegends/wine-staging-i386_lol-patched_x86_64-bionic.AppImage"
+        ;;
+        *) w_die "Unexpected argument '$leagueoflegends_workaround_47198' in function 'leagueoflegends_workaround_47198'"
+      esac
 
-    # Sanity check for executable permissions
-    [ ! -x "$WINE" ] && chmod +x "$WINE"
-  }
+      # Sanity check for executable permissions
+      [ ! -x "$WINE" ] && chmod +x "$WINE"
+    }
 
-  # Game won't launch due https://bugs.winehq.org/show_bug.cgi?id=47198
-  if w_workaround_wine_bug 47198 "Using patched wine binary" ; then leagueoflegends_workaround_47198 bionic ; fi
+    # Game won't launch due https://bugs.winehq.org/show_bug.cgi?id=47198
+    if w_workaround_wine_bug 47198 "Using patched wine binary" ; then leagueoflegends_workaround_47198 bionic ; fi
 
-  # Install
-  if [ ! -e "${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe" ]; then
-     leagueoflegends_fetch
-     (
-        [ -z "$WINEDEBUG" ] && export WINEDEBUG="fixme-all"
-        w_try "$WINE" "${W_CACHE}/leagueoflegends/League%20of%20Legends%20installer%20${leagueoflegends_region}.exe"
-     )
-     return 0
+    # Install
+    if [ ! -e "${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe" ]; then
+       leagueoflegends_fetch
+       (
+          [ -z "$WINEDEBUG" ] && export WINEDEBUG="fixme-all"
+          w_try "$WINE" "${W_CACHE}/leagueoflegends/League%20of%20Legends%20installer%20${leagueoflegends_region}.exe"
+       )
+       return 0
 
-  # Run if already installed
-  elif [ -e "${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe" ]; then
-    w_info "League Of Legends is already installed in $WINEPREFIX, executing.."
-    w_try "$WINE" "${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe"
-  fi
+    # Run if already installed
+    elif [ -e "${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe" ]; then
+      w_info "League Of Legends is already installed in $WINEPREFIX, executing.."
+      w_try "$WINE" "${W_DRIVE_C}/Riot Games/League of Legends/LeagueClient.exe"
+    fi
 }
 
 #----------------------------------------------------------------


### PR DESCRIPTION
DO NOT MERGE!  - Game got updated and previous workarounds no longer works

![Leagueoflegendsbanner](https://user-images.githubusercontent.com/11302521/65441918-89e5a780-de2b-11e9-8558-f75ff8aadd22.png)

Attempt to add leagueoflegends compatibility for winetricks

NOTICE: is it reported that wine-staging >4,15 with provided patches has runtime issues https://bugs.winehq.org/show_bug.cgi?id=47198#c81

- (resolved) DXVK should give us 120~180% performance boost compared to 100% on 'optimized' windows/mac assuming usage of wrapper for DX9 to run DX11 that runs on vulkan. (https://github.com/PhoenicisOrg/scripts/pull/797)

- (Won't be resolved immediately, proceed without) checksum (https://boards.na.leagueoflegends.com/en/c/general-discussion/tZ4uPccJ-checksum-for-league-of-legends-installer)

- Hotfix https://github.com/Winetricks/winetricks/pull/1335#issuecomment-534690633

Blocked (hotfixed) by https://github.com/Winetricks/winetricks/pull/1338 assuming that there is no way to make winetricks to invoke WINE after verb is called where function `winetricks_init()` is conflicting due to the:
https://github.com/Winetricks/winetricks/blob/f54242371e4917c94bfc01b87ea34727ad9ab09c/src/winetricks#L5106

DEPENDS: https://github.com/Winetricks/winetricks/pull/1354
DEPENDS: https://github.com/Winetricks/winetricks/pull/1351 (hotfixed)
BLOCKED BY: https://github.com/Winetricks/winetricks/pull/1359 (hotfixed)

NOTICE: Affected by https://bugs.winehq.org/show_bug.cgi?id=47198
NOTICE: Affected by https://bugs.winehq.org/show_bug.cgi?id=47765

Signed-off-by: Jacob Hrbek <kreyren@rixotstudio.cz>

---

# Notice to winetricks maintainers

Currently not fully functional due used to the workaround for winebug 47198 where workarounds that require reinvoking the script, but allow wineapp installation 

Uses wineappimagebuilder, but is able to work without it ($WINETRICKS_BUILD_WINE unset by default)

Requesting review/approval for following:
- Documentation in winetricks wiki on https://github.com/Winetricks/winetricks/pull/1335#issuecomment-534035206
- Proposed solution for workaround in case providing wine in sandboxed environment like `AppImage` is not sufficient (currently is it. but this solution could make it possible to be used on FreeBSD/MacOS based on conversation in https://github.com/Winetricks/winetricks/pull/1318). 
- Note that current merge request is using https://github.com/Winetricks/winetricks/pull/1338 to get cygwin compatibility which is in works.
- Note that AHK script may be possible to make log-in automatic this merge request adds only comment with TODO for this atm.
- Please squash using github with first comment in this merge request excluding image at the top and "Notice to winetricks maintainers"
- Notice that this installer is meant to be used with provided WINE which is based on available info impossible with winetricks (https://github.com/Winetricks/winetricks/pull/1335#issuecomment-534910844) this is being tracked in https://github.com/Winetricks/winetricks/issues/1344 and i'm working on contrib

I've made lots of changes let me know if it's hard to track the changes and i stage them in multiple merge requests or request a more effective way to handle review (if needed).