### PR TITLE
ie6: Updated mirror using webarchive.org

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -13758,7 +13758,7 @@ load_ie6()
 {
     w_package_unsupported_win64
 
-    w_download http://cdn.browserarchive.org/ie/win32/6.0/ie60.exe e34e0557d939e7e83185f5354403df99c92a3f3ff80f5ee0c75f6843eaa6efb2
+    w_download https://web.archive.org/web/20150411022055if_/http://download.oldapps.com/Internet_Explorer/ie60.exe e34e0557d939e7e83185f5354403df99c92a3f3ff80f5ee0c75f6843eaa6efb2
 
     w_try_cd "$W_TMP"
     "$WINE" "$W_CACHE/$W_PACKAGE/$file1"


### PR DESCRIPTION
Current mirror is down, this attempts to use webarchive.org's mirror 
from oldapps.com

Fixes: https://github.com/Winetricks/winetricks/issues/1336
Relevant: https://github.com/Winetricks/winetricks/issues/1336#issuecomment-535097786

Signed-off-by: Jacob Hrbek <kreyren@rixotstudio.cz>