### PR TITLE
annihilate: Include prefix shortcuts rooted at $XDG_DATA_HOME/applications

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -4968,7 +4968,7 @@ winetricks_annihilate_wineprefix()
     rm -rf "$WINEPREFIX"
 
     # Also remove menu items.
-    find "$XDG_DATA_HOME/applications/wine" -type f -name '*.desktop' -exec grep -q -l "$WINEPREFIX" '{}' ';' -exec rm '{}' ';'
+    find "$XDG_DATA_HOME/applications" -type f -name '*.desktop' -exec grep -q -l "$WINEPREFIX" '{}' ';' -exec rm '{}' ';'
 
     # Also remove desktop items.
     # Desktop might be synonym for home directory, so only go one level


### PR DESCRIPTION
When the `winetricks_annihilate_wineprefix` function removes shortcuts associated to the prefix under the XDG user-specific data directory, it starts at `$XDG_DATA_HOME/applications/wine`. With Wine 4.9 (and other unspecified versions) shortcuts are actually rooted at `$XDG_DATA_HOME/applications`, adopting the naming pattern `wine-extension-<suffix>.desktop`. Besides leaving stray shortcuts, the `wine/` folder may well never be created, causing the `find` invocation to output: `find: ‘[...]/.local/share/applications/wine’: No such file or directory`. This change aims to remedy the problem by finding files from one level up.