### PR TITLE
vcrun2015/7: Attempt to improve handling of winevn for 37781 workaround

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -11714,11 +11714,11 @@ load_vcrun2017()
 
     if w_workaround_wine_bug 37781; then
         w_warn "This may fail in non-XP mode, see https://bugs.winehq.org/show_bug.cgi?id=37781"
+        w_set_app_winver 'vc_redist.x86.exe' 'winxp'
+        w_set_app_winver 'vc_redist.x64.exe' 'winxp'
     fi
 
     w_override_dlls native,builtin api-ms-win-crt-conio-l1-1-0 api-ms-win-crt-heap-l1-1-0 api-ms-win-crt-locale-l1-1-0 api-ms-win-crt-math-l1-1-0 api-ms-win-crt-runtime-l1-1-0 api-ms-win-crt-stdio-l1-1-0 api-ms-win-crt-time-l1-1-0 atl140 concrt140 msvcp140 msvcr140 ucrtbase vcomp140 vcruntime140
-
-    w_set_winver winxp
 
     w_try_cd "$W_CACHE/$W_PACKAGE"
     w_try "$WINE" vc_redist.x86.exe $W_UNATTENDED_SLASH_Q

--- a/src/winetricks
+++ b/src/winetricks
@@ -11650,11 +11650,11 @@ load_vcrun2015()
 
     if w_workaround_wine_bug 37781; then
         w_warn "This may fail in non-XP mode, see https://bugs.winehq.org/show_bug.cgi?id=37781"
+        w_set_app_winver 'vc_redist.x86.exe' 'winxp'
+        w_set_app_winver 'vc_redist.x64.exe' 'winxp'
     fi
 
     w_override_dlls native,builtin api-ms-win-crt-conio-l1-1-0 api-ms-win-crt-heap-l1-1-0 api-ms-win-crt-locale-l1-1-0 api-ms-win-crt-math-l1-1-0 api-ms-win-crt-runtime-l1-1-0 api-ms-win-crt-stdio-l1-1-0 api-ms-win-crt-time-l1-1-0 atl140 concrt140 msvcp140 msvcr140 ucrtbase vcomp140 vcruntime140
-
-    w_set_winver winxp
 
     w_try_cd "$W_CACHE"/"$W_PACKAGE"
     w_try "$WINE" vc_redist.x86.exe $W_UNATTENDED_SLASH_Q


### PR DESCRIPTION
Attempt to improve handling of winenv for vcrun2015/7

Test run:
https://gist.githubusercontent.com/Kreyren/aeb5db05975079dbced68b9835c30159/raw/967cb8944696d00e856cd7f4b61c7e9ab8b9962c/sdgasdg

Note that the issue doesn't seem to be present anymore or my system is not affected:
https://gist.github.com/Kreyren/a579d5eebc8cf6292a175e87cf6e1de2

This prevents issues alike: https://github.com/Winetricks/winetricks/pull/1345#issuecomment-536001079

Signed-off-by: Jacob Hrbek <kreyren@rixotstudio.cz>