### PR TITLE
mtg_arena: new verb

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -18002,12 +18002,31 @@ load_mtg_arena()
     w_warn "Affected by https://bugs.winehq.org/show_bug.cgi?id=45898"
   fi
 
+  # https://bugs.winehq.org/show_bug.cgi?id=45546
   if w_workaround_wine_bug 45546; then
-    w_download "https://github.com/Kreyren/kreytricks/releases/download/7f230d2/MTGA.AppImage"
-    [ "$WINE" != "$W_CACHE/$W_PACKAGE/MTGA.AppImage" ] && w_die "This installer requires patched wine from '$W_CACHE/$W_PACKAGE/MTGA.AppImage' provide this path to the WINE variable and execute the script again."
+    if [ -n "$WINETRICKS_BUILD_WINE" ]; then
+      w_warn "We are about to build a wine from source and package it in AppImage"
+      wineappimagebuilder_patches() {
+        w_download "https://bugs.winehq.org/attachment.cgi?id=62956" '' "$W_CACHE/$W_PACKAGE/62956.diff"
+
+        if ! grep -qF "for (i = 0; i < 2000; i++)" "$wineappimagebuilder_workdir/wine-4.17/dlls/ntdll/thread.c"; then
+          patch "$wineappimagebuilder_workdir/wine-4.17/dlls/ntdll/thread.c" "$W_CACHE/$W_PACKAGE/62956.diff" || w_die "Failed to apply patch in '$wineappimagebuilder_workdir/wine-4.17/dlls/ntdll/thread.c'"
+        elif grep -qF "for (i = 0; i < 2000; i++)" "$wineappimagebuilder_workdir/wine-4.17/dlls/ntdll/thread.c"; then
+          w_debug "Patch for 45546 is already applied"
+        else w_die "Unexpected output in wineappimagebuilder_patches function"
+        fi
+      }
+      load_wineappimagebuilder
+    elif [ -z "$WINETRICKS_BUILD_WINE" ]; then
+      w_download "https://github.com/Kreyren/kreytricks/releases/download/7f230d2/MTGA.AppImage"
+    fi
+
+    # Sanitycheck for applied patches
+    [ "$WINE" != "$W_CACHE/$W_PACKAGE/MTGA.AppImage" ] && [ "$WINE" != "$W_CACHE/$W_PACKAGE/$W_PACKAGE.AppImage" ] && w_die "This installer requires patched wine named MTGA.AppImage' or '$W_PACKAGE.AppImage' from '$W_CACHE/$W_PACKAGE/' provide this path to the WINE variable and execute the script again. (You can also blacklist winebug 45546)"
   fi
 
-  (WINEDEBUG="fixme-all" w_try "$WINE" msiexec /i "${W_CACHE}/${W_PACKAGE}/${file1}")
+  w_warn "It may take few seconds for installer to launch (max 50sec)"
+  (WINEDEBUG="fixme-all" w_try "$WINE" msiexec /i "$W_CACHE/$W_PACKAGE/$file1")
 }
 
 #----------------------------------------------------------------

--- a/src/winetricks
+++ b/src/winetricks
@@ -17969,6 +17969,49 @@ load_hordesoforcs2_demo()
 
 #----------------------------------------------------------------
 
+# https://appdb.winehq.org/objectManager.php?sClass=version&iId=37229
+
+w_metadata mtg_arena games \
+    title="Magic: The Gathering arena" \
+    publisher="Wizards of the Coast" \
+    year="2019" \
+    media="download" \
+    installed_exe1="$W_PROGRAMS_X86_WIN/Wizards of the Coast/MTGA/MTGA.exe"
+
+load_mtg_arena()
+{
+  # https://bugs.winehq.org/show_bug.cgi?id=45937#c13
+  if w_workaround_wine_bug 45937; then
+    w_call 'usetakefocus=disabled'
+  fi
+
+  # https://bugs.winehq.org/show_bug.cgi?id=47820
+  if w_workaround_wine_bug 47820; then
+    # Credit: ZeroPointEnergy (https://appdb.winehq.org/objectManager.php?sClass=version&iId=37229)
+    w_warn "This may take a while to load"
+    w_download "https://mtgarena.downloads.wizards.com/Live/Windows32/versions/1790.733462/MTGAInstaller_0.1.1790.733462.msi"
+    export file1="MTGAInstaller_0.1.1790.733462.msi"
+    w_warn "Installer is going to complain about permssions set on windows, these doesn't seem to be related to WINE and doesn't affect the runtime of game"
+  elif ! w_workaround_wine_bug 47820; then
+    w_download "https://mtgarena.downloads.wizards.com/Live/Windows32/MTGAInstaller.exe"
+    export file1="MTGAInstaller.msi"
+  fi
+
+  # https://bugs.winehq.org/show_bug.cgi?id=45898
+  if w_workaround_wine_bug 45898; then
+    w_warn "Affected by https://bugs.winehq.org/show_bug.cgi?id=45898"
+  fi
+
+  if w_workaround_wine_bug 45546; then
+    w_download "https://github.com/Kreyren/kreytricks/releases/download/7f230d2/MTGA.AppImage"
+    [ "$WINE" != "$W_CACHE/$W_PACKAGE/MTGA.AppImage" ] && w_die "This installer requires patched wine from '$W_CACHE/$W_PACKAGE/MTGA.AppImage' provide this path to the WINE variable and execute the script again."
+  fi
+
+  (WINEDEBUG="fixme-all" w_try "$WINE" msiexec /i "${W_CACHE}/${W_PACKAGE}/${file1}")
+}
+
+#----------------------------------------------------------------
+
 w_metadata mfsxde games \
     title="Microsoft Flight Simulator X: Deluxe Edition" \
     publisher="Microsoft" \


### PR DESCRIPTION
DO NOT MERGE - Game was updated and this no longer works.

Adds Magic: The Gathering Arena verb

Referencing: https://github.com/PhoenicisOrg/scripts/issues/934

game using non-visualstuio installer works with output that doesn't seem to be relevant to WINE:
```
Executing wine msiexec /I /home/kreyren/.cache/winetricks/mtg_arena/MTGAInstaller_0.1.1790.733462.msi

Z:\home\kreyren>chcp 65001
Can't recognize 'chcp 65001 ' as an internal or external command, or batch script.

Z:\home\kreyren>del "C:\users\kreyren\Temp\{CE5264CC-7EDF-492E-84F6-B9E7A53A606A}.bat" /Q /F
Can't recognize 'C:\users\kreyren\Temp\{CE5264CC-7EDF-492E-84F6-B9E7A53A606A}.bat' as an internal or external command, or batch script.
```

Official uses visualstudio installer
- returns `0070:err:msi:custom_get_thread_return Invalid Return Code 1627` for https://mtgarena.downloads.wizards.com/Live/Windows32/MTGAInstaller.exe
- winebug https://bugs.winehq.org/show_bug.cgi?id=47820, logic adapted

Uses: https://github.com/Winetricks/winetricks/pull/1348

Signed-off-by: Jacob Hrbek <kreyren@rixotstudio.cz>