### PR TITLE
winetricks: Improved wording in source

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -15,7 +15,7 @@ WINETRICKS_VERSION=20190912-next
 
 #--------------------------------------------------------------------
 #
-# Winetricks is a package manager for Win32 dlls and applications on POSIX.
+# Winetricks is POSIX shell frontend for WINE to configure wineapps and it's components
 # Features:
 # - Consists of a single shell script - no installation required
 # - Downloads packages automatically from original trusted sources


### PR DESCRIPTION
Improved wording to prevent freenode.net/#bash and other scripters from freaking out about 25K+ long POSIX shell script that is a package manager.

<img width="852" alt="image" src="https://user-images.githubusercontent.com/11302521/65905859-b4060f00-e3c1-11e9-861d-635dc0c0fadb.png">

Signed-off-by: Jacob Hrbek <kreyren@rixotstudio.cz>