### PR TITLE
opensymbol: Update mirror

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -13034,7 +13034,7 @@ w_metadata opensymbol fonts \
     publisher="OpenOffice.org" \
     year="2017" \
     media="download" \
-    file1="fonts-opensymbol_102.10+LibO6.1.5-3+deb10u3_all.deb" \
+    file1="fonts-opensymbol_102.10+LibO6.1.5-3+deb10u4_all.deb" \
     installed_file1="$W_FONTSDIR_WIN/opens___.ttf"
 
 load_opensymbol()
@@ -13042,8 +13042,7 @@ load_opensymbol()
     # The OpenSymbol fonts are a replacement for the Windows Wingdings font from OpenOffice.org.
     # Need to w_download Debian since I can't find a standalone download from OpenOffice
     # Note: The source download package on debian is for _all_ of OpenOffice, which is 266 MB.
-    w_download "https://deb.debian.org/debian-security/pool/updates/main/libr/libreoffice/fonts-opensymbol_102.10+LibO6.1.5-3+deb10u3_all.deb" fb302a58166bf3fa29efee234d6659361213e5f36a7abfd948fa7288c5f7fb30
-
+    w_download "https://cdn-aws.deb.debian.org/debian-security/pool/updates/main/libr/libreoffice/fonts-opensymbol_102.10+LibO6.1.5-3+deb10u4_all.deb" 1b2ab1e8eeb9a3a4a07e4a1c9bf539bb721734bf8b9881f4d0b8e71e822cecde
     w_try_cd "$W_TMP"
     w_try_ar "$W_CACHE/$W_PACKAGE/$file1" data.tar.xz
     w_try tar -Jxf "$W_TMP/data.tar.xz" ./usr/share/fonts/truetype/openoffice/opens___.ttf


### PR DESCRIPTION
Fixes: https://github.com/Winetricks/winetricks/issues/1357

```console
kreyren@dreamon:~$ kreytricks prefix=opensymbol opensymbol
------------------------------------------------------
You are using a 64-bit WINEPREFIX. Note that many verbs only install 32-bit versions of packages. If you encounter problems, please retest in a clean 32-bit WINEPREFIX before reporting a bug.
------------------------------------------------------
Using winetricks 20190912-next - sha256sum: 419c6f274e9e91026017b78d5938ce5f9ad7bc6955fcc284d5717438f736d7bf with wine-4.17 (Staging) and WINEARCH=win64
------------------------------------------------------
You are using a 64-bit WINEPREFIX. Note that many verbs only install 32-bit versions of packages. If you encounter problems, please retest in a clean 32-bit WINEPREFIX before reporting a bug.
------------------------------------------------------
Executing w_do_call opensymbol
Executing load_opensymbol
Executing mkdir -p /home/kreyren/.cache/winetricks/opensymbol
Executing cd /home/kreyren/.cache/winetricks/opensymbol
Downloading https://cdn-aws.deb.debian.org/debian-security/pool/updates/main/libr/libreoffice/fonts-opensymbol_102.10+LibO6.1.5-3+deb10u4_all.deb to /home/kreyren/.cache/winetricks/opensymbol
--2019-10-02 18:44:11--  https://cdn-aws.deb.debian.org/debian-security/pool/updates/main/libr/libreoffice/fonts-opensymbol_102.10+LibO6.1.5-3+deb10u4_all.deb
Resolving cdn-aws.deb.debian.org (cdn-aws.deb.debian.org)... 13.225.78.120, 13.225.78.87, 13.225.78.74, ...
Connecting to cdn-aws.deb.debian.org (cdn-aws.deb.debian.org)|13.225.78.120|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 273072 (267K) [application/x-debian-package]
Saving to: ���fonts-opensymbol_102.10+LibO6.1.5-3+deb10u4_all.deb���

fonts-opensymbol_102.10+LibO6.1.5-3+deb1 100%[================================================================================>] 266.67K  --.-KB/s    in 0.07s

2019-10-02 18:44:12 (3.81 MB/s) - ���fonts-opensymbol_102.10+LibO6.1.5-3+deb10u4_all.deb��� saved [273072/273072]

Executing cd /home/kreyren
Executing cd /home/kreyren/.local/share/wineprefixes/opensymbol/dosdevices/c:/windows/temp/_opensymbol
Executing ar x /home/kreyren/.cache/winetricks/opensymbol/fonts-opensymbol_102.10+LibO6.1.5-3+deb10u4_all.deb data.tar.xz
Executing tar -Jxf /home/kreyren/.local/share/wineprefixes/opensymbol/dosdevices/c:/windows/temp/_opensymbol/data.tar.xz ./usr/share/fonts/truetype/openoffice/opens___.ttf
------------------------------------------------------
Running /usr/bin/wineserver -w. This will hang until all wine processes in prefix=/home/kreyren/.local/share/wineprefixes/opensymbol terminate
------------------------------------------------------
Executing wine regedit C:\windows\Temp\_opensymbol\_register-font.reg
Executing wine64 regedit C:\windows\Temp\_opensymbol\_register-font.reg
Executing cp /home/kreyren/.local/share/wineprefixes/opensymbol/dosdevices/c:/windows/temp/_opensymbol/_register-font.reg /tmp/winetricks.A53lPDmJ/_reg_27db49c0_25726.reg
Executing wine regedit C:\windows\Temp\_opensymbol\_register-font.reg
Executing wine64 regedit C:\windows\Temp\_opensymbol\_register-font.reg
Executing cp /home/kreyren/.local/share/wineprefixes/opensymbol/dosdevices/c:/windows/temp/_opensymbol/_register-font.reg /tmp/winetricks.A53lPDmJ/_reg_7fd847b4_25726.reg
```

Signed-off-by: Jacob Hrbek <kreyren@rixotstudio.cz>