### PR TITLE
reorder -f|--force options, required by bash-completion script

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -5320,7 +5320,7 @@ winetricks_handle_option()
 {
     case "$1" in
         --country=*) W_COUNTRY="${1##--country=}" ;;
-        --force|-f) WINETRICKS_FORCE=1;;
+        -f|--force) WINETRICKS_FORCE=1;;
         --gui) winetricks_detect_gui;;
         -h|--help) winetricks_usage ; exit 0 ;;
         --isolate) WINETRICKS_OPT_SHAREDPREFIX=0 ;;


### PR DESCRIPTION
 * winetricks.bash-completion: requries that short options are
   listed before long options, in the BASH case statement entries.
   This is due to simplified regex handling employed in the
   bash-completion script.
 * fixes a regression introduced by:
   f40b4655f8f3951730b271ee02ebe9dbcc619ecc