### PR TITLE
Update copyright

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -67,7 +67,7 @@ WINETRICKS_VERSION=20190912-next
 #   Copyright (C) 2011 Trevor Johnson
 #   Copyright (C) 2011 Franco Junio
 #   Copyright (C) 2011 Craig Sanders
-#   Copyright (C) 2011 Matthew Bauer <mjbauer95>
+#   Copyright (C) 2011 Matthew Bauer <mjbauer95!gmail.com>
 #   Copyright (C) 2011 Giuseppe Dia
 #   Copyright (C) 2011 Łukasz Wojniłowicz
 #   Copyright (C) 2011 Matthew Bozarth


### PR DESCRIPTION
I noticed that it's a little bit odd that Matthew Bauer has no proper contact information. First I thought it was the github username, but that would be an account that didn't even exist in 2011 (https://github.com/mjbauer95).
So I did a little bit of research and I suspect that it's this Matthew Bauer: https://github.com/matthewbauer
There is also his email specified, and I guess that's what should be there. It should definitely not be just <mjbauer95>, since that can lead to wrong assumptions (like my first one). In case this is not him or it can't be verified from anyone on this project anymore, I would simply remove the contact information, since misleading contact information is worse than none.