### PR TITLE
Add powershell app based on PowerShell Core 6.1,

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -14982,8 +14982,7 @@ load_powershell()
     w_try_7z  "$W_SYSTEM32_DLLS"/WindowsPowerShell/v1.0/ "${W_CACHE}/${W_PACKAGE}/${file1}"
     w_try_cd "$W_SYSTEM32_DLLS"/WindowsPowerShell/v1.0
     w_try cp -f pwsh.exe powershell.exe
-    for file in *\\*
-    do
+    for file in *\\*; do
         target=$(printf '%s\n' "$file" | sed 's#\\#/#g')
         w_try mkdir -p "${target%/*}"
         w_try mv -v "$file" "$target"

--- a/src/winetricks
+++ b/src/winetricks
@@ -14963,17 +14963,13 @@ w_metadata powershell apps \
 
 load_powershell()
 {
-    if test "$W_ARCH" = "win64"; then
-        w_die "Only implemented for 32bit arch at the moment"
-    fi
+    w_package_unsupported_win64
 
-    w_warn "Installing Powershell into $W_SYSTEM32_DLLS_WIN/WindowsPowerShell/v1.0/"
-    w_warn "So that apps that require psh scripts to be executed would find it"
-    w_warn "Note that some functionality may not work without Windows Management Framework"
+    w_warn "Installing Powershell into $W_SYSTEM32_DLLS_WIN/WindowsPowerShell/v1.0/. Note that some functionality may not work without Windows Management Framework"
 
     w_call dotnet462
 
-    w_download https://github.com/PowerShell/PowerShell/releases/download/v6.1.6/PowerShell-6.1.6-win-x86.zip 1dc690c9a1091d0ed5b71de903ab3cd7b58ba9638acdfeb9f9fe7031abaf47e9 PowerShell-6.1.6-win-x86.zip
+    w_download https://github.com/PowerShell/PowerShell/releases/download/v6.1.6/PowerShell-6.1.6-win-x86.zip 1dc690c9a1091d0ed5b71de903ab3cd7b58ba9638acdfeb9f9fe7031abaf47e9
 
     w_override_dlls native powershell.exe
 
@@ -14986,7 +14982,12 @@ load_powershell()
     w_try_7z  "$W_SYSTEM32_DLLS"/WindowsPowerShell/v1.0/ "${W_CACHE}/${W_PACKAGE}/${file1}"
     w_try_cd "$W_SYSTEM32_DLLS"/WindowsPowerShell/v1.0
     w_try cp -f pwsh.exe powershell.exe
-    for file in *\\*; do target="${file//\\//}"; mkdir -p "${target%/*}"; mv -v "$file" "$target"; done
+    for file in *\\*
+    do
+        target=$(printf '%s\n' "$file" | sed 's#\\#/#g')
+        w_try mkdir -p "${target%/*}"
+        w_try mv -v "$file" "$target"
+    done
     w_append_path "$W_SYSTEM32_DLLS"/WindowsPowerShell/v1.0
 }
 

--- a/src/winetricks
+++ b/src/winetricks
@@ -14977,7 +14977,7 @@ load_powershell()
     rm -f "$W_SYSTEM32_DLLS"/powershell.exe
 
 
-    mkdir -p "$W_SYSTEM32_DLLS"/WindowsPowerShell/v1.0
+    w_try mkdir -p "$W_SYSTEM32_DLLS"/WindowsPowerShell/v1.0
 
     w_try_7z  "$W_SYSTEM32_DLLS"/WindowsPowerShell/v1.0/ "${W_CACHE}/${W_PACKAGE}/${file1}"
     w_try_cd "$W_SYSTEM32_DLLS"/WindowsPowerShell/v1.0

--- a/src/winetricks
+++ b/src/winetricks
@@ -14953,6 +14953,45 @@ load_openwatcom()
 
 #----------------------------------------------------------------
 
+w_metadata powershell apps \
+    title="Windows Powershell" \
+    publisher="Microsoft" \
+    year="2019" \
+    media="download" \
+    file1="PowerShell-6.1.6-win-x86.zip" \
+    installed_file1="$W_SYSTEM32_DLLS_WIN/WindowsPowerShell/v1.0/powershell.exe"
+
+load_powershell()
+{
+    if test "$W_ARCH" = "win64"; then
+        w_die "Only implemented for 32bit arch at the moment"
+    fi
+
+    w_warn "Installing Powershell into $W_SYSTEM32_DLLS_WIN/WindowsPowerShell/v1.0/"
+    w_warn "So that apps that require psh scripts to be executed would find it"
+    w_warn "Note that some functionality may not work without Windows Management Framework"
+
+    w_call dotnet462
+
+    w_download https://github.com/PowerShell/PowerShell/releases/download/v6.1.6/PowerShell-6.1.6-win-x86.zip 1dc690c9a1091d0ed5b71de903ab3cd7b58ba9638acdfeb9f9fe7031abaf47e9 PowerShell-6.1.6-win-x86.zip
+
+    w_override_dlls native powershell.exe
+
+    # remove builtin placeholders
+    rm -f "$W_SYSTEM32_DLLS"/powershell.exe
+
+
+    mkdir -p "$W_SYSTEM32_DLLS"/WindowsPowerShell/v1.0
+
+    w_try_7z  "$W_SYSTEM32_DLLS"/WindowsPowerShell/v1.0/ "${W_CACHE}/${W_PACKAGE}/${file1}"
+    w_try_cd "$W_SYSTEM32_DLLS"/WindowsPowerShell/v1.0
+    w_try cp -f pwsh.exe powershell.exe
+    for file in *\\*; do target="${file//\\//}"; mkdir -p "${target%/*}"; mv -v "$file" "$target"; done
+    w_append_path "$W_SYSTEM32_DLLS"/WindowsPowerShell/v1.0
+}
+
+#----------------------------------------------------------------
+
 w_metadata protectionid apps \
     title="Protection ID" \
     publisher="CDKiLLER & TippeX" \


### PR DESCRIPTION
 functionality enough to satisfy installers requiring powershell

For example this allows Magic Arena ( https://magic.wizards.com/en/mtgarena ) installer work in wine


Note: https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-windows?view=powershell-6  says WMF is a prerequisite but I have not found a way to install it. And installing it this way is at least enough for installer to work (thus warns). 
It is also not clear what dotnet version it requires ... it works with 462 but probably any 45+ will work (not sure how to reflect such dependency)