### PR TITLE
wmp10: workaround for broken installer wmp10

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -15936,8 +15936,8 @@ load_wmp10()
     # Crashes on exit, but otherwise ok; see https://bugs.winehq.org/show_bug.cgi?id=12633
     w_try_cd "$W_CACHE/$W_PACKAGE"
     w_try cabextract -d "$W_TMP" ./MP10Setup.exe
-    w_try cd "$W_TMP"
-    w_try_cd "$WINE" setup_wm.exe $W_UNATTENDED_SLASH_CAP_QUIET
+    w_try_cd "$W_TMP"
+    "$WINE" setup_wm.exe $W_UNATTENDED_SLASH_CAP_QUIET
 
     # Disable WMP's services, since they depend on unimplemented stuff, they trigger the GUI debugger several times
     w_try_regedit /D "HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Services\\Cdr4_2K"

--- a/src/winetricks
+++ b/src/winetricks
@@ -4890,6 +4890,7 @@ winetricks_set_unattended()
             W_UNATTENDED_SLASH_QNT="/qnt"
             W_UNATTENDED_SLASH_QT="/qt"
             W_UNATTENDED_SLASH_QUIET="/quiet"
+            W_UNATTENDED_SLASH_CAP_QUIET="/Quiet"
             W_UNATTENDED_SLASH_S="/S"
             W_UNATTENDED_DASH_SILENT="-silent"
             W_UNATTENDED_SLASH_SILENT="/silent"
@@ -15936,7 +15937,7 @@ load_wmp10()
     w_try_cd "$W_CACHE/$W_PACKAGE"
     w_try cabextract -d "$W_TMP" ./MP10Setup.exe
     w_try cd "$W_TMP"
-    w_try "$WINE" setup_wm.exe $W_UNATTENDED_SLASH_Q
+    w_try "$WINE" setup_wm.exe $W_UNATTENDED_SLASH_CAP_QUIET
 
     # Disable WMP's services, since they depend on unimplemented stuff, they trigger the GUI debugger several times
     w_try_regedit /D "HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Services\\Cdr4_2K"

--- a/src/winetricks
+++ b/src/winetricks
@@ -15937,7 +15937,7 @@ load_wmp10()
     w_try_cd "$W_CACHE/$W_PACKAGE"
     w_try cabextract -d "$W_TMP" ./MP10Setup.exe
     w_try cd "$W_TMP"
-    w_try "$WINE" setup_wm.exe $W_UNATTENDED_SLASH_CAP_QUIET
+    w_try_cd "$WINE" setup_wm.exe $W_UNATTENDED_SLASH_CAP_QUIET
 
     # Disable WMP's services, since they depend on unimplemented stuff, they trigger the GUI debugger several times
     w_try_regedit /D "HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Services\\Cdr4_2K"

--- a/src/winetricks
+++ b/src/winetricks
@@ -15915,8 +15915,6 @@ load_wmp10()
 {
     w_package_unsupported_win64
 
-    w_package_broken "https://bugs.winehq.org/show_bug.cgi?id=48347" 5.0
-
     # FIXME: what versions of Windows are really bundled with wmp10?
     w_skip_windows wmp10 && return
 
@@ -15936,7 +15934,9 @@ load_wmp10()
 
     # Crashes on exit, but otherwise ok; see https://bugs.winehq.org/show_bug.cgi?id=12633
     w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" MP10Setup.exe $W_UNATTENDED_SLASH_Q
+    w_try cabextract -d "$W_TMP" ./MP10Setup.exe
+    w_try cd "$W_TMP"
+    w_try "$WINE" setup_wm.exe $W_UNATTENDED_SLASH_Q
 
     # Disable WMP's services, since they depend on unimplemented stuff, they trigger the GUI debugger several times
     w_try_regedit /D "HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Services\\Cdr4_2K"


### PR DESCRIPTION
Since bug 48347 is IMO a "wontfix" here`s workaround to still get wmp10 installed