### PR TITLE
new verb: dxtrans

### DIFF
--- a/files/verbs/dlls.txt
+++ b/files/verbs/dlls.txt
@@ -103,6 +103,7 @@ dxdiagn                  DirectX Diagnostic Library (Microsoft, 2011) [downloada
 dxdiag                   DirectX Diagnostic Tool (Microsoft, 2010) [downloadable]
 dxsdk_jun2010            MS DirectX SDK, June 2010 (developers only) (Microsoft, 2010) [downloadable]
 dxsdk_nov2006            MS DirectX SDK, November 2006 (developers only) (Microsoft, 2006) [downloadable]
+dxtrans                  MS dxtrans.dll (Microsoft, 2002) [downloadable]
 dxvk054                  Vulkan-based D3D11 implementation for Linux / Wine (0.54) (Philip Rebohle, 2017) [downloadable]
 dxvk060                  Vulkan-based D3D11 implementation for Linux / Wine (0.60) (Philip Rebohle, 2017) [downloadable]
 dxvk061                  Vulkan-based D3D11 implementation for Linux / Wine (0.61) (Philip Rebohle, 2017) [downloadable]

--- a/src/winetricks
+++ b/src/winetricks
@@ -6829,6 +6829,24 @@ load_dxsdk_jun2010()
 
 #----------------------------------------------------------------
 
+w_metadata dxtrans dlls \
+    title="MS dxtrans.dll" \
+    publisher="Microsoft" \
+    year="2002" \
+    media="download" \
+    file1="../winxpsp3/WindowsXP-KB936929-SP3-x86-ENU.exe" \
+    installed_file1="$W_SYSTEM32_DLLS_WIN/dxtrans.dll" \
+
+load_dxtrans()
+{
+    helper_winxpsp3 i386/dxtrans.dl_
+    w_try_cabextract --directory="$W_SYSTEM32_DLLS" "$W_TMP"/i386/dxtrans.dl_
+    w_override_dlls native,builtin dxtrans
+    w_try_regsvr dxtrans.dll
+}
+
+#----------------------------------------------------------------
+
 # $1 - dxvk archive name (required)
 # $2 - minimum Wine version (required)
 # $3 - minimum Vulkan API version (required)


### PR DESCRIPTION
Add a new dxtrans verb, which extracts dxtrans.dll from downloaded WindowsXP-KB936929-SP3-x86-ENU.exe, copies it to system32 and registers. That dll is required by Windows Movie Maker 2.0 installer and missing in Wine by default.
Just checked: after my chages, installing MS dxtrans works correctly.
I preferred using already implemented XPSP3 helper instead of adding a new DirectX 8.x helper, because it is a bit hard to find original DirectX 8.2 XP installer in the Web, since it was removed from the MS website.
Also I doubt about publishing year: should I use a year when the file has been changed last time or a year when that DirectX version has been released? :thinking: 