### PR TITLE
new setting: mackeyremap

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -20959,6 +20959,34 @@ _EOF_
 }
 
 #----------------------------------------------------------------
+
+w_metadata mackeyremap=y settings \
+    title="Enable mapping opt->alt and cmd->ctrl keys for the Mac native driver"
+w_metadata mackeyremap=n settings \
+    title="Do not remap keys for the Mac native driver (default)"
+
+load_mackeyremap()
+{
+    case "$1" in
+        y|n) arg=$1;;
+        *) w_die "illegal value $1 for MacKeyRemap";;
+    esac
+    
+    echo "Setting MacKeyRemap to $arg"
+    cat > "$W_TMP"/set-mackeyremap.reg <<_EOF_
+REGEDIT4
+
+[HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver]
+"LeftCommandIsCtrl"="$arg"
+"LeftOptionIsAlt"="$arg"
+"RightCommandIsCtrl"="$arg"
+"RightOptionIsAlt"="$arg"
+
+_EOF_
+    w_try_regedit "$W_TMP"/set-mackeyremap.reg
+}
+
+#----------------------------------------------------------------
 # X11 Driver settings
 
 w_metadata grabfullscreen=y settings \

--- a/src/winetricks
+++ b/src/winetricks
@@ -20960,15 +20960,19 @@ _EOF_
 
 #----------------------------------------------------------------
 
-w_metadata mackeyremap=y settings \
+w_metadata mackeyremap=both settings \
     title="Enable mapping opt->alt and cmd->ctrl keys for the Mac native driver"
-w_metadata mackeyremap=n settings \
+w_metadata mackeyremap=left settings \
+    title="Enable mapping of left opt->alt and cmd->ctrl keys for the Mac native driver"
+w_metadata mackeyremap=none settings \
     title="Do not remap keys for the Mac native driver (default)"
 
 load_mackeyremap()
 {
     case "$1" in
-        y|n) arg=$1;;
+        both|y) arg=both; _W_arg_l=y; _W_arg_r=y ;;
+        left)   arg=left; _W_arg_l=y; _W_arg_r=n ;;
+        none|n) arg=none; _W_arg_l=n; _W_arg_r=n ;;
         *) w_die "illegal value $1 for MacKeyRemap";;
     esac
 
@@ -20977,13 +20981,15 @@ load_mackeyremap()
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver]
-"LeftCommandIsCtrl"="$arg"
-"LeftOptionIsAlt"="$arg"
-"RightCommandIsCtrl"="$arg"
-"RightOptionIsAlt"="$arg"
+"LeftCommandIsCtrl"="$_W_arg_l"
+"LeftOptionIsAlt"="$_W_arg_l"
+"RightCommandIsCtrl"="$_W_arg_r"
+"RightOptionIsAlt"="$_W_arg_r"
 
 _EOF_
     w_try_regedit "$W_TMP"/set-mackeyremap.reg
+
+    unset _W_arg_l _W_arg_r
 }
 
 #----------------------------------------------------------------

--- a/src/winetricks
+++ b/src/winetricks
@@ -20971,7 +20971,7 @@ load_mackeyremap()
         y|n) arg=$1;;
         *) w_die "illegal value $1 for MacKeyRemap";;
     esac
-    
+
     echo "Setting MacKeyRemap to $arg"
     cat > "$W_TMP"/set-mackeyremap.reg <<_EOF_
 REGEDIT4


### PR DESCRIPTION
enables remapping of modifier keys for mac keyboards. See Wine Bug 35351

This is only applicable in Wine >= 3.17 and when using macdriver=mac