### PR TITLE
Fix dxvk_master verb downloading from d9vk repository

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -7986,12 +7986,12 @@ w_metadata dxvk_master dlls \
 
 load_dxvk_master()
 {
-    # https://git.froggi.es/joshua/d9vk
+    # https://git.froggi.es/doitsujin/dxvk
     # FIXME: Delete cached file, when verb is forced. Gitlab artifacts do not supply any version/commit hash information.
     if test "$WINETRICKS_FORCE" = 1 && test -f "${W_CACHE}/${W_PACKAGE}/${file1}"; then
         w_try rm -f "${W_CACHE}/${W_PACKAGE}/${file1}"
     fi
-    w_linkcheck_ignore=1 w_download_to "${W_CACHE}/${W_PACKAGE}" "https://git.froggi.es/joshua/d9vk/-/jobs/artifacts/master/download?job=dxvk" "" "dxvk_master.zip"
+    w_linkcheck_ignore=1 w_download_to "${W_CACHE}/${W_PACKAGE}" "https://git.froggi.es/doitsujin/dxvk/-/jobs/artifacts/master/download?job=dxvk" "" "dxvk_master.zip"
     helper_dxvk_d9vk "$file1" "4.20" "1.1.113" "dxgi,d3d9,d3d10,d3d11"
 }
 


### PR DESCRIPTION
The referenced D9VK repository for this verb is achieved and unmaintained, as it was merged with DXVK. It no longer receives the latest builds of DXVK.