### PR TITLE
dotnet: Override mscorwks to native.

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -8254,6 +8254,8 @@ load_dotnet11()
         WINEDLLOVERRIDES="regsvcs.exe=b" w_try "$WINE" dotnetfx.exe
     fi
 
+    w_override_dlls native mscorwks
+
     W_NGEN_CMD="w_try $WINE $W_DRIVE_C/windows/Microsoft.NET/Framework/v1.1.4322/ngen.exe executequeueditems"
 }
 
@@ -8308,6 +8310,8 @@ load_dotnet11sp1()
     else
         WINEDLLOVERRIDES="regsvcs.exe=b" w_try "$WINE" "$W_CACHE"/dotnet11sp1/NDP1.1sp1-KB867460-X86.exe
     fi
+
+    w_override_dlls native mscorwks
 
     W_NGEN_CMD="w_try $WINE $W_DRIVE_C/windows/Microsoft.NET/Framework/v1.1.4322/ngen.exe executequeueditems"
 }
@@ -8394,6 +8398,8 @@ load_dotnet20()
         w_try_cd "$W_CACHE"/"$W_PACKAGE"
         w_try "$WINE" NetFx64.exe ${W_OPT_UNATTENDED:+/q /c:"install.exe /q"}
     fi
+
+    w_override_dlls native mscorwks
 
     W_NGEN_CMD="w_try $WINE $W_DRIVE_C/windows/Microsoft.NET/Framework/v2.0.50727/ngen.exe executequeueditems"
 }
@@ -8543,6 +8549,8 @@ load_dotnet20sp1()
 
     W_NGEN_CMD="w_try $WINE $W_DRIVE_C/windows/Microsoft.NET/Framework/v2.0.50727/ngen.exe executequeueditems"
 
+    w_override_dlls native mscorwks
+
     # Installs the same file(name)s as dotnet35sp1, let users install dotnet35sp1 after dotnet20sp1
     w_try touch "${W_WINDIR_UNIX}/dotnet20sp1.installed.workaround"
 }
@@ -8613,6 +8621,7 @@ load_dotnet20sp2()
     fi
 
     w_set_winver 'default'
+    w_override_dlls native mscorwks
 
     W_NGEN_CMD="w_try $WINE $W_DRIVE_C/windows/Microsoft.NET/Framework/v2.0.50727/ngen.exe executequeueditems"
 }
@@ -8694,6 +8703,8 @@ load_dotnet30()
     w_warn "Installing .NET 3.0 runtime silently, as otherwise it gets hidden behind taskbar. Installation usually takes about 3 minutes."
     w_try "$WINE" "$file1" /q /c:"install.exe /q"
 
+    w_override_dlls native mscorwks
+
     # Doesn't install any ngen.exe
     # W_NGEN_CMD=""
 }
@@ -8760,6 +8771,7 @@ load_dotnet30sp1()
         *) w_die "exit status $status - $W_PACKAGE installation failed" ;;
     esac
 
+    w_override_dlls native mscorwks
     w_set_winver 'default'
 
     # Doesn't install any ngen.exe
@@ -8802,7 +8814,7 @@ load_dotnet35()
 
     w_set_winver winxp
 
-    w_override_dlls native mscoree
+    w_override_dlls native mscoree mscorwks
     w_wineserver -w
 
     w_try_cd "$W_CACHE/$W_PACKAGE"


### PR DESCRIPTION
From <https://bugs.winehq.org/show_bug.cgi?id=48218>. Either the application
or the .NET runtime tries to load mscorwks.dll from a fixed path which
doesn't contain mscorwks.dll, causing the builtin stub to be loaded in its
stead instead of returning failure.

Tested with "winetricks-test dotnet", no failures.