### PR TITLE
load_gdiplus_winxp: update to newer winxp gdiplus

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -10007,18 +10007,18 @@ load_gdiplus()
 w_metadata gdiplus_winxp dlls \
     title="MS GDI+" \
     publisher="Microsoft" \
-    year="2004" \
+    year="2009" \
     media="manual_download" \
-    file1="NDP1.0sp2-KB830348-X86-Enu.exe" \
+    file1="WindowsXP-KB975337-x86-ENU.exe" \
     installed_file1="$W_SYSTEM32_DLLS_WIN/gdiplus.dll"
 
 load_gdiplus_winxp()
 {
     # https://www.microsoft.com/en-us/download/details.aspx?id=5339
-    w_download https://download.microsoft.com/download/1/4/6/1467c2ba-4d1f-43ad-8d9b-3e8bc1c6ac3d/NDP1.0sp2-KB830348-X86-Enu.exe 3c6c7eed4a0ccd2ea2ce0446359b8c752dd2a3b82332663f655e803ce0b05335
+    w_download https://web.archive.org/web/20140615000000/http://download.microsoft.com/download/a/b/c/abc45517-97a0-4cee-a362-1957be2f24e1/WindowsXP-KB975337-x86-ENU.exe 699e76e9f100db3d50da8762c484a369df4698d4b84f7821d4df0e37ce68bcbe
     w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try_cabextract -d "$W_TMP" -F FL_gdiplus_dll_____X86.3643236F_FC70_11D3_A536_0090278A1BB8 "$W_CACHE/${W_PACKAGE}/$file1"
-    w_try cp "$W_TMP/FL_gdiplus_dll_____X86.3643236F_FC70_11D3_A536_0090278A1BB8" "$W_SYSTEM32_DLLS/gdiplus.dll"
+    w_try_cabextract -d "$W_TMP" -F _sfx_0005._p "$W_CACHE/${W_PACKAGE}/$file1"
+    w_try cp "$W_TMP/_sfx_0005._p" "$W_SYSTEM32_DLLS/gdiplus.dll"
 
     # For some reason, native, builtin isn't good enough...?
     w_override_dlls native gdiplus


### PR DESCRIPTION
There is a much newer version of gdiplus for Windows XP available from the internet archive (2009 instead of 2004). Playonlinux has been using the newer version for a while: https://www.playonlinux.com/en/app-518-POL_Install_gdiplus.html

This PR updates `load_gdiplus_winxp` to load the newer version of gdiplus.