### PR TITLE
Various speechsdk fixes

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -11645,7 +11645,8 @@ load_speechsdk()
 
     w_override_dlls native sapi
 
-    w_set_winver 'default'
+    # SAPI 5.1 doesn't work on vista and newer
+    w_set_winver winxp
 }
 
 #----------------------------------------------------------------

--- a/src/winetricks
+++ b/src/winetricks
@@ -11618,6 +11618,8 @@ w_metadata speechsdk dlls \
 
 load_speechsdk()
 {
+    w_package_warn_win64
+
     # https://www.microsoft.com/en-us/download/details.aspx?id=10121
     w_download https://download.microsoft.com/download/B/4/3/B4314928-7B71-4336-9DE7-6FA4CF00B7B3/SpeechSDK51.exe 520aa5d1a72dc6f41dc9b8b88603228ffd5d5d6f696224fc237ec4828fe7f6e0
 

--- a/src/winetricks
+++ b/src/winetricks
@@ -5057,7 +5057,6 @@ winetricks_set_wineprefix()
         W_PROGRAMS_UNIX="$(w_pathconv -u "$W_PROGRAMS_WIN")"
 
         # Common variable for 32-bit dlls on win32/win64:
-        W_32BIT_DLLS="$W_WINDIR_UNIX/syswow64"
         W_SYSTEM32_DLLS="$W_WINDIR_UNIX/syswow64"
         W_SYSTEM32_DLLS_WIN="C:\\windows\\syswow64"
 
@@ -5094,7 +5093,6 @@ winetricks_set_wineprefix()
         W_PROGRAMS_UNIX="$(w_pathconv -u "$W_PROGRAMS_WIN")"
 
         # Common variable for 32-bit dlls on win32/win64:
-        W_32BIT_DLLS="$W_WINDIR_UNIX/system32"
         W_SYSTEM32_DLLS="$W_WINDIR_UNIX/system32"
         W_SYSTEM32_DLLS_WIN="C:\\windows\\system32"
 
@@ -11640,7 +11638,8 @@ load_speechsdk()
 
     # If sapi.dll isn't in original location, applications won't start, see
     # e.g., https://bugs.winehq.org/show_bug.cgi?id=43841
-    w_try ln -s "$W_COMMONFILES_X86/Microsoft Shared/Speech/sapi.dll" "$W_32BIT_DLLS/Speech/Common"
+    mkdir -p "$W_SYSTEM32_DLLS/Speech/Common/"
+    w_try ln -s "$W_COMMONFILES_X86/Microsoft Shared/Speech/sapi.dll" "$W_SYSTEM32_DLLS/Speech/Common"
 
     w_override_dlls native sapi
 


### PR DESCRIPTION
This should fix #1517. (except for the request for newer speechsdk version, but I think that could/should be a new issue)

I also removed the W_32BIT_DLLS variable as it was the same as W_SYSTEM32_DLLS and only used in speechsdk.

I added a warn for 64bit as it seems only a 32bit dll is installed.

If any of the above is not desirable, let me know.