### PR TITLE
Add separate mfc verbs

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -11965,6 +11965,21 @@ load_vcrun2003()
     w_try_7z "$W_SYSTEM32_DLLS" "${W_CACHE}/vcrun2003/BZEditW32_1.6.5.exe" "mfc71.dll" "msvcp71.dll" "msvcr71.dll" -y
 }
 
+w_metadata mfc71 dlls \
+    title="Visual C++ 2003 mfc71 library; part of vcrun2003" \
+    publisher="Microsoft" \
+    year="2003" \
+    media="download" \
+    file1="BZEditW32_1.6.5.exe" \
+    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc71.dll"
+
+load_mfc71()
+{
+    w_download_to vcrun2003 https://sourceforge.net/projects/bzflag/files/bzedit%20win32/1.6.5/BZEditW32_1.6.5.exe 84d1bda5dbf814742898a2e1c0e4bc793e9bc1fba4b7a93d59a7ef12bd0fd802
+
+    w_try_7z "$W_SYSTEM32_DLLS" "${W_CACHE}/vcrun2003/BZEditW32_1.6.5.exe" "mfc71.dll" -y
+}
+
 #----------------------------------------------------------------
 
 # Temporary fix for bug 169

--- a/src/winetricks
+++ b/src/winetricks
@@ -12181,6 +12181,39 @@ load_vcrun2010()
     esac
 }
 
+w_metadata mfc100 dlls \
+    title="Visual C++ 2010 mfc100 library; part of vcrun2010" \
+    publisher="Microsoft" \
+    year="2010" \
+    media="download" \
+    file1="../vcrun2010/vcredist_x86.exe" \
+    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc100u.dll"
+
+load_mfc100()
+{
+    w_download_to vcrun2010 https://download.microsoft.com/download/5/B/C/5BC5DBB3-652D-4DCE-B14A-475AB85EEF6E/vcredist_x86.exe 8162b2d665ca52884507ede19549e99939ce4ea4a638c537fa653539819138c8
+
+    w_try_cabextract --directory="$W_TMP/win32" "$W_CACHE"/vcrun2010/vcredist_x86.exe -F '*.cab'
+    w_try_cabextract --directory="$W_TMP/win32" "$W_TMP/win32/vc_red.cab"
+
+    w_try cp "$W_TMP/win32"/F_CENTRAL_mfc100_x86 "$W_SYSTEM32_DLLS"/mfc100.dll
+    w_try cp "$W_TMP/win32"/F_CENTRAL_mfc100u_x86 "$W_SYSTEM32_DLLS"/mfc100u.dll
+    w_try cp "$W_TMP/win32"/F_CENTRAL_mfcm100_x86 "$W_SYSTEM32_DLLS"/mfcm100.dll
+    w_try cp "$W_TMP/win32"/F_CENTRAL_mfcm100u_x86 "$W_SYSTEM32_DLLS"/mfcm100u.dll
+
+    if [ "$W_ARCH" = "win64" ]; then
+        w_download_to vcrun2010 https://download.microsoft.com/download/A/8/0/A80747C3-41BD-45DF-B505-E9710D2744E0/vcredist_x64.exe c6cd2d3f0b11dc2a604ffdc4dd97861a83b77e21709ba71b962a47759c93f4c8
+
+        w_try_cabextract --directory="$W_TMP/win64" "$W_CACHE"/vcrun2010/vcredist_x64.exe -F '*.cab'
+        w_try_cabextract --directory="$W_TMP/win64" "$W_TMP/win64/vc_red.cab"
+
+        w_try cp "$W_TMP/win64"/F_CENTRAL_mfc100_x64 "$W_SYSTEM64_DLLS"/mfc100.dll
+        w_try cp "$W_TMP/win64"/F_CENTRAL_mfc100u_x64 "$W_SYSTEM64_DLLS"/mfc100u.dll
+        w_try cp "$W_TMP/win64"/F_CENTRAL_mfcm100_x64 "$W_SYSTEM64_DLLS"/mfcm100.dll
+        w_try cp "$W_TMP/win64"/F_CENTRAL_mfcm100u_x64 "$W_SYSTEM64_DLLS"/mfcm100u.dll
+    fi
+}
+
 #----------------------------------------------------------------
 
 w_metadata vcrun2012 dlls \

--- a/src/winetricks
+++ b/src/winetricks
@@ -12256,6 +12256,39 @@ load_vcrun2012()
     esac
 }
 
+w_metadata mfc110 dlls \
+    title="Visual C++ 2012 mfc110 library; part of vcrun2012" \
+    publisher="Microsoft" \
+    year="2012" \
+    media="download" \
+    file1="../vcrun2012/vcredist_x86.exe" \
+    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc110u.dll"
+
+load_mfc110()
+{
+    w_download_to vcrun2012 https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe b924ad8062eaf4e70437c8be50fa612162795ff0839479546ce907ffa8d6e386
+
+    w_try_cabextract --directory="$W_TMP/win32"  "$W_CACHE"/vcrun2012/vcredist_x86.exe -F 'a3'
+    w_try_cabextract --directory="$W_TMP/win32" "$W_TMP/win32/a3"
+
+    w_try cp "$W_TMP/win32"/F_CENTRAL_mfc110_x86 "$W_SYSTEM32_DLLS"/mfc110.dll
+    w_try cp "$W_TMP/win32"/F_CENTRAL_mfc110u_x86 "$W_SYSTEM32_DLLS"/mfc110u.dll
+    w_try cp "$W_TMP/win32"/F_CENTRAL_mfcm110_x86 "$W_SYSTEM32_DLLS"/mfcm110.dll
+    w_try cp "$W_TMP/win32"/F_CENTRAL_mfcm110u_x86 "$W_SYSTEM32_DLLS"/mfcm110u.dll
+
+    if [ "$W_ARCH" = "win64" ]; then
+        w_download_to vcrun2012 https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe 681be3e5ba9fd3da02c09d7e565adfa078640ed66a0d58583efad2c1e3cc4064
+
+        w_try_cabextract --directory="$W_TMP/win64"  "$W_CACHE"/vcrun2012/vcredist_x64.exe -F 'a3'
+        w_try_cabextract --directory="$W_TMP/win64" "$W_TMP/win64/a3"
+
+        w_try cp "$W_TMP/win64"/F_CENTRAL_mfc110_x64 "$W_SYSTEM64_DLLS"/mfc110.dll
+        w_try cp "$W_TMP/win64"/F_CENTRAL_mfc110u_x64 "$W_SYSTEM64_DLLS"/mfc110u.dll
+        w_try cp "$W_TMP/win64"/F_CENTRAL_mfcm110_x64 "$W_SYSTEM64_DLLS"/mfcm110.dll
+        w_try cp "$W_TMP/win64"/F_CENTRAL_mfcm110u_x64 "$W_SYSTEM64_DLLS"/mfcm110u.dll
+    fi
+}
+
 #----------------------------------------------------------------
 
 w_metadata vcrun2013 dlls \

--- a/src/winetricks
+++ b/src/winetricks
@@ -12333,6 +12333,39 @@ load_vcrun2013()
     esac
 }
 
+w_metadata mfc120 dlls \
+    title="Visual C++ 2013 mfc120 library; part of vcrun2013" \
+    publisher="Microsoft" \
+    year="2013" \
+    media="download" \
+    file1="../vcrun2013/vcredist_x86.exe" \
+    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc120u.dll"
+
+load_mfc120()
+{
+    w_download_to vcrun2013 https://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x86.exe 89f4e593ea5541d1c53f983923124f9fd061a1c0c967339109e375c661573c17
+
+    w_try_cabextract --directory="$W_TMP/win32"  "$W_CACHE"/vcrun2013/vcredist_x86.exe -F 'a3'
+    w_try_cabextract --directory="$W_TMP/win32" "$W_TMP/win32/a3"
+
+    w_try cp "$W_TMP/win32"/F_CENTRAL_mfc120_x86 "$W_SYSTEM32_DLLS"/mfc120.dll
+    w_try cp "$W_TMP/win32"/F_CENTRAL_mfc120u_x86 "$W_SYSTEM32_DLLS"/mfc120u.dll
+    w_try cp "$W_TMP/win32"/F_CENTRAL_mfcm120_x86 "$W_SYSTEM32_DLLS"/mfcm120.dll
+    w_try cp "$W_TMP/win32"/F_CENTRAL_mfcm120u_x86 "$W_SYSTEM32_DLLS"/mfcm120u.dll
+
+    if [ "$W_ARCH" = "win64" ]; then
+        w_download_to vcrun2013 https://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x64.exe 20e2645b7cd5873b1fa3462b99a665ac8d6e14aae83ded9d875fea35ffdd7d7e
+
+        w_try_cabextract --directory="$W_TMP/win64"  "$W_CACHE"/vcrun2013/vcredist_x64.exe -F 'a3'
+        w_try_cabextract --directory="$W_TMP/win64" "$W_TMP/win64/a3"
+
+        w_try cp "$W_TMP/win64"/F_CENTRAL_mfc120_x64 "$W_SYSTEM64_DLLS"/mfc120.dll
+        w_try cp "$W_TMP/win64"/F_CENTRAL_mfc120u_x64 "$W_SYSTEM64_DLLS"/mfc120u.dll
+        w_try cp "$W_TMP/win64"/F_CENTRAL_mfcm120_x64 "$W_SYSTEM64_DLLS"/mfcm120.dll
+        w_try cp "$W_TMP/win64"/F_CENTRAL_mfcm120u_x64 "$W_SYSTEM64_DLLS"/mfcm120u.dll
+    fi
+}
+
 #----------------------------------------------------------------
 
 w_metadata vcrun2015 dlls \

--- a/src/winetricks
+++ b/src/winetricks
@@ -12108,6 +12108,39 @@ load_vcrun2008()
     esac
 }
 
+w_metadata mfc90 dlls \
+    title="Visual C++ 2008 mfc90 library; part of vcrun2008" \
+    publisher="Microsoft" \
+    year="2011" \
+    media="download" \
+    file1="../vcrun2008/vcredist_x86.exe" \
+    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc90.dll"
+
+load_mfc90()
+{
+    w_download_to vcrun2008 https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x86.exe 6b3e4c51c6c0e5f68c8a72b497445af3dbf976394cbb62aa23569065c28deeb6
+
+    w_try_cabextract --directory="$W_TMP/win32" "$W_CACHE"/vcrun2008/vcredist_x86.exe -F 'vc_red.cab'
+    w_try_cabextract --directory="$W_TMP/win32" "$W_TMP/win32/vc_red.cab"
+
+    w_try cp "$W_TMP/win32"/mfc90.dll.30729.6161.Microsoft_VC90_MFC_x86.QFE "$W_SYSTEM32_DLLS"/mfc90.dll
+    w_try cp "$W_TMP/win32"/mfc90u.dll.30729.6161.Microsoft_VC90_MFC_x86.QFE "$W_SYSTEM32_DLLS"/mfc90u.dll
+    w_try cp "$W_TMP/win32"/mfcm90.dll.30729.6161.Microsoft_VC90_MFC_x86.QFE "$W_SYSTEM32_DLLS"/mfcm90.dll
+    w_try cp "$W_TMP/win32"/mfcm90u.dll.30729.6161.Microsoft_VC90_MFC_x86.QFE "$W_SYSTEM32_DLLS"/mfcm90u.dll
+
+    if [ "$W_ARCH" = "win64" ]; then
+        w_download_to vcrun2008 https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x64.exe b811f2c047a3e828517c234bd4aa4883e1ec591d88fad21289ae68a6915a6665
+
+        w_try_cabextract --directory="$W_TMP/win64" "$W_CACHE"/vcrun2008/vcredist_x64.exe -F 'vc_red.cab'
+        w_try_cabextract --directory="$W_TMP/win64" "$W_TMP/win64/vc_red.cab"
+
+        w_try cp "$W_TMP/win64"/mfc90.dll.30729.6161.Microsoft_VC90_MFC_x64.QFE "$W_SYSTEM64_DLLS"/mfc90.dll
+        w_try cp "$W_TMP/win64"/mfc90u.dll.30729.6161.Microsoft_VC90_MFC_x64.QFE "$W_SYSTEM64_DLLS"/mfc90u.dll
+        w_try cp "$W_TMP/win64"/mfcm90.dll.30729.6161.Microsoft_VC90_MFC_x64.QFE "$W_SYSTEM64_DLLS"/mfcm90.dll
+        w_try cp "$W_TMP/win64"/mfcm90u.dll.30729.6161.Microsoft_VC90_MFC_x64.QFE "$W_SYSTEM64_DLLS"/mfcm90u.dll
+    fi
+}
+
 #----------------------------------------------------------------
 
 w_metadata vcrun2010 dlls \

--- a/src/winetricks
+++ b/src/winetricks
@@ -12022,6 +12022,39 @@ load_vcrun2005()
     fi
 }
 
+w_metadata mfc80 dlls \
+    title="Visual C++ 2005 mfc80 library; part of vcrun2005" \
+    publisher="Microsoft" \
+    year="2011" \
+    media="download" \
+    file1="../vcrun2005/vcredist_x86.EXE" \
+    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc80.dll"
+
+load_mfc80()
+{
+    w_download_to vcrun2005 https://download.microsoft.com/download/8/B/4/8B42259F-5D70-43F4-AC2E-4B208FD8D66A/vcredist_x86.EXE 4ee4da0fe62d5fa1b5e80c6e6d88a4a2f8b3b140c35da51053d0d7b72a381d29
+
+    w_try_cabextract --directory="$W_TMP/win32" "$W_CACHE"/vcrun2005/vcredist_x86.EXE -F 'vcredist.msi'
+    w_try_cabextract --directory="$W_TMP/win32" "$W_TMP/win32/vcredist.msi"
+
+    w_try cp "$W_TMP/win32"/mfc80.dll.8.0.50727.6195.9BAE13A2_E7AF_D6C3_FF1F_C8B3B9A1E18E "$W_SYSTEM32_DLLS"/mfc80.dll
+    w_try cp "$W_TMP/win32"/mfc80u.dll.8.0.50727.6195.9BAE13A2_E7AF_D6C3_FF1F_C8B3B9A1E18E "$W_SYSTEM32_DLLS"/mfc80u.dll
+    w_try cp "$W_TMP/win32"/mfcm80.dll.8.0.50727.6195.9BAE13A2_E7AF_D6C3_FF1F_C8B3B9A1E18E "$W_SYSTEM32_DLLS"/mfcm80.dll
+    w_try cp "$W_TMP/win32"/mfcm80u.dll.8.0.50727.6195.9BAE13A2_E7AF_D6C3_FF1F_C8B3B9A1E18E "$W_SYSTEM32_DLLS"/mfcm80u.dll
+
+    if [ "$W_ARCH" = "win64" ]; then
+        w_download_to vcrun2005 https://download.microsoft.com/download/8/B/4/8B42259F-5D70-43F4-AC2E-4B208FD8D66A/vcredist_x64.EXE 0551a61c85b718e1fa015b0c3e3f4c4eea0637055536c00e7969286b4fa663e0
+
+        w_try_cabextract --directory="$W_TMP/win64" "$W_CACHE"/vcrun2005/vcredist_x64.EXE -F 'vcredist.msi'
+        w_try_cabextract --directory="$W_TMP/win64" "$W_TMP/win64/vcredist.msi"
+
+        w_try cp "$W_TMP/win64"/mfc80.dll.8.0.50727.6195.8731EA9C_B0D8_8F16_FF1F_C8B3B9A1E18E "$W_SYSTEM64_DLLS"/mfc80.dll
+        w_try cp "$W_TMP/win64"/mfc80u.dll.8.0.50727.6195.8731EA9C_B0D8_8F16_FF1F_C8B3B9A1E18E "$W_SYSTEM64_DLLS"/mfc80u.dll
+        w_try cp "$W_TMP/win64"/mfcm80.dll.8.0.50727.6195.8731EA9C_B0D8_8F16_FF1F_C8B3B9A1E18E "$W_SYSTEM64_DLLS"/mfcm80.dll
+        w_try cp "$W_TMP/win64"/mfcm80u.dll.8.0.50727.6195.8731EA9C_B0D8_8F16_FF1F_C8B3B9A1E18E "$W_SYSTEM64_DLLS"/mfcm80u.dll
+    fi
+}
+
 #----------------------------------------------------------------
 
 w_metadata vcrun2008 dlls \

--- a/src/winetricks
+++ b/src/winetricks
@@ -11958,13 +11958,11 @@ w_metadata vcrun2003 dlls \
 
 load_vcrun2003()
 {
-    # Load the Visual C++ 2003 runtime libraries
     # Sadly, I know of no Microsoft URL for these
-    echo "Installing BZFlag (which comes with the Visual C++ 2003 runtimes)"
     # winetricks-test can't handle ${file1} in url since it does a raw parsing :/
     w_download https://sourceforge.net/projects/bzflag/files/bzedit%20win32/1.6.5/BZEditW32_1.6.5.exe 84d1bda5dbf814742898a2e1c0e4bc793e9bc1fba4b7a93d59a7ef12bd0fd802
-    w_try "$WINE" "$W_CACHE/vcrun2003/${file1}" ${W_OPT_UNATTENDED:+/S}
-    w_try cp "$W_PROGRAMS_X86_UNIX/BZEdit1.6.5"/m*71* "$W_SYSTEM32_DLLS"
+
+    w_try_7z "$W_SYSTEM32_DLLS" "${W_CACHE}/vcrun2003/BZEditW32_1.6.5.exe" "mfc71.dll" "msvcp71.dll" "msvcr71.dll" -y
 }
 
 #----------------------------------------------------------------

--- a/src/winetricks
+++ b/src/winetricks
@@ -12429,6 +12429,39 @@ load_vcrun2015()
     esac
 }
 
+w_metadata mfc140 dlls \
+    title="Visual C++ 2015 mfc140 library; part of vcrun2015" \
+    publisher="Microsoft" \
+    year="2015" \
+    media="download" \
+    file1="../vcrun2015/vc_redist.x86.exe" \
+    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc140u.dll"
+
+load_mfc140()
+{
+    w_download_to vcrun2015 https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x86.exe fdd1e1f0dcae2d0aa0720895eff33b927d13076e64464bb7c7e5843b7667cd14
+
+    w_try_cabextract --directory="$W_TMP/win32"  "$W_CACHE"/vcrun2015/vc_redist.x86.exe -F 'a11'
+    w_try_cabextract --directory="$W_TMP/win32" "$W_TMP/win32/a11"
+
+    w_try cp "$W_TMP/win32"/mfc140.dll "$W_SYSTEM32_DLLS"/mfc140.dll
+    w_try cp "$W_TMP/win32"/mfc140u.dll "$W_SYSTEM32_DLLS"/mfc140u.dll
+    w_try cp "$W_TMP/win32"/mfcm140.dll "$W_SYSTEM32_DLLS"/mfcm140.dll
+    w_try cp "$W_TMP/win32"/mfcm140u.dll "$W_SYSTEM32_DLLS"/mfcm140u.dll
+
+    if [ "$W_ARCH" = "win64" ]; then
+        w_download_to vcrun2015 https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe 5eea714e1f22f1875c1cb7b1738b0c0b1f02aec5ecb95f0fdb1c5171c6cd93a3
+
+        w_try_cabextract --directory="$W_TMP/win64"  "$W_CACHE"/vcrun2015/vc_redist.x64.exe -F 'a11'
+        w_try_cabextract --directory="$W_TMP/win64" "$W_TMP/win64/a11"
+
+        w_try cp "$W_TMP/win64"/mfc140.dll "$W_SYSTEM64_DLLS"/mfc140.dll
+        w_try cp "$W_TMP/win64"/mfc140u.dll "$W_SYSTEM64_DLLS"/mfc140u.dll
+        w_try cp "$W_TMP/win64"/mfcm140.dll "$W_SYSTEM64_DLLS"/mfcm140.dll
+        w_try cp "$W_TMP/win64"/mfcm140u.dll "$W_SYSTEM64_DLLS"/mfcm140u.dll
+    fi
+}
+
 #----------------------------------------------------------------
 
 w_metadata vcrun2017 dlls \


### PR DESCRIPTION
@austin987 I haven't finished, but this is what I have now, the rest will look similar. The reason I'm creating this draft PR now is so that, if you have time, you can have a look at the approach, so I don't have to rework more than necessary.

Some notes:

- I'm not completely sure what installed_file{1,2,etc} are for, but the old wiki seems to suggest they're used to check if a verb is already installed. This will be a problem for the mfc verbs, since the vcrun* verbs use the mfc dlls as installed_file1. Am I correct here and if so, what would be a good way to fix this?

- I opted against using a separate helper function since it didn't seem worth it, but if you know some more ways to avoid code duplication a little, let me know.

Fixes #1455