### PR TITLE
ddr: fix registry key for newer wine versions

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -21540,7 +21540,11 @@ w_metadata ddr=opengl settings \
 
 load_ddr()
 {
-    winetricks_set_wined3d_var DirectDrawRenderer "$1"
+    if w_wine_version_in ,3.16 ; then
+        winetricks_set_wined3d_var DirectDrawRenderer "$1"
+    else
+        winetricks_set_wined3d_var renderer "$1"
+    fi
 }
 
 #----------------------------------------------------------------


### PR DESCRIPTION
The renderer key was introduced in [wine-3.17](https://source.winehq.org/git/wine.git/commit/723e62ab9956288e241c9a2956eaf9d2c955161e) and the DirectDrawRenderer key was removed in [wine-5.1](https://source.winehq.org/git/wine.git/commit/6e515efb715824a4811c40ee3833d48e460d5e67).

Fixes #1542 