### PR TITLE
README.md: Update link to Arch package

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ https://github.com/Winetricks/winetricks/releases
 # Installing
 The ```winetricks``` package should be used if it is available and up to date. The package is available in most mainstream (Unix-like) Operating Systems:
 
-* Arch: https://www.archlinux.org/packages/community/any/winetricks/
+* Arch: https://www.archlinux.org/packages/multilib/x86_64/winetricks/
 * Debian: https://packages.debian.org/sid/winetricks
 * Fedora: https://fedoraproject.org/wiki/Wine#Packages
 * FreeBSD: https://www.freebsd.org/cgi/ports.cgi?query=winetricks&stype=all


### PR DESCRIPTION
I noticed that the link now 404s, corrected by searching the package repo for `winetricks`.