### PR TITLE
misc: SC2250 added braces around variable references

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -120,11 +120,11 @@ WINETRICKS_VERSION=20200412-next
 #   close curlies ('}') and 'fi' should line up with the matching { or if,
 #   cases indented 4 spaces from 'case' and 'esac'.  For instance,
 #
-#      if test "$FOO" = "bar"; then
+#      if test "${FOO}" = "bar"; then
 #         echo "FOO is bar"
 #      fi
 #
-#      case "$FOO" in
+#      case "${FOO}" in
 #          bar) echo "FOO is still bar" ;;
 #      esac
 #
@@ -147,7 +147,7 @@ WINETRICKS_VERSION=20200412-next
 # Internationalization / localization:
 # - Important or frequently used message should be internationalized
 #   so translations can be easily added.  For example:
-#     case $LANG in
+#     case ${LANG} in
 #         de*) echo "Das ist die deutsche Meldung" ;;
 #         *)   echo "This is the English message" ;;
 #     esac
@@ -168,17 +168,17 @@ TRUE=0
 FALSE=1
 
 # FIXME: XDG_CACHE_HOME is defined twice, clean this up
-XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
-XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+XDG_DATA_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}"
+XDG_CACHE_HOME="${XDG_CACHE_HOME:-${HOME}/.cache}"
 
 W_COUNTRY=""
-W_PREFIXES_ROOT="${WINE_PREFIXES:-$XDG_DATA_HOME/wineprefixes}"
+W_PREFIXES_ROOT="${WINE_PREFIXES:-${XDG_DATA_HOME}/wineprefixes}"
 
-# For temp files before $WINEPREFIX is available:
+# For temp files before ${WINEPREFIX} is available:
 if [ -x "$(command -v mktemp 2>/dev/null)" ] ; then
     W_TMP_EARLY="$(mktemp -d "${TMPDIR:-/tmp}/winetricks.XXXXXXXX")"
-elif [ -w "$TMPDIR" ] ; then
-    W_TMP_EARLY="$TMPDIR"
+elif [ -w "${TMPDIR}" ] ; then
+    W_TMP_EARLY="${TMPDIR}"
 else
     W_TMP_EARLY="/tmp"
 fi
@@ -192,26 +192,26 @@ w_askpermission()
     echo "$@"
     echo "------------------------------------------------------"
 
-    if test "$W_OPT_UNATTENDED"; then
+    if test "${W_OPT_UNATTENDED}"; then
         _W_timeout="--timeout 5"
     fi
 
-    case $WINETRICKS_GUI in
-        zenity) $WINETRICKS_GUI "$_W_timeout" --question --title=winetricks --text="$(echo "$@" | sed 's,\\\\,\\\\\\\\,g')" --no-wrap;;
-        kdialog) $WINETRICKS_GUI --title winetricks --warningcontinuecancel "$@" ;;
+    case ${WINETRICKS_GUI} in
+        zenity) ${WINETRICKS_GUI} "${_W_timeout}" --question --title=winetricks --text="$(echo "$@" | sed 's,\\\\,\\\\\\\\,g')" --no-wrap;;
+        kdialog) ${WINETRICKS_GUI} --title winetricks --warningcontinuecancel "$@" ;;
         none)
-            if [ -n "$_W_timeout" ]; then
+            if [ -n "${_W_timeout}" ]; then
                 # -t / TMOUT don't seem to be portable, so just assume yes in unattended mode
                 w_info "Unattended mode, not prompting for confirmation"
             else
                 printf %s "Press Y or N, then Enter: "
                 read -r response
-                test "$response" = Y || test "$response" = y
+                test "${response}" = Y || test "${response}" = y
             fi
     esac
 
     if test $? -ne 0; then
-        case $LANG in
+        case ${LANG} in
             uk*) w_die "Операція скасована." ;;
             pl*) w_die "Anulowano operację, opuszczanie." ;;
             *) w_die "Operation cancelled, quitting." ;;
@@ -225,16 +225,16 @@ w_askpermission()
 # Display info message.  Time out quickly if user doesn't click.
 w_info()
 {
-    # If $WINETRICKS_SUPER_QUIET is set, w_info is a no-op:
-    if [ -z "$WINETRICKS_SUPER_QUIET" ] ; then
+    # If ${WINETRICKS_SUPER_QUIET} is set, w_info is a no-op:
+    if [ -z "${WINETRICKS_SUPER_QUIET}" ] ; then
         echo "------------------------------------------------------"
         echo "$@"
         echo "------------------------------------------------------"
     fi
 
-    case $WINETRICKS_GUI in
-        zenity) $WINETRICKS_GUI --timeout=3 --info --title=winetricks --text="$(echo "$@" | sed 's,\\\\,\\\\\\\\,g')" --no-wrap;;
-        kdialog) $WINETRICKS_GUI --title winetricks --msgbox "$@" ;;
+    case ${WINETRICKS_GUI} in
+        zenity) ${WINETRICKS_GUI} --timeout=3 --info --title=winetricks --text="$(echo "$@" | sed 's,\\\\,\\\\\\\\,g')" --no-wrap;;
+        kdialog) ${WINETRICKS_GUI} --title winetricks --msgbox "$@" ;;
         none) ;;
     esac
 }
@@ -242,20 +242,20 @@ w_info()
 # Display warning message to stderr (since it is called inside redirected code)
 w_warn()
 {
-    # If $WINETRICKS_SUPER_QUIET is set, w_info is a no-op:
-    if [ -z "$WINETRICKS_SUPER_QUIET" ] ; then
+    # If ${WINETRICKS_SUPER_QUIET} is set, w_info is a no-op:
+    if [ -z "${WINETRICKS_SUPER_QUIET}" ] ; then
         echo "------------------------------------------------------"
         echo "$@"
         echo "------------------------------------------------------"
     fi
 
-    if test "$W_OPT_UNATTENDED"; then
+    if test "${W_OPT_UNATTENDED}"; then
         _W_timeout="--timeout 5"
     fi
 
-    case $WINETRICKS_GUI in
-        zenity) $WINETRICKS_GUI "$_W_timeout" --error --title=winetricks --text="$(echo "$@" | sed 's,\\\\,\\\\\\\\,g')";;
-        kdialog) $WINETRICKS_GUI --title winetricks --error "$@" ;;
+    case ${WINETRICKS_GUI} in
+        zenity) ${WINETRICKS_GUI} "${_W_timeout}" --error --title=winetricks --text="$(echo "$@" | sed 's,\\\\,\\\\\\\\,g')";;
+        kdialog) ${WINETRICKS_GUI} --title winetricks --error "$@" ;;
         none) ;;
     esac
 
@@ -271,14 +271,14 @@ w_warn_cancel()
     echo "$@" >&2
     echo "------------------------------------------------------" >&2
 
-    if test "$W_OPT_UNATTENDED"; then
+    if test "${W_OPT_UNATTENDED}"; then
         _W_timeout="--timeout 5"
     fi
 
     # Zenity has no cancel button, but will set status to 1 if you click the go-away X
-    case $WINETRICKS_GUI in
-        zenity) $WINETRICKS_GUI "$_W_timeout" --error --title=winetricks --text="$(echo "$@" | sed 's,\\\\,\\\\\\\\,g')";;
-        kdialog) $WINETRICKS_GUI --title winetricks --warningcontinuecancel "$@" ;;
+    case ${WINETRICKS_GUI} in
+        zenity) ${WINETRICKS_GUI} "${_W_timeout}" --error --title=winetricks --text="$(echo "$@" | sed 's,\\\\,\\\\\\\\,g')";;
+        kdialog) ${WINETRICKS_GUI} --title winetricks --warningcontinuecancel "$@" ;;
         none) ;;
     esac
 
@@ -305,10 +305,10 @@ w_killall()
 _w_force_continue_check()
 {
     exitval="${1:-99}"
-    if [ "$WINETRICKS_FORCE" = 1 ]; then
+    if [ "${WINETRICKS_FORCE}" = 1 ]; then
         w_warn "--force was used, so trying anyway. Caveat emptor."
     else
-        exit "$exitval"
+        exit "${exitval}"
     fi
 }
 
@@ -321,20 +321,20 @@ w_package_broken()
     bad_version="$2"
     good_version="$3"
 
-    if [ -z "$bug_link" ] ; then
+    if [ -z "${bug_link}" ] ; then
         w_die "Bug report link required!"
     fi
 
-    if [ -n "$good_version" ]; then
+    if [ -n "${good_version}" ]; then
         if ! w_wine_version_in "${bad_version},${good_version}"; then
-            w_warn "This package ($W_PACKAGE) is broken in ${_wine_version_stripped}. Upgrade to >=${good_version}. See ${bug_link} for more info."
+            w_warn "This package (${W_PACKAGE}) is broken in ${_wine_version_stripped}. Upgrade to >=${good_version}. See ${bug_link} for more info."
         fi
-    elif [ -n "$bad_version" ]; then
+    elif [ -n "${bad_version}" ]; then
         if ! w_wine_version_in "${bad_version}"; then
-            w_warn "This package ($W_PACKAGE) is broken in ${_wine_version_stripped}. Broken since ${bad_version}. See ${bug_link} for more info."
+            w_warn "This package (${W_PACKAGE}) is broken in ${_wine_version_stripped}. Broken since ${bad_version}. See ${bug_link} for more info."
         fi
     else
-        w_warn "This package ($W_PACKAGE) is broken. See ${bug_link} for more info."
+        w_warn "This package (${W_PACKAGE}) is broken. See ${bug_link} for more info."
     fi
 
     _w_force_continue_check
@@ -376,31 +376,31 @@ w_package_broken_mingw()
 
     w_detect_mingw
 
-    if [ -z "$_W_mingw" ]; then
+    if [ -z "${_W_mingw}" ]; then
         # We're not using a mingw build, nothing to do:
         return
     fi
 
-    if [ -z "$bug_link" ] ; then
+    if [ -z "${bug_link}" ] ; then
         w_die "Bug report link required!"
     fi
 
-    if [ -n "$good_version" ]; then
+    if [ -n "${good_version}" ]; then
         if ! w_wine_version_in "${bad_version},${good_version}"; then
-            w_warn "This package ($W_PACKAGE) is broken in ${_wine_version_stripped} when wine is built with mingw. Upgrade to >=${good_version} or disable mingw. See ${bug_link} for more info."
+            w_warn "This package (${W_PACKAGE}) is broken in ${_wine_version_stripped} when wine is built with mingw. Upgrade to >=${good_version} or disable mingw. See ${bug_link} for more info."
             _w_force_continue_check
         else
             echo "package was broken, now fixed"
         fi
-    elif [ -n "$bad_version" ]; then
+    elif [ -n "${bad_version}" ]; then
         if ! w_wine_version_in "${bad_version}"; then
-            w_warn "This package ($W_PACKAGE) is broken in ${_wine_version_stripped} (broken since ${bad_version} when wine is built with mingw. See ${bug_link} for more info."
+            w_warn "This package (${W_PACKAGE}) is broken in ${_wine_version_stripped} (broken since ${bad_version} when wine is built with mingw. See ${bug_link} for more info."
             _w_force_continue_check
         else
             echo "Package is broken in future versions"
         fi
     else
-        w_warn "This package ($W_PACKAGE) is broken when wine is built with mingw. See ${bug_link} for more info."
+        w_warn "This package (${W_PACKAGE}) is broken when wine is built with mingw. See ${bug_link} for more info."
         _w_force_continue_check
     fi
 }
@@ -414,31 +414,31 @@ w_package_broken_no_mingw()
     bad_version="$2"
     good_version="$3"
 
-    if [ -z "$_W_no_mingw" ]; then
+    if [ -z "${_W_no_mingw}" ]; then
         # We're using a mingw build, nothing to do:
         return
     fi
 
-    if [ -z "$bug_link" ] ; then
+    if [ -z "${bug_link}" ] ; then
         w_die "Bug report link required!"
     fi
 
-    if [ -n "$good_version" ]; then
+    if [ -n "${good_version}" ]; then
         if ! w_wine_version_in "${bad_version},${good_version}"; then
-            w_warn "This package ($W_PACKAGE) is broken in ${_wine_version_stripped} when wine is built without mingw. Upgrade to >=${good_version}. See ${bug_link} for more info."
+            w_warn "This package (${W_PACKAGE}) is broken in ${_wine_version_stripped} when wine is built without mingw. Upgrade to >=${good_version}. See ${bug_link} for more info."
             _w_force_continue_check
         else
             echo "package was broken, now fixed"
         fi
-    elif [ -n "$bad_version" ]; then
+    elif [ -n "${bad_version}" ]; then
         if ! w_wine_version_in "${bad_version}"; then
-            w_warn "This package ($W_PACKAGE) is broken in ${_wine_version_stripped} (broken since ${bad_version} when wine is built without mingw. See ${bug_link} for more info."
+            w_warn "This package (${W_PACKAGE}) is broken in ${_wine_version_stripped} (broken since ${bad_version} when wine is built without mingw. See ${bug_link} for more info."
             _w_force_continue_check
         else
             echo "Package is broken in future versions"
         fi
     else
-        w_warn "This package ($W_PACKAGE) is broken when wine is built without mingw. See ${bug_link} for more info."
+        w_warn "This package (${W_PACKAGE}) is broken when wine is built without mingw. See ${bug_link} for more info."
         _w_force_continue_check
     fi
 }
@@ -452,29 +452,29 @@ w_package_broken_win64()
     bad_version="$2"
     good_version="$3"
 
-    if [ "$W_ARCH" != "win64" ]; then
+    if [ "${W_ARCH}" != "win64" ]; then
         # not a 64-bit prefix, nothing to do:
         :
-    elif [ -z "$bug_link" ]; then
+    elif [ -z "${bug_link}" ]; then
         w_die "Bug report link required!"
     fi
 
-    if [ -n "$good_version" ]; then
+    if [ -n "${good_version}" ]; then
         if ! w_wine_version_in "${bad_version},${good_version}"; then
-            w_warn "This package ($W_PACKAGE) is broken on 64-bit wine-${_wine_version_stripped}. Use a prefix made with WINEARCH=win32 or upgrade wine to >=${good_version} to work around this. See: ${bug_link}"
+            w_warn "This package (${W_PACKAGE}) is broken on 64-bit wine-${_wine_version_stripped}. Use a prefix made with WINEARCH=win32 or upgrade wine to >=${good_version} to work around this. See: ${bug_link}"
             _w_force_continue_check
         else
             echo "package was broken on win64, now fixed"
         fi
-    elif [ -n "$bad_version" ]; then
+    elif [ -n "${bad_version}" ]; then
         if ! w_wine_version_in "${bad_version}"; then
-            w_warn "This package ($W_PACKAGE) is broken on 64-bit wine-${_wine_version_stripped} (broken since ${bad_version}. Use a prefix made with WINEARCH=win32 to work around this. See: ${bug_link}"
+            w_warn "This package (${W_PACKAGE}) is broken on 64-bit wine-${_wine_version_stripped} (broken since ${bad_version}. Use a prefix made with WINEARCH=win32 to work around this. See: ${bug_link}"
             _w_force_continue_check
         else
             echo "Package is broken in future versions on win64"
         fi
     else
-        w_warn "This package ($W_PACKAGE) is broken when wine is built without mingw. See ${bug_link} for more info."
+        w_warn "This package (${W_PACKAGE}) is broken when wine is built without mingw. See ${bug_link} for more info."
         _w_force_continue_check
     fi
 }
@@ -483,8 +483,8 @@ w_package_broken_win64()
 # Returns 64 (for tests/winetricks-test)
 w_package_unsupported_win32()
 {
-    if [ "$W_ARCH" = "win32" ] ; then
-        w_warn "This package ($W_PACKAGE) does not work on a 32-bit installation. You must use a prefix made with WINEARCH=win64."
+    if [ "${W_ARCH}" = "win32" ] ; then
+        w_warn "This package (${W_PACKAGE}) does not work on a 32-bit installation. You must use a prefix made with WINEARCH=win64."
         _w_force_continue_check 64
     fi
 }
@@ -495,13 +495,13 @@ w_package_unsupported_win32()
 # Returns 32 (for tests/winetricks-test)
 w_package_unsupported_win64()
 {
-    if [ "$W_ARCH" = "win64" ] ; then
-        case $LANG in
-            pl*) w_warn "Ten pakiet ($W_PACKAGE) nie działa z 64-bitową instalacją. Musisz użyć prefiksu utworzonego z WINEARCH=win32." ;;
+    if [ "${W_ARCH}" = "win64" ] ; then
+        case ${LANG} in
+            pl*) w_warn "Ten pakiet (${W_PACKAGE}) nie działa z 64-bitową instalacją. Musisz użyć prefiksu utworzonego z WINEARCH=win32." ;;
             ru*) w_warn "Данный пакет не работает в 64-битном окружении. Используйте префикс, созданный с помощью WINEARCH=win32." ;;
-            zh_CN*) w_warn "($W_PACKAGE) 无法在64位下工作，只能将容器变量设置为 WINEARCH=win32 安装。" ;;
-            zh_TW*|zh_HK*) w_warn "($W_PACKAGE) 無法在64元下工作，只能將容器變數設定為 WINEARCH=win32 安装。" ;;
-            *) w_warn "This package ($W_PACKAGE) does not work on a 64-bit installation. You must use a prefix made with WINEARCH=win32." ;;
+            zh_CN*) w_warn "(${W_PACKAGE}) 无法在64位下工作，只能将容器变量设置为 WINEARCH=win32 安装。" ;;
+            zh_TW*|zh_HK*) w_warn "(${W_PACKAGE}) 無法在64元下工作，只能將容器變數設定為 WINEARCH=win32 安装。" ;;
+            *) w_warn "This package (${W_PACKAGE}) does not work on a 64-bit installation. You must use a prefix made with WINEARCH=win32." ;;
         esac
         _w_force_continue_check 32
     fi
@@ -510,13 +510,13 @@ w_package_unsupported_win64()
 # For packages that are not well tested or have some known issues on win64, but aren't broken
 w_package_warn_win64()
 {
-    if [ "$W_ARCH" = "win64" ] ; then
-        case $LANG in
-            pl*) w_warn "Ten pakiet ($W_PACKAGE) może nie działać poprawnie z 64-bitową instalacją. Prefiks 32-bitowy może działać lepiej." ;;
+    if [ "${W_ARCH}" = "win64" ] ; then
+        case ${LANG} in
+            pl*) w_warn "Ten pakiet (${W_PACKAGE}) może nie działać poprawnie z 64-bitową instalacją. Prefiks 32-bitowy może działać lepiej." ;;
             ru*) w_warn "Данный пакет может работать не полностью в 64-битном окружении. 32-битные префиксы могут работать лучше." ;;
-            zh_CN*) w_warn "($W_PACKAGE) 可能在64位环境下工作有问题，安装在32位环境可能会更好。" ;;
-            zh_TW*|zh_HK*) w_warn "($W_PACKAGE) 可能在64元環境下工作有問題，安装在32元環境可能會更好。" ;;
-            *) w_warn "This package ($W_PACKAGE) may not fully work on a 64-bit installation. 32-bit prefixes may work better." ;;
+            zh_CN*) w_warn "(${W_PACKAGE}) 可能在64位环境下工作有问题，安装在32位环境可能会更好。" ;;
+            zh_TW*|zh_HK*) w_warn "(${W_PACKAGE}) 可能在64元環境下工作有問題，安装在32元環境可能會更好。" ;;
+            *) w_warn "This package (${W_PACKAGE}) may not fully work on a 64-bit installation. 32-bit prefixes may work better." ;;
         esac
     fi
 }
@@ -532,8 +532,8 @@ w_try()
     # This is a problem when trying to pass environment variables to e.g. wine.
     # Adding an explicit export here works around it, so add any we use.
     export WINEDLLOVERRIDES
-    # If $WINETRICKS_SUPER_QUIET is set, make w_try quiet
-    if [ -z "$WINETRICKS_SUPER_QUIET" ]; then
+    # If ${WINETRICKS_SUPER_QUIET} is set, make w_try quiet
+    if [ -z "${WINETRICKS_SUPER_QUIET}" ]; then
         printf '%s\n' "Executing $*"
     fi
 
@@ -605,17 +605,17 @@ w_try_7z()
     shift 2
 
     # Not always installed, use Windows 7-Zip as a fallback:
-    if [ -z "$WINETRICKS_FORCE_WIN_7Z" ] && [ -x "$(command -v 7z 2>/dev/null)" ] ; then
-        w_try 7z x "$filename" -o"$destdir" "$@"
+    if [ -z "${WINETRICKS_FORCE_WIN_7Z}" ] && [ -x "$(command -v 7z 2>/dev/null)" ] ; then
+        w_try 7z x "${filename}" -o"${destdir}" "$@"
     else
         w_warn "Cannot find 7z. Using Windows 7-Zip instead. (You can avoid this by installing 7z, e.g. 'sudo apt-get install p7zip-full' or 'sudo yum install p7zip-plugins')."
         WINETRICKS_OPT_SHAREDPREFIX=1 w_call 7zip
 
-        # w_call above will wipe $W_TMP; if that's the CWD, things will break. So forcefully reset the directory:
-        w_try_cd "$PWD"
+        # w_call above will wipe ${W_TMP}; if that's the CWD, things will break. So forcefully reset the directory:
+        w_try_cd "${PWD}"
 
         # errors out if there is a space between -o and path
-        w_try "$WINE" "$W_PROGRAMS_X86_WIN\\7-Zip\\7z.exe" x "$(w_pathconv -w "$filename")" -o"$(w_pathconv -w "$destdir")" "$@"
+        w_try "${WINE}" "${W_PROGRAMS_X86_WIN}\\7-Zip\\7z.exe" x "$(w_pathconv -w "${filename}")" -o"$(w_pathconv -w "${destdir}")" "$@"
     fi
 }
 
@@ -625,18 +625,18 @@ w_try_ar()
     # $2 - file to extract (optional)
 
     # Not always installed, use Windows 7-zip as a fallback:
-    if [ -z "$WINETRICKS_FORCE_WIN_7Z" ] && [ -x "$(command -v ar 2>/dev/null)" ]; then
+    if [ -z "${WINETRICKS_FORCE_WIN_7Z}" ] && [ -x "$(command -v ar 2>/dev/null)" ]; then
         w_try ar x "$@"
     else
         w_warn "Cannot find ar. Using Windows 7-zip instead. (You can avoid this by installing binutils, e.g. 'sudo apt-get install binutils' or 'sudo yum install binutils')."
         WINETRICKS_OPT_SHAREDPREFIX=1 w_call 7zip
 
-        # w_call above will wipe $W_TMP; if that's the CWD, things will break. So forcefully reset the directory:
-        w_try_cd "$PWD"
+        # w_call above will wipe ${W_TMP}; if that's the CWD, things will break. So forcefully reset the directory:
+        w_try_cd "${PWD}"
 
         # -t* prevents 7-zip from decompressing .tar.xz to .tar, see
         # https://sourceforge.net/p/sevenzip/discussion/45798/thread/8cd16946/?limit=25
-        w_try "$WINE" "$W_PROGRAMS_X86_WIN\\7-Zip\\7z.exe" -t* x "$(w_pathconv -w "$1")"
+        w_try "${WINE}" "${W_PROGRAMS_X86_WIN}\\7-Zip\\7z.exe" -t* x "$(w_pathconv -w "$1")"
     fi
 }
 
@@ -671,15 +671,15 @@ w_try_cp_font_files()
     _W_pattern="$3"
     shift 2
 
-    if test ! -d "$_W_src_dir"; then
+    if test ! -d "${_W_src_dir}"; then
         w_die "bug: missing source dir"
     fi
 
-    if test ! -d "$_W_dest_dir"; then
+    if test ! -d "${_W_dest_dir}"; then
         w_die "bug: missing destination dir"
     fi
 
-    if test -z "$_W_pattern"; then
+    if test -z "${_W_pattern}"; then
         _W_pattern="*.ttf"
     fi
 
@@ -688,23 +688,23 @@ w_try_cp_font_files()
 #
 # See https://github.com/Winetricks/winetricks/issues/995 for details
 
-cat > "$WINETRICKS_WORKDIR/cp_font_files.sh" <<_EOF_
+cat > "${WINETRICKS_WORKDIR}/cp_font_files.sh" <<_EOF_
 #!/bin/sh
     _W_src_file="\$@"
 
     # Extract the file name and lower case it
-    _W_file_name="\$(basename "\$_W_src_file" | tr "[:upper:]" "[:lower:]")"
+    _W_file_name="\$(basename "\${_W_src_file}" | tr "[:upper:]" "[:lower:]")"
 
     # Remove any existing font files that might have the same name, but with different case characters
-    find "$_W_dest_dir" -maxdepth 1 -type f -iname "\$_W_file_name" -exec rm '{}' ';'
+    find "${_W_dest_dir}" -maxdepth 1 -type f -iname "\${_W_file_name}" -exec rm '{}' ';'
 
     # FIXME: w_try() isn't available, need some better error handling:
-    cp -f "\$_W_src_file" "$_W_dest_dir/\$_W_file_name"
+    cp -f "\${_W_src_file}" "${_W_dest_dir}/\${_W_file_name}"
 _EOF_
 
     # Use -exec "sh .." to avoid issues with noexec
     # Gross quoting is to avoid SC2156
-    find "$_W_src_dir" -maxdepth 1 -type f -iname "$_W_pattern" -exec sh -c 'sh '"$WINETRICKS_WORKDIR/cp_font_files.sh"' "$1"' _ {} \;
+    find "${_W_src_dir}" -maxdepth 1 -type f -iname "${_W_pattern}" -exec sh -c 'sh '"${WINETRICKS_WORKDIR}/cp_font_files.sh"' "$1"' _ {} \;
 
     # Wait for Wine to add the new font to the registry under HKCU\Software\Wine\Fonts\Cache
     w_wineserver -w
@@ -714,19 +714,19 @@ _EOF_
 
 w_try_msiexec64()
 {
-    if test "$W_ARCH" != "win64"; then
-        w_die "bug: 64-bit msiexec called from a $W_ARCH prefix."
+    if test "${W_ARCH}" != "win64"; then
+        w_die "bug: 64-bit msiexec called from a ${W_ARCH} prefix."
     fi
 
-    w_try "$WINE" start /wait "$W_SYSTEM64_DLLS_WIN32/msiexec.exe" ${W_OPT_UNATTENDED:+/q} "$@"
+    w_try "${WINE}" start /wait "${W_SYSTEM64_DLLS_WIN32}/msiexec.exe" ${W_OPT_UNATTENDED:+/q} "$@"
 }
 
 w_try_regedit()
 {
     # If on wow64, run under both wine and wine64 (otherwise they only go in the 32-bit registry afaict)
-    if [ "$W_ARCH" = "win32" ]; then
+    if [ "${W_ARCH}" = "win32" ]; then
         w_try_regedit32 "$@"
-    elif [ "$W_ARCH" = "win64" ]; then
+    elif [ "${W_ARCH}" = "win64" ]; then
         w_try_regedit32 "$@"
         w_try_regedit64 "$@"
     fi
@@ -735,35 +735,35 @@ w_try_regedit()
 w_try_regedit32()
 {
     # on windows, doesn't work without cmd /c
-    case "$W_PLATFORM" in
+    case "${W_PLATFORM}" in
         windows_cmd|wine_cmd) cmdc="cmd /c";;
         *) unset cmdc ;;
     esac
 
     # shellcheck disable=SC2086
-    w_try "$WINE_MULTI" $cmdc regedit ${W_OPT_UNATTENDED:+/S} "$@"
+    w_try "${WINE_MULTI}" ${cmdc} regedit ${W_OPT_UNATTENDED:+/S} "$@"
 }
 
 w_try_regedit64()
 {
     # on windows, doesn't work without cmd /c
-    case "$W_PLATFORM" in
+    case "${W_PLATFORM}" in
         windows_cmd|wine_cmd) cmdc="cmd /c";;
         *) unset cmdc ;;
     esac
 
     # shellcheck disable=SC2086
-    w_try "$WINE64" $cmdc regedit ${W_OPT_UNATTENDED:+/S} "$@"
+    w_try "${WINE64}" ${cmdc} regedit ${W_OPT_UNATTENDED:+/S} "$@"
 }
 
 w_try_regsvr()
 {
-    w_try "$WINE" regsvr32 ${W_OPT_UNATTENDED:+/S} "$@"
+    w_try "${WINE}" regsvr32 ${W_OPT_UNATTENDED:+/S} "$@"
 }
 
 w_try_regsvr64()
 {
-    w_try "$WINE64" regsvr32 ${W_OPT_UNATTENDED:+/S} "$@"
+    w_try "${WINE64}" regsvr32 ${W_OPT_UNATTENDED:+/S} "$@"
 }
 
 w_try_unrar()
@@ -771,16 +771,16 @@ w_try_unrar()
     # $1 - zipfile to extract (keeping internal paths, in cwd)
 
     # Not always installed, use Windows 7-Zip as a fallback:
-    if [ -z "$WINETRICKS_FORCE_WIN_7Z" ] && [ -x "$(command -v unrar 2>/dev/null)" ]; then
+    if [ -z "${WINETRICKS_FORCE_WIN_7Z}" ] && [ -x "$(command -v unrar 2>/dev/null)" ]; then
         w_try unrar x "$@"
     else
         w_warn "Cannot find unrar. Using Windows 7-Zip instead. (You can avoid this by installing unrar, e.g. 'sudo apt-get install unrar' or 'sudo yum install unrar')."
         WINETRICKS_OPT_SHAREDPREFIX=1 w_call 7zip
 
-        # w_call above will wipe $W_TMP; if that's the CWD, things will break. So forcefully reset the directory:
-        w_try_cd "$PWD"
+        # w_call above will wipe ${W_TMP}; if that's the CWD, things will break. So forcefully reset the directory:
+        w_try_cd "${PWD}"
 
-        w_try "$WINE" "$W_PROGRAMS_X86_WIN\\7-Zip\\7z.exe" x "$(w_pathconv -w "$1")"
+        w_try "${WINE}" "${W_PROGRAMS_X86_WIN}\\7-Zip\\7z.exe" x "$(w_pathconv -w "$1")"
     fi
 }
 
@@ -795,12 +795,12 @@ w_try_unzip()
     shift 2
 
     # Not always installed, use Windows 7-Zip as a fallback:
-    if [ -z "$WINETRICKS_FORCE_WIN_7Z" ] && [ -x "$(command -v unzip 2>/dev/null)" ]; then
+    if [ -z "${WINETRICKS_FORCE_WIN_7Z}" ] && [ -x "$(command -v unzip 2>/dev/null)" ]; then
         # FreeBSD ships unzip, but it doesn't support self-compressed executables
         # If it fails, fall back to 7-Zip:
-        unzip -o -q -d"$destdir" "$zipfile" "$@"
+        unzip -o -q -d"${destdir}" "${zipfile}" "$@"
         ret=$?
-        case $ret in
+        case ${ret} in
             0) return ;;
             1|*) w_warn "Unzip failed, trying Windows 7-Zip instead." ;;
         esac
@@ -810,73 +810,73 @@ w_try_unzip()
 
     WINETRICKS_OPT_SHAREDPREFIX=1 w_call 7zip
 
-    # w_call above will wipe $W_TMP; if that's the CWD, things will break. So forcefully reset the directory:
-    w_try_cd "$PWD"
+    # w_call above will wipe ${W_TMP}; if that's the CWD, things will break. So forcefully reset the directory:
+    w_try_cd "${PWD}"
 
     # errors out if there is a space between -o and path
-    w_try "$WINE" "$W_PROGRAMS_X86_WIN\\7-Zip\\7z.exe" x "$(w_pathconv -w "$zipfile")" -o"$(w_pathconv -w "$destdir")" "$@"
+    w_try "${WINE}" "${W_PROGRAMS_X86_WIN}\\7-Zip\\7z.exe" x "$(w_pathconv -w "${zipfile}")" -o"$(w_pathconv -w "${destdir}")" "$@"
 }
 
 ### End of w_try ###
 
 w_read_key()
 {
-    if test ! "$W_OPT_UNATTENDED"; then
+    if test ! "${W_OPT_UNATTENDED}"; then
         W_KEY=dummy_to_make_autohotkey_happy
         return "${TRUE}"
     fi
 
-    mkdir -p "$W_CACHE/$W_PACKAGE"
+    mkdir -p "${W_CACHE}/${W_PACKAGE}"
 
     # backwards compatible location
     # Auth doesn't belong in cache, since restoring it requires user input
-    _W_keyfile="$W_CACHE/$W_PACKAGE/key.txt"
-    if ! test -f "$_W_keyfile"; then
-        _W_keyfile="$WINETRICKS_AUTH/$W_PACKAGE/key.txt"
+    _W_keyfile="${W_CACHE}/${W_PACKAGE}/key.txt"
+    if ! test -f "${_W_keyfile}"; then
+        _W_keyfile="${WINETRICKS_AUTH}/${W_PACKAGE}/key.txt"
     fi
-    if ! test -f "$_W_keyfile"; then
+    if ! test -f "${_W_keyfile}"; then
         # read key from user
-        case $LANG in
-            da*) _W_keymsg="Angiv venligst registrerings-nøglen for pakken '$W_PACKAGE'"
+        case ${LANG} in
+            da*) _W_keymsg="Angiv venligst registrerings-nøglen for pakken '${W_PACKAGE}'"
                 _W_nokeymsg="Ingen nøgle angivet"
                 ;;
-            de*) _W_keymsg="Bitte einen Key für Paket '$W_PACKAGE' eingeben"
+            de*) _W_keymsg="Bitte einen Key für Paket '${W_PACKAGE}' eingeben"
                 _W_nokeymsg="Keinen Key eingegeben?"
                 ;;
-            pl*) _W_keymsg="Proszę podać klucz dla programu '$W_PACKAGE'"
+            pl*) _W_keymsg="Proszę podać klucz dla programu '${W_PACKAGE}'"
                 _W_nokeymsg="Nie podano klucza"
                 ;;
-            ru*) _W_keymsg="Пожалуйста, введите ключ для приложения '$W_PACKAGE'"
+            ru*) _W_keymsg="Пожалуйста, введите ключ для приложения '${W_PACKAGE}'"
                 _W_nokeymsg="Ключ не введён"
                 ;;
-            uk*) _W_keymsg="Будь ласка, введіть ключ для додатка '$W_PACKAGE'"
+            uk*) _W_keymsg="Будь ласка, введіть ключ для додатка '${W_PACKAGE}'"
                 _W_nokeymsg="Ключ не надано"
                 ;;
-            zh_CN*)  _W_keymsg="按任意键为 '$W_PACKAGE'"
+            zh_CN*)  _W_keymsg="按任意键为 '${W_PACKAGE}'"
                 _W_nokeymsg="No key given"
                 ;;
-            zh_TW*|zh_HK*)  _W_keymsg="按任意鍵為 '$W_PACKAGE'"
+            zh_TW*|zh_HK*)  _W_keymsg="按任意鍵為 '${W_PACKAGE}'"
                 _W_nokeymsg="No key given"
                 ;;
-            *)  _W_keymsg="Please enter the key for app '$W_PACKAGE'"
+            *)  _W_keymsg="Please enter the key for app '${W_PACKAGE}'"
                 _W_nokeymsg="No key given"
                 ;;
         esac
 
-        case $WINETRICKS_GUI in
-            *zenity) W_KEY=$(zenity --entry --text "$_W_keymsg") ;;
-            *kdialog) W_KEY=$(kdialog --inputbox "$_W_keymsg") ;;
+        case ${WINETRICKS_GUI} in
+            *zenity) W_KEY=$(zenity --entry --text "${_W_keymsg}") ;;
+            *kdialog) W_KEY=$(kdialog --inputbox "${_W_keymsg}") ;;
             *xmessage) w_die "sorry, can't read key from GUI with xmessage" ;;
-            none) printf %s "$_W_keymsg": ; read -r W_KEY ;;
+            none) printf %s "${_W_keymsg}": ; read -r W_KEY ;;
         esac
 
-        if test "$W_KEY" = ""; then
-            w_die "$_W_nokeymsg"
+        if test "${W_KEY}" = ""; then
+            w_die "${_W_nokeymsg}"
         fi
-        echo "$W_KEY" > "$_W_keyfile"
+        echo "${W_KEY}" > "${_W_keyfile}"
     fi
-    W_RAW_KEY=$(cat "$_W_keyfile")
-    W_KEY=$(echo "$W_RAW_KEY" | tr -d '[:blank:][=-=]')
+    W_RAW_KEY=$(cat "${_W_keyfile}")
+    W_KEY=$(echo "${W_RAW_KEY}" | tr -d '[:blank:][=-=]')
     unset _W_keyfile _W_keymsg _W_nokeymsg
 }
 
@@ -898,9 +898,9 @@ winetricks_wintounix()
     # Remove drive letter and colon
     _W_winp="${_W_winp_#??}"
     # Prepend the location of drive c
-    printf %s "$WINEPREFIX"/dosdevices/c:
+    printf %s "${WINEPREFIX}"/dosdevices/c:
     # Change backslashes to slashes
-    echo "$_W_winp" | sed 's,\\,/,g'
+    echo "${_W_winp}" | sed 's,\\,/,g'
 }
 
 # Convert between Unix path and Windows path
@@ -908,7 +908,7 @@ winetricks_wintounix()
 # so -u to convert to Unix, and -w to convert to Windows
 w_pathconv()
 {
-    case "$W_PLATFORM" in
+    case "${W_PLATFORM}" in
         windows_cmd)
             # for some reason, cygpath turns some spaces into newlines?!
             cygpath "$@" | tr '\012' '\040' | sed 's/ $//'
@@ -940,12 +940,12 @@ w_get_github_latest_release()
     # aria2c condenses the json (https://github.com/aria2/aria2/issues/1389)
     # but curl/wget don't, so handle both cases:
     json_length="$(wc -l "${W_TMP_EARLY}/release.json")"
-    case "$json_length" in
+    case "${json_length}" in
         0*) latest_version="$(sed -e "s/\",\"/|/g" "${W_TMP_EARLY}/release.json" | tr '|' '\n' | grep tag_name | sed 's@.*"@@')";;
         *) latest_version="$(grep -w tag_name "${W_TMP_EARLY}/release.json" | cut -d '"' -f 4)";;
     esac
 
-    echo "$latest_version"
+    echo "${latest_version}"
 }
 
 # Get the latest tagged prerelease from github.com API
@@ -960,25 +960,25 @@ w_get_github_latest_prerelease()
     # aria2c condenses the json (https://github.com/aria2/aria2/issues/1389)
     # but curl/wget don't, so handle both cases:
     json_length="$(wc -l "${W_TMP_EARLY}/release.json")"
-    case "$json_length" in
+    case "${json_length}" in
         0*) latest_version="$(sed -e "s/\",\"/|/g" "${W_TMP_EARLY}/release.json" | tr '|' '\n' | grep tag_name -m 1 | sed 's@.*"@@')";;
         *) latest_version="$(grep -m 1 -w tag_name "${W_TMP_EARLY}/release.json" | cut -d '"' -f 4)";;
     esac
 
-    echo "$latest_version"
+    echo "${latest_version}"
 }
 
-# get sha256sum string and set $_W_gotsha256sum to it
+# get sha256sum string and set ${_W_gotsha256sum} to it
 w_get_sha256sum()
 {
     _W_sha256_file="$1"
 
     # See https://github.com/Winetricks/winetricks/issues/645
     # User is running winetricks from /dev/stdin
-    if [ -f "$_W_sha256_file" ] || [ -h "$_W_sha256_file" ] ; then
-        _W_gotsha256sum=$($WINETRICKS_SHA256SUM < "$_W_sha256_file" | sed 's/(stdin)= //;s/ .*//')
+    if [ -f "${_W_sha256_file}" ] || [ -h "${_W_sha256_file}" ] ; then
+        _W_gotsha256sum=$(${WINETRICKS_SHA256SUM} < "${_W_sha256_file}" | sed 's/(stdin)= //;s/ .*//')
     else
-        w_warn "$_W_sha256_file is not a regular file, not checking sha256sum"
+        w_warn "${_W_sha256_file} is not a regular file, not checking sha256sum"
         return
     fi
 }
@@ -988,8 +988,8 @@ w_get_shatype() {
 
     # tr -d " " is for FreeBSD/OS X/Solaris return a leading space:
     # See https://stackoverflow.com/questions/30927590/wc-on-osx-return-includes-spaces/30927885#30927885
-    _W_sum_length="$(echo "$_W_sum" | tr -d "\\n" | wc -c | tr -d " ")"
-    case "$_W_sum_length" in
+    _W_sum_length="$(echo "${_W_sum}" | tr -d "\\n" | wc -c | tr -d " ")"
+    case "${_W_sum_length}" in
         0) _W_shatype="none" ;;
         64) _W_shatype="sha256" ;;
         # 128) sha512..
@@ -1003,12 +1003,12 @@ w_verify_sha256sum()
     _W_vs_wantsum=$1
     _W_vs_file=$2
 
-    w_get_sha256sum "$_W_vs_file"
-    if [ "$_W_gotsha256sum"x != "$_W_vs_wantsum"x ] ; then
-        case $LANG in
-            pl*) w_die "Niezgodność sumy sha256sum! Zmień nazwę $_W_vs_file i spróbuj ponownie." ;;
-            ru*) w_die "Контрольная сумма sha256sum не совпадает! Переименуйте файл $_W_vs_file и попробуйте еще раз." ;;
-            *) w_die "sha256sum mismatch! Rename $_W_vs_file and try again." ;;
+    w_get_sha256sum "${_W_vs_file}"
+    if [ "${_W_gotsha256sum}"x != "${_W_vs_wantsum}"x ] ; then
+        case ${LANG} in
+            pl*) w_die "Niezgodność sumy sha256sum! Zmień nazwę ${_W_vs_file} i spróbuj ponownie." ;;
+            ru*) w_die "Контрольная сумма sha256sum не совпадает! Переименуйте файл ${_W_vs_file} и попробуйте еще раз." ;;
+            *) w_die "sha256sum mismatch! Rename ${_W_vs_file} and try again." ;;
         esac
     fi
     unset _W_vs_wantsum _W_vs_file _W_gotsha256sum
@@ -1020,11 +1020,11 @@ w_verify_shasum()
     _W_vs_wantsum="$1"
     _W_vs_file="$2"
 
-    w_get_shatype "$_W_vs_wantsum"
+    w_get_shatype "${_W_vs_wantsum}"
 
-    case "$_W_shatype" in
+    case "${_W_shatype}" in
         none) w_warn "No checksum provided, not verifying" ;;
-        sha256) w_verify_sha256sum "$_W_sum" "$_W_vs_file" ;;
+        sha256) w_verify_sha256sum "${_W_sum}" "${_W_vs_file}" ;;
         # 128) sha512..
         *) w_die "unsupported shasum..bug" ;;
     esac
@@ -1049,19 +1049,19 @@ w_winepath()
 w_wineserver()
 {
     case "$@" in
-        *-k) w_warn "Running $WINESERVER -k. This will kill all running wine processes in prefix=$WINEPREFIX";;
-        *-w) w_warn "Running $WINESERVER -w. This will hang until all wine processes in prefix=$WINEPREFIX terminate";;
+        *-k) w_warn "Running ${WINESERVER} -k. This will kill all running wine processes in prefix=${WINEPREFIX}";;
+        *-w) w_warn "Running ${WINESERVER} -w. This will hang until all wine processes in prefix=${WINEPREFIX} terminate";;
         *)   w_warn "Invoking wineserver with '$*'";;
     esac
     # shellcheck disable=SC2068
-    "$WINESERVER" $@
+    "${WINESERVER}" $@
 }
 
 winetricks_parse_wget_progress()
 {
     # Parse a percentage, a size, and a time into $1, $2 and $3
     # then use them to create the output line.
-    case $LANG in
+    case ${LANG} in
         pl*) perl -p -e \
             '$| = 1; s/^.* +([0-9]+%) +([0-9,.]+[GMKB]) +([0-9hms,.]+).*$/\1\n# Pobieranie… \2 (\3)/' ;;
         ru*) perl -p -e \
@@ -1074,29 +1074,29 @@ winetricks_parse_wget_progress()
 # Execute wget, and if in GUI mode, also show a graphical progress bar
 winetricks_wget_progress()
 {
-    case $WINETRICKS_GUI in
+    case ${WINETRICKS_GUI} in
         zenity)
             # Use a subshell so if the user clicks 'Cancel',
             # the --auto-kill kills the subshell, not the current shell
             (
                 ${torify} wget "$@" 2>&1 |
                 winetricks_parse_wget_progress | \
-                $WINETRICKS_GUI --progress --width 400 --title="$_W_file" --auto-kill --auto-close
+                ${WINETRICKS_GUI} --progress --width 400 --title="${_W_file}" --auto-kill --auto-close
             )
             err=$?
-            if test $err -gt 128; then
+            if test ${err} -gt 128; then
                 # 129 is 'killed by SIGHUP'
                 # Sadly, --auto-kill only applies to parent process,
                 # which was the subshell, not all the elements of the pipeline...
                 # have to go find and kill the wget.
                 # If we ran wget in the background, we could kill it more directly, perhaps...
-                if pid=$(pgrep -f ."$_W_file"); then
+                if pid=$(pgrep -f ."${_W_file}"); then
                     echo User aborted download, killing wget
                     # shellcheck disable=SC2086
-                    kill $pid
+                    kill ${pid}
                 fi
             fi
-            return $err
+            return ${err}
             ;;
         *) ${torify} wget "$@" ;;
     esac
@@ -1139,7 +1139,7 @@ w_dotnet_verify()
         run, netfx_setupverifier.exe /q:a /c:"setupverifier2.exe"
         winwait, Verification Utility
         ControlClick, Button1
-        Control, ChooseString, NET Framework $version, ComboBox1
+        Control, ChooseString, NET Framework ${version}, ComboBox1
         ControlClick, Button1 ; Verify
         loop, 60
         {
@@ -1163,7 +1163,7 @@ w_dotnet_verify()
         }
     "
     dn_status="$?"
-    w_info ".Net Verifier returned $dn_status"
+    w_info ".Net Verifier returned ${dn_status}"
 }
 
 # Checks if the user can run the self-update/rollback commands
@@ -1191,33 +1191,33 @@ winetricks_selfupdate()
     _W_update_file="${0}.update"
 
     _W_tmpdir=${TMPDIR:-/tmp}
-    _W_tmpdir="$(mktemp -d "$_W_tmpdir/$_W_filename.XXXXXXXX")"
+    _W_tmpdir="$(mktemp -d "${_W_tmpdir}/${_W_filename}.XXXXXXXX")"
 
-    w_download_to "$_W_tmpdir" https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks "" "$_W_filename"
+    w_download_to "${_W_tmpdir}" https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks "" "${_W_filename}"
 
     # 2016/10/26: now file is uncompressed? Handle both cases:
-    update_file_type="$(file "$_W_tmpdir/$_W_filename")"
-    case "$update_file_type" in
+    update_file_type="$(file "${_W_tmpdir}/${_W_filename}")"
+    case "${update_file_type}" in
         *"POSIX shell script"*)
             #echo "already decompressed!"
-            w_try mv "$_W_tmpdir/$_W_filename" "${_W_update_file}"
+            w_try mv "${_W_tmpdir}/${_W_filename}" "${_W_update_file}"
             ;;
         *"gzip compressed data"*)
-            w_try mv "$_W_tmpdir/$_W_filename" "${_W_update_file}.gz"
+            w_try mv "${_W_tmpdir}/${_W_filename}" "${_W_update_file}.gz"
             w_try gunzip "${_W_update_file}.gz"
             ;;
         *)
-            echo "Unknown file type: $update_file_type"
+            echo "Unknown file type: ${update_file_type}"
             exit 1
             ;;
     esac
 
-    w_try rmdir "$_W_tmpdir"
+    w_try rmdir "${_W_tmpdir}"
 
-    w_try cp "$0" "$_W_rollback_file"
-    w_try chmod -x "$_W_rollback_file"
+    w_try cp "$0" "${_W_rollback_file}"
+    w_try chmod -x "${_W_rollback_file}"
 
-    w_try mv "$_W_update_file" "$0"
+    w_try mv "${_W_update_file}" "$0"
     w_try chmod +x "$0"
 
     w_warn "Update finished! The current version is $($0 -V). Use 'winetricks --update-rollback' to return to the previous version."
@@ -1231,8 +1231,8 @@ winetricks_selfupdate_rollback()
 
     _W_rollback_file="${0}.bak"
 
-    if test -f "$_W_rollback_file"; then
-        w_try mv "$_W_rollback_file" "$0"
+    if test -f "${_W_rollback_file}"; then
+        w_try mv "${_W_rollback_file}" "$0"
         w_try chmod +x "$0"
         w_warn "Rollback finished! The current version is $($0 -V)."
     else
@@ -1243,7 +1243,7 @@ winetricks_selfupdate_rollback()
 
 # Download a file
 # Usage: w_download_to (packagename|path to download file) url [shasum [filename [cookie jar]]]
-# Caches downloads in winetrickscache/$packagename
+# Caches downloads in winetrickscache/${packagename}
 w_download_to()
 {
     winetricks_download_setup
@@ -1254,31 +1254,31 @@ w_download_to()
     _W_file="$4"
     _W_cookiejar="$5"
 
-    case $_W_packagename in
+    case ${_W_packagename} in
         .) w_die "bug: please do not download packages to top of cache" ;;
     esac
 
-    if echo "$_W_url" | grep ' ' ; then
+    if echo "${_W_url}" | grep ' ' ; then
         w_die "bug: please use %20 instead of literal spaces in urls, curl rejects spaces, and they make life harder for linkcheck.sh"
     fi
-    if [ "$_W_file"x = ""x ] ; then
-        _W_file=$(basename "$_W_url")
+    if [ "${_W_file}"x = ""x ] ; then
+        _W_file=$(basename "${_W_url}")
     fi
 
-    w_get_shatype "$_W_sum"
+    w_get_shatype "${_W_sum}"
 
     if echo "${_W_packagename}" | grep -q -e '\/-' -e '^-'; then
             w_die "Invalid path ${_W_packagename} given"
     else
         if ! echo "${_W_packagename}" | grep -q '^/' ; then
-            _W_cache="$W_CACHE/$_W_packagename"
+            _W_cache="${W_CACHE}/${_W_packagename}"
         else
-            _W_cache="$_W_packagename"
+            _W_cache="${_W_packagename}"
         fi
     fi
 
-    if test ! -d "$_W_cache" ; then
-        w_try mkdir -p "$_W_cache"
+    if test ! -d "${_W_cache}" ; then
+        w_try mkdir -p "${_W_cache}"
     fi
 
     # Try download twice
@@ -1286,60 +1286,60 @@ w_download_to()
     tries=0
     # Set olddir before entering the loop, otherwise second try will overwrite
     _W_dl_olddir=$(pwd)
-    while test $tries -lt 2 ; do
+    while test ${tries} -lt 2 ; do
         # Warn on a second try
-        test "$tries" -eq 1 && winetricks_dl_warning
+        test "${tries}" -eq 1 && winetricks_dl_warning
         tries=$((tries + 1))
 
-        if test -s "$_W_cache/$_W_file" ; then
-            if test "$_W_sum" ; then
-                if test $tries = 1 ; then
+        if test -s "${_W_cache}/${_W_file}" ; then
+            if test "${_W_sum}" ; then
+                if test ${tries} = 1 ; then
                     # The cache was full.  If the file is larger than 500 MB,
                     # don't checksum it, that just annoys the user.
                     # shellcheck disable=SC2046
-                    if test $(du -k "$_W_cache/$_W_file" | cut -f1) -gt 500000 ; then
+                    if test $(du -k "${_W_cache}/${_W_file}" | cut -f1) -gt 500000 ; then
                         checksum_ok=1
                         break
                     fi
                 fi
                 # If checksum matches, declare success and exit loop
-                case "$_W_shatype" in
+                case "${_W_shatype}" in
                     none)
                         w_warn "No checksum provided, not verifying"
                         ;;
                     sha256)
-                        w_get_sha256sum "$_W_cache/$_W_file"
-                        if [ "$_W_gotsha256sum"x = "$_W_sum"x ] ; then
+                        w_get_sha256sum "${_W_cache}/${_W_file}"
+                        if [ "${_W_gotsha256sum}"x = "${_W_sum}"x ] ; then
                             checksum_ok=1
                             break
                         fi
                         ;;
                 esac
 
-                if test ! "$WINETRICKS_CONTINUE_DOWNLOAD" ; then
-                    case $LANG in
-                        pl*) w_warn "Niezgodność sum kontrolnych dla $_W_cache/$_W_file, pobieram ponownie" ;;
-                        ru*) w_warn "Контрольная сумма файла $_W_cache/$_W_file не совпадает, попытка повторной загрузки" ;;
-                        *) w_warn "Checksum for $_W_cache/$_W_file did not match, retrying download" ;;
+                if test ! "${WINETRICKS_CONTINUE_DOWNLOAD}" ; then
+                    case ${LANG} in
+                        pl*) w_warn "Niezgodność sum kontrolnych dla ${_W_cache}/${_W_file}, pobieram ponownie" ;;
+                        ru*) w_warn "Контрольная сумма файла ${_W_cache}/${_W_file} не совпадает, попытка повторной загрузки" ;;
+                        *) w_warn "Checksum for ${_W_cache}/${_W_file} did not match, retrying download" ;;
                     esac
-                    mv -f "$_W_cache/$_W_file" "$_W_cache/$_W_file".bak
+                    mv -f "${_W_cache}/${_W_file}" "${_W_cache}/${_W_file}".bak
                 fi
             else
                 # file exists, no checksum known, declare success and exit loop
                 break
             fi
-        elif test -f "$_W_cache/$_W_file" ; then
+        elif test -f "${_W_cache}/${_W_file}" ; then
             # zero-length file, just delete before retrying
-            rm "$_W_cache/$_W_file"
+            rm "${_W_cache}/${_W_file}"
         fi
 
-        w_try_cd "$_W_cache"
+        w_try_cd "${_W_cache}"
         # Mac folks tend to have curl rather than wget
         # On Mac, 'which' doesn't return good exit status
-        echo "Downloading $_W_url to $_W_cache"
+        echo "Downloading ${_W_url} to ${_W_cache}"
 
         # For sites that prefer Mozilla in the user-agent header, set W_BROWSERAGENT=1
-        case "$W_BROWSERAGENT" in
+        case "${W_BROWSERAGENT}" in
             1) _W_agent="Mozilla/5.0 (compatible; Konqueror/2.1.1; X11)" ;;
             *) _W_agent="" ;;
         esac
@@ -1357,20 +1357,20 @@ w_download_to()
             #   ovewritten by the new aria2 process
 
             # shellcheck disable=SC2086
-            $torify aria2c \
-                ${aria2c_torify_opts:+"$aria2c_torify_opts"} \
+            ${torify} aria2c \
+                ${aria2c_torify_opts:+"${aria2c_torify_opts}"} \
                 --connect-timeout="${WINETRICKS_DOWNLOADER_TIMEOUT}" \
                 --continue \
                 --daemon=false \
-                --dir="$_W_cache" \
+                --dir="${_W_cache}" \
                 --enable-rpc=false \
                 --input-file='' \
                 --max-connection-per-server=5 \
-                --max-tries="$WINETRICKS_DOWNLOADER_RETRIES" \
-                --out="$_W_file" \
+                --max-tries="${WINETRICKS_DOWNLOADER_RETRIES}" \
+                --out="${_W_file}" \
                 --save-session='' \
                 --stream-piece-selector=geom \
-                "$_W_url"
+                "${_W_url}"
         elif [ "${WINETRICKS_DOWNLOADER}" = "wget" ] ; then
             # Use -nd to insulate ourselves from people who set -x in WGETRC
             # [*] --retry-connrefused works around the broken sf.net mirroring
@@ -1381,40 +1381,40 @@ w_download_to()
 
             # shellcheck disable=SC2086
             winetricks_wget_progress \
-                -O "$_W_file" \
+                -O "${_W_file}" \
                 -nd \
                 -c\
                 --read-timeout 300 \
                 --retry-connrefused \
                 --timeout "${WINETRICKS_DOWNLOADER_TIMEOUT}" \
-                --tries "$WINETRICKS_DOWNLOADER_RETRIES" \
-                ${_W_cookiejar:+--load-cookies "$_W_cookiejar"} \
-                ${_W_agent:+--user-agent="$_W_agent"} \
-                "$_W_url"
+                --tries "${WINETRICKS_DOWNLOADER_RETRIES}" \
+                ${_W_cookiejar:+--load-cookies "${_W_cookiejar}"} \
+                ${_W_agent:+--user-agent="${_W_agent}"} \
+                "${_W_url}"
         elif [ "${WINETRICKS_DOWNLOADER}" = "curl" ] ; then
             # Note: curl does not accept '=' when passing options
             # curl doesn't get filename from the location given by the server!
             # fortunately, we know it
 
             # shellcheck disable=SC2086
-            $torify curl \
+            ${torify} curl \
                 --connect-timeout "${WINETRICKS_DOWNLOADER_TIMEOUT}" \
                 -L \
-                -o "$_W_file" \
+                -o "${_W_file}" \
                 -C - \
-                --retry "$WINETRICKS_DOWNLOADER_RETRIES" \
-                ${_W_cookiejar:+--cookie "$_W_cookiejar"} \
-                ${_W_agent:+--user-agent "$_W_agent"} \
-                "$_W_url"
+                --retry "${WINETRICKS_DOWNLOADER_RETRIES}" \
+                ${_W_cookiejar:+--cookie "${_W_cookiejar}"} \
+                ${_W_agent:+--user-agent "${_W_agent}"} \
+                "${_W_url}"
         elif [ "${WINETRICKS_DOWNLOADER}" = "fetch" ] ; then
             # Note: fetch does not support configurable retry count
 
             # shellcheck disable=SC2086
-            $torify fetch \
+            ${torify} fetch \
                 -T "${WINETRICKS_DOWNLOADER_TIMEOUT}" \
-                -o "$_W_file" \
-                ${_W_agent:+--user-agent="$_W_agent"} \
-                "$_W_url"
+                -o "${_W_file}" \
+                ${_W_agent:+--user-agent="${_W_agent}"} \
+                "${_W_url}"
         else
             w_die "Here be dragons"
         fi
@@ -1424,33 +1424,33 @@ w_download_to()
             # Also affects ttf files on github
             # FIXME: gzip hack below may no longer be needed, but need to investigate before removing
             _W_filetype=$(command -v file 2>/dev/null)
-            case $_W_filetype-$_W_file in
+            case ${_W_filetype}-${_W_file} in
                 /*-*.exe|/*-*.ttf|/*-*.zip)
-                    case $(file "$_W_file") in
-                        *:*gzip*) mv "$_W_file" "$_W_file.gz"; gunzip < "$_W_file.gz" > "$_W_file";;
+                    case $(file "${_W_file}") in
+                        *:*gzip*) mv "${_W_file}" "${_W_file}.gz"; gunzip < "${_W_file}.gz" > "${_W_file}";;
                     esac
             esac
 
             # On Cygwin, .exe's must be marked +x
-            case "$_W_file" in
-                *.exe) chmod +x "$_W_file" ;;
+            case "${_W_file}" in
+                *.exe) chmod +x "${_W_file}" ;;
             esac
 
-            w_try_cd "$_W_dl_olddir"
+            w_try_cd "${_W_dl_olddir}"
             unset _W_dl_olddir
 
             # downloaded successfully, exit from loop
             break
-        elif test $tries = 2; then
-            test -f "$_W_file" && rm "$_W_file"
-            w_die "Downloading $_W_url failed"
+        elif test ${tries} = 2; then
+            test -f "${_W_file}" && rm "${_W_file}"
+            w_die "Downloading ${_W_url} failed"
         fi
         # Download from the Wayback Machine on second try
-        _W_url="https://web.archive.org/web/2000/$_W_url"
+        _W_url="https://web.archive.org/web/2000/${_W_url}"
     done
 
-    if test "$_W_sum" && test ! "$checksum_ok"; then
-        w_verify_shasum "$_W_sum" "$_W_cache/$_W_file"
+    if test "${_W_sum}" && test ! "${checksum_ok}"; then
+        w_verify_shasum "${_W_sum}" "${_W_cache}/${_W_file}"
     fi
 }
 
@@ -1459,12 +1459,12 @@ w_download_to()
 w_open_folder()
 {
     for _W_cmd in xdg-open open cygstart true ; do
-        _W_cmdpath=$(command -v $_W_cmd)
-        if test -n "$_W_cmdpath" ; then
+        _W_cmdpath=$(command -v ${_W_cmd})
+        if test -n "${_W_cmdpath}" ; then
             break
         fi
     done
-    $_W_cmd "$1" &
+    ${_W_cmd} "$1" &
     unset _W_cmd _W_cmdpath
 }
 
@@ -1474,27 +1474,27 @@ w_open_webpage()
 {
     # See https://www.dwheeler.com/essays/open-files-urls.html
     for _W_cmd in xdg-open sdtwebclient cygstart open firefox true ; do
-        _W_cmdpath=$(command -v $_W_cmd)
-        if test -n "$_W_cmdpath" ; then
+        _W_cmdpath=$(command -v ${_W_cmd})
+        if test -n "${_W_cmdpath}" ; then
             break
         fi
     done
-    $_W_cmd "$1" &
+    ${_W_cmd} "$1" &
     unset _W_cmd _W_cmdpath
 }
 
 # Download a file
 # Usage: w_download url [shasum [filename [cookie jar]]]
-# Caches downloads in winetrickscache/$W_PACKAGE
+# Caches downloads in winetrickscache/${W_PACKAGE}
 w_download()
 {
-    w_download_to "$W_PACKAGE" "$@"
+    w_download_to "${W_PACKAGE}" "$@"
 }
 
 # Download one or more files via BitTorrent
 # Usage: w_download_torrent [foo.torrent]
-# Caches downloads in $W_CACHE/$W_PACKAGE, torrent files are assumed to be there
-# If no foo.torrent is given, will add ALL .torrent files in $W_CACHE/$W_PACKAGE
+# Caches downloads in ${W_CACHE}/${W_PACKAGE}, torrent files are assumed to be there
+# If no foo.torrent is given, will add ALL .torrent files in ${W_CACHE}/${W_PACKAGE}
 w_download_torrent()
 {
     # FIXME: figure out how to extract the filename from the .torrent file
@@ -1502,14 +1502,14 @@ w_download_torrent()
 
     w_call utorrent
 
-    UT_WINPATH="$W_CACHE_WIN\\$W_PACKAGE"
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    UT_WINPATH="${W_CACHE_WIN}\\${W_PACKAGE}"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
     if [ "$2"x != ""x ] ; then # foo.torrent parameter supplied
-        w_try "$WINE" utorrent "/DIRECTORY" "$UT_WINPATH" "$UT_WINPATH\\$2" &
+        w_try "${WINE}" utorrent "/DIRECTORY" "${UT_WINPATH}" "${UT_WINPATH}\\$2" &
     else # grab all torrents
         for torrent in *.torrent ; do
-            w_try "$WINE" utorrent "/DIRECTORY" "$UT_WINPATH" "$UT_WINPATH\\$torrent" &
+            w_try "${WINE}" utorrent "/DIRECTORY" "${UT_WINPATH}" "${UT_WINPATH}\\${torrent}" &
         done
     fi
 
@@ -1563,32 +1563,32 @@ w_download_manual_to()
     _W_shasum="$4"
 
     # shellcheck disable=SC2154
-    case "$media" in
+    case "${media}" in
         "download") w_info "FAIL: bug: media type is download, but w_download_manual was called.  Programmer, please change verb's media type to manual_download." ;;
     esac
 
-    if ! test -f "$W_CACHE/$_W_packagename/$_W_file"; then
-        case $LANG in
-            da*) _W_dlmsg="Hent venligst filen $_W_file fra $_W_url og placér den i $W_CACHE/$_W_packagename, kør derefter dette skript.";;
-            de*) _W_dlmsg="Bitte laden Sie $_W_file von $_W_url runter, stellen Sie's in $W_CACHE/$_W_packagename, dann wiederholen Sie dieses Kommando.";;
-            pl*) _W_dlmsg="Proszę pobrać plik $_W_file z $_W_url, następnie umieścić go w $W_CACHE/$_W_packagename, a na końcu uruchomić ponownie ten skrypt.";;
-            ru*) _W_dlmsg="Пожалуйста, скачайте файл $_W_file по адресу $_W_url, и поместите его в $W_CACHE/$_W_packagename, а затем запустите winetricks заново.";;
-            uk*) _W_dlmsg="Будь ласка, звантажте $_W_file з $_W_url, розташуйте в $W_CACHE/$_W_packagename, потім запустіть скрипт знову.";;
-            zh_CN*) _W_dlmsg="请从 $_W_url 下载 $_W_file，并置放于 $W_CACHE/$_W_packagename, 然后重新运行 winetricks.";;
-            zh_TW*|zh_HK*) _W_dlmsg="請從 $_W_url 下載 $_W_file，并置放於 $W_CACHE/$_W_packagename, 然后重新執行 winetricks.";;
-            *) _W_dlmsg="Please download $_W_file from $_W_url, place it in $W_CACHE/$_W_packagename, then re-run this script.";;
+    if ! test -f "${W_CACHE}/${_W_packagename}/${_W_file}"; then
+        case ${LANG} in
+            da*) _W_dlmsg="Hent venligst filen ${_W_file} fra ${_W_url} og placér den i ${W_CACHE}/${_W_packagename}, kør derefter dette skript.";;
+            de*) _W_dlmsg="Bitte laden Sie ${_W_file} von ${_W_url} runter, stellen Sie's in ${W_CACHE}/${_W_packagename}, dann wiederholen Sie dieses Kommando.";;
+            pl*) _W_dlmsg="Proszę pobrać plik ${_W_file} z ${_W_url}, następnie umieścić go w ${W_CACHE}/${_W_packagename}, a na końcu uruchomić ponownie ten skrypt.";;
+            ru*) _W_dlmsg="Пожалуйста, скачайте файл ${_W_file} по адресу ${_W_url}, и поместите его в ${W_CACHE}/${_W_packagename}, а затем запустите winetricks заново.";;
+            uk*) _W_dlmsg="Будь ласка, звантажте ${_W_file} з ${_W_url}, розташуйте в ${W_CACHE}/${_W_packagename}, потім запустіть скрипт знову.";;
+            zh_CN*) _W_dlmsg="请从 ${_W_url} 下载 ${_W_file}，并置放于 ${W_CACHE}/${_W_packagename}, 然后重新运行 winetricks.";;
+            zh_TW*|zh_HK*) _W_dlmsg="請從 ${_W_url} 下載 ${_W_file}，并置放於 ${W_CACHE}/${_W_packagename}, 然后重新執行 winetricks.";;
+            *) _W_dlmsg="Please download ${_W_file} from ${_W_url}, place it in ${W_CACHE}/${_W_packagename}, then re-run this script.";;
         esac
 
-        mkdir -p "$W_CACHE/$_W_packagename"
-        w_open_folder "$W_CACHE/$_W_packagename"
-        w_open_webpage "$_W_url"
+        mkdir -p "${W_CACHE}/${_W_packagename}"
+        w_open_folder "${W_CACHE}/${_W_packagename}"
+        w_open_webpage "${_W_url}"
         sleep 3   # give some time for web browser to open
-        w_die "$_W_dlmsg"
+        w_die "${_W_dlmsg}"
         # FIXME: wait in loop until file is finished?
     fi
 
-    if test "$_W_shasum"; then
-        w_verify_shasum "$_W_shasum" "$W_CACHE/$_W_packagename/$_W_file"
+    if test "${_W_shasum}"; then
+        w_verify_shasum "${_W_shasum}" "${W_CACHE}/${_W_packagename}/${_W_file}"
     fi
 
     unset _W_dlmsg _W_file _W_sha256sum _W_url
@@ -1596,14 +1596,14 @@ w_download_manual_to()
 
 w_download_manual()
 {
-    w_download_manual_to "$W_PACKAGE" "$@"
+    w_download_manual_to "${W_PACKAGE}" "$@"
 }
 
 # Turn off news, overlays, and friend interaction in Steam
 # Run from inside C:\Program Files\Steam
 w_steam_safemode()
 {
-    cat > "$W_TMP/steamconfig.pl" <<"_EOF_"
+    cat > "${W_TMP}/steamconfig.pl" <<"_EOF_"
 #!/usr/bin/env perl
 # Parse Steam's localconfig.vcf, add settings to it, and write it out again
 # The file is a recursive dictionary
@@ -1690,22 +1690,22 @@ print "}\n";
 _EOF_
 
 for file in userdata/*/config/localconfig.vdf ; do
-    cp "$file" "$file.old"
-    perl "$W_TMP"/steamconfig.pl "$file.old" > "$file"
+    cp "${file}" "${file}.old"
+    perl "${W_TMP}"/steamconfig.pl "${file}.old" > "${file}"
 done
 }
 
 w_question()
 {
-    case $WINETRICKS_GUI in
-        *zenity) $WINETRICKS_GUI --entry --text "$1" ;;
-        *kdialog) $WINETRICKS_GUI --inputbox "$1" ;;
+    case ${WINETRICKS_GUI} in
+        *zenity) ${WINETRICKS_GUI} --entry --text "$1" ;;
+        *kdialog) ${WINETRICKS_GUI} --inputbox "$1" ;;
         *xmessage) w_die "sorry, can't ask question with xmessage" ;;
         none)
             # Using printf instead of echo because we don't want a newline
             printf "%s" "$1" >&2 ;
             read -r W_ANSWER ;
-            echo "$W_ANSWER";
+            echo "${W_ANSWER}";
             unset W_ANSWER;;
     esac
 }
@@ -1718,22 +1718,22 @@ w_steam_getid()
     _W_steamidmsg="Please enter your Steam login ID (not email)"
     _W_steampasswordmsg="Please enter your Steam password"
 
-    if test ! "$W_STEAM_ID"; then
-        if test -f "$W_CACHE"/steam_userid.txt; then
-            W_STEAM_ID=$(cat "$W_CACHE"/steam_userid.txt)
+    if test ! "${W_STEAM_ID}"; then
+        if test -f "${W_CACHE}"/steam_userid.txt; then
+            W_STEAM_ID=$(cat "${W_CACHE}"/steam_userid.txt)
         else
-            W_STEAM_ID=$(w_question "$_W_steamidmsg")
-            echo "$W_STEAM_ID" > "$W_CACHE"/steam_userid.txt
-            chmod 600 "$W_CACHE"/steam_userid.txt
+            W_STEAM_ID=$(w_question "${_W_steamidmsg}")
+            echo "${W_STEAM_ID}" > "${W_CACHE}"/steam_userid.txt
+            chmod 600 "${W_CACHE}"/steam_userid.txt
         fi
     fi
-    if test ! "$W_STEAM_PASSWORD"; then
-        if test -f "$W_CACHE"/steam_password.txt; then
-            W_STEAM_PASSWORD=$(cat "$W_CACHE"/steam_password.txt)
+    if test ! "${W_STEAM_PASSWORD}"; then
+        if test -f "${W_CACHE}"/steam_password.txt; then
+            W_STEAM_PASSWORD=$(cat "${W_CACHE}"/steam_password.txt)
         else
-            W_STEAM_PASSWORD=$(w_question "$_W_steampasswordmsg")
-            echo "$W_STEAM_PASSWORD" > "$W_CACHE"/steam_password.txt
-            chmod 600 "$W_CACHE"/steam_password.txt
+            W_STEAM_PASSWORD=$(w_question "${_W_steampasswordmsg}")
+            echo "${W_STEAM_PASSWORD}" > "${W_CACHE}"/steam_password.txt
+            chmod 600 "${W_CACHE}"/steam_password.txt
         fi
     fi
 }
@@ -1756,17 +1756,17 @@ w_steam_install_game()
     # "Steam" (small window) - connecting, wait for it to close
     # "Steam" (large window) - the main window
     # "Steam - Updates News" - close it forcefully
-    # "Install - $title" - send enter, click a couple checkboxes, send enter again
-    # "Updating $title" - small download progress dialog
+    # "Install - ${title}" - send enter, click a couple checkboxes, send enter again
+    # "Updating ${title}" - small download progress dialog
     # "Steam - Ready" game install done.  (Only comes up if main window not up.)
 
-    w_try_cd "$W_PROGRAMS_X86_UNIX/Steam"
+    w_try_cd "${W_PROGRAMS_X86_UNIX}/Steam"
     w_ahk_do "
         SetTitleMatchMode 2
         SetWinDelay 500
         ; Run steam once until it finishes its initial update.
         ; For me, this exits at 26%.
-        run steam.exe -applaunch $_W_steamid -login $W_STEAM_ID $W_STEAM_PASSWORD
+        run steam.exe -applaunch ${_W_steamid} -login ${W_STEAM_ID} ${W_STEAM_PASSWORD}
         Loop
         {
             ifWinExist, Steam - Updating
@@ -1780,7 +1780,7 @@ w_steam_install_game()
                 winwaitclose
                 process close, Steam.exe
                 ; Run a third time, have it log in, wait until it has finished connecting
-                run steam.exe -applaunch $_W_steamid -login $W_STEAM_ID $W_STEAM_PASSWORD
+                run steam.exe -applaunch ${_W_steamid} -login ${W_STEAM_ID} ${W_STEAM_PASSWORD}
             }
             ifWinExist, Steam Login
             {
@@ -1795,7 +1795,7 @@ w_steam_install_game()
         winwaitclose
     "
 
-if [ "$STEAM_DVD" = "TRUE" ]; then
+if [ "${STEAM_DVD}" = "TRUE" ]; then
     w_ahk_do "
         ; Run a fourth time, have it install the app.
         run steam.exe -install ${W_ISO_MOUNT_LETTER}:\\
@@ -1803,12 +1803,12 @@ if [ "$STEAM_DVD" = "TRUE" ]; then
 else
     w_ahk_do "
         ; Run a fourth time, have it install the app.
-        run steam.exe -applaunch $_W_steamid
+        run steam.exe -applaunch ${_W_steamid}
     "
 fi
 
     w_ahk_do "
-        winwait Install - $_W_steamtitle
+        winwait Install - ${_W_steamtitle}
         if ( w_opt_unattended > 0 ) {
             send {enter}          ; next (for 1st of 3 pages of install dialog)
             sleep 1000
@@ -1824,25 +1824,25 @@ fi
                     winclose
                     continue
                 }
-                ifwinexist Install - $_W_steamtitle
+                ifwinexist Install - ${_W_steamtitle}
                 {
                     winactivate
                     send {enter}      ; next (for 3rd of 3 pages of install dialog)
                 }
-                ifwinnotexist Install - $_W_steamtitle
+                ifwinnotexist Install - ${_W_steamtitle}
                 {
                     sleep 1000
-                    ifwinnotexist Install - $_W_steamtitle
+                    ifwinnotexist Install - ${_W_steamtitle}
                         break
                 }
             }
         }
     "
 
-if [ "$STEAM_DVD" = "TRUE" ]; then
+if [ "${STEAM_DVD}" = "TRUE" ]; then
     # Wait for install to finish
     while true; do
-        grep "SetHasAllLocalContent(true) called for $_W_steamid" "$W_PROGRAMS_X86_UNIX/Steam/logs/download_log.txt" && break
+        grep "SetHasAllLocalContent(true) called for ${_W_steamid}" "${W_PROGRAMS_X86_UNIX}/Steam/logs/download_log.txt" && break
         sleep 5
     done
 fi
@@ -1851,7 +1851,7 @@ fi
         ; For DVD's: theoretically, it should be installed now, but most games want to download updates. Do that now.
         ; For regular downloads: relaunch to coax steam into showing its nice small download progress dialog
         process close, Steam.exe
-        run steam.exe -login $W_STEAM_ID $W_STEAM_PASSWORD -applaunch $_W_steamid
+        run steam.exe -login ${W_STEAM_ID} ${W_STEAM_PASSWORD} -applaunch ${_W_steamid}
         winwait Ready -
         process close, Steam.exe
     "
@@ -1875,19 +1875,19 @@ fi
 w_mount()
 {
     if test "$3"; then
-        WINETRICKS_IMG="$W_CACHE/$W_PACKAGE/$1-$3.iso"
+        WINETRICKS_IMG="${W_CACHE}/${W_PACKAGE}/$1-$3.iso"
     else
-        WINETRICKS_IMG="$W_CACHE/$W_PACKAGE/$1.iso"
+        WINETRICKS_IMG="${W_CACHE}/${W_PACKAGE}/$1.iso"
     fi
-    mkdir -p "$W_CACHE/$W_PACKAGE"
+    mkdir -p "${W_CACHE}/${W_PACKAGE}"
 
-    if test -f "$WINETRICKS_IMG"; then
+    if test -f "${WINETRICKS_IMG}"; then
         winetricks_mount_cached_iso
     else
-        if test "$WINETRICKS_OPT_KEEPISOS" = 0 || test "$2"; then
+        if test "${WINETRICKS_OPT_KEEPISOS}" = 0 || test "$2"; then
             while true; do
                 winetricks_mount_real_volume "$1"
-                if test "$2" = "" || test -f "$W_ISO_MOUNT_ROOT/$2"; then
+                if test "$2" = "" || test -f "${W_ISO_MOUNT_ROOT}/$2"; then
                     break
                 else
                     w_warn "Wrong disc inserted, $2 not found."
@@ -1895,7 +1895,7 @@ w_mount()
             done
         fi
 
-        case "$WINETRICKS_OPT_KEEPISOS" in
+        case "${WINETRICKS_OPT_KEEPISOS}" in
             1)
                 winetricks_cache_iso "$1"
                 winetricks_mount_cached_iso
@@ -1906,71 +1906,71 @@ w_mount()
 
 w_umount()
 {
-    if test "$WINE" = ""; then
+    if test "${WINE}" = ""; then
         # Windows
         winetricks_load_vcdmount
-        w_try_cd "$VCD_DIR"
+        w_try_cd "${VCD_DIR}"
         w_try vcdmount.exe /u
     else
-        if test "$W_USE_USERMOUNT"; then
+        if test "${W_USE_USERMOUNT}"; then
             # FUSE-based tools or hdiutil
-            if test -d "$W_ISO_USER_MOUNT_ROOT"; then
-                "$WINE" eject "${W_ISO_MOUNT_LETTER}:"
-                cat > "$W_TMP"/unset_type_cdrom.reg <<_EOF_
+            if test -d "${W_ISO_USER_MOUNT_ROOT}"; then
+                "${WINE}" eject "${W_ISO_MOUNT_LETTER}:"
+                cat > "${W_TMP}"/unset_type_cdrom.reg <<_EOF_
 REGEDIT4
 
 [HKEY_LOCAL_MACHINE\\Software\\Wine\\Drives]
 "${W_ISO_MOUNT_LETTER}:"=-
 _EOF_
-                w_try_regedit "$W_TMP"/unset_type_cdrom.reg
-                rm -f "$WINEPREFIX/dosdevices/${W_ISO_MOUNT_LETTER}:"
-                rm -f "$WINEPREFIX/dosdevices/${W_ISO_MOUNT_LETTER}::"
+                w_try_regedit "${W_TMP}"/unset_type_cdrom.reg
+                rm -f "${WINEPREFIX}/dosdevices/${W_ISO_MOUNT_LETTER}:"
+                rm -f "${WINEPREFIX}/dosdevices/${W_ISO_MOUNT_LETTER}::"
 
-                case "$WINETRICKS_ISO_MOUNT" in
+                case "${WINETRICKS_ISO_MOUNT}" in
                     hdiutil)
-                        "$WINETRICKS_ISO_MOUNT" detach "$W_ISO_USER_MOUNT_ROOT"
+                        "${WINETRICKS_ISO_MOUNT}" detach "${W_ISO_USER_MOUNT_ROOT}"
                         ;;
                     *)
                         # -uz lazy unmount in case executable still running
-                        fusermount -uz "$W_ISO_USER_MOUNT_ROOT"
+                        fusermount -uz "${W_ISO_USER_MOUNT_ROOT}"
                         ;;
                 esac
-                w_try rmdir "$W_ISO_USER_MOUNT_ROOT"
+                w_try rmdir "${W_ISO_USER_MOUNT_ROOT}"
             fi
             W_ISO_MOUNT_ROOT=/mnt/winetricks
         else
             # sudo + umount
-            echo "Running $WINETRICKS_SUDO umount $W_ISO_MOUNT_ROOT"
+            echo "Running ${WINETRICKS_SUDO} umount ${W_ISO_MOUNT_ROOT}"
 
-            case "$WINETRICKS_SUDO" in
+            case "${WINETRICKS_SUDO}" in
                 gksu*|kdesudo)
                     # -l lazy unmount in case executable still running
-                    "$WINETRICKS_SUDO" "umount -l $W_ISO_MOUNT_ROOT"
-                    w_try "$WINETRICKS_SUDO" "rm -rf $W_ISO_MOUNT_ROOT"
+                    "${WINETRICKS_SUDO}" "umount -l ${W_ISO_MOUNT_ROOT}"
+                    w_try "${WINETRICKS_SUDO}" "rm -rf ${W_ISO_MOUNT_ROOT}"
                     ;;
                 kdesu)
-                    "$WINETRICKS_SUDO" -c "umount -l $W_ISO_MOUNT_ROOT"
-                    w_try "$WINETRICKS_SUDO" -c "rm -rf $W_ISO_MOUNT_ROOT"
+                    "${WINETRICKS_SUDO}" -c "umount -l ${W_ISO_MOUNT_ROOT}"
+                    w_try "${WINETRICKS_SUDO}" -c "rm -rf ${W_ISO_MOUNT_ROOT}"
                     ;;
                 *)
-                    "$WINETRICKS_SUDO" umount -l "$W_ISO_MOUNT_ROOT"
-                    w_try "$WINETRICKS_SUDO" rm -rf "$W_ISO_MOUNT_ROOT"
+                    "${WINETRICKS_SUDO}" umount -l "${W_ISO_MOUNT_ROOT}"
+                    w_try "${WINETRICKS_SUDO}" rm -rf "${W_ISO_MOUNT_ROOT}"
                     ;;
             esac
 
-            "$WINE" eject "${W_ISO_MOUNT_LETTER}:"
-            rm -f "$WINEPREFIX/dosdevices/${W_ISO_MOUNT_LETTER}:"
-            rm -f "$WINEPREFIX/dosdevices/${W_ISO_MOUNT_LETTER}::"
+            "${WINE}" eject "${W_ISO_MOUNT_LETTER}:"
+            rm -f "${WINEPREFIX}/dosdevices/${W_ISO_MOUNT_LETTER}:"
+            rm -f "${WINEPREFIX}/dosdevices/${W_ISO_MOUNT_LETTER}::"
         fi
     fi
 }
 
 w_ahk_do()
 {
-    if ! test -f "$W_CACHE/ahk/AutoHotkey.exe"; then
+    if ! test -f "${W_CACHE}/ahk/AutoHotkey.exe"; then
         w_download_to ahk https://github.com/AutoHotkey/AutoHotkey/releases/download/v1.0.48.05/AutoHotkey104805_Install.exe 4311c3e7c29ed2d67f415138360210bc2f55ff78758b20b003b91d775ee207b9
-        w_try_7z "$W_CACHE/ahk" "$W_CACHE/ahk/AutoHotkey104805_Install.exe" AutoHotkey.exe AU3_Spy.exe
-        chmod +x "$W_CACHE/ahk/AutoHotkey.exe"
+        w_try_7z "${W_CACHE}/ahk" "${W_CACHE}/ahk/AutoHotkey104805_Install.exe" AutoHotkey.exe AU3_Spy.exe
+        chmod +x "${W_CACHE}/ahk/AutoHotkey.exe"
     fi
 
     # Previously this used printf + sed, but that was broken with BSD sed (FreeBSD/OS X):
@@ -1993,7 +1993,7 @@ _EOF_
 
 w_skip_windows()
 {
-    case "$W_PLATFORM" in
+    case "${W_PLATFORM}" in
         windows_cmd)
             echo "Skipping operation '$1' on Windows"
             return "${TRUE}"
@@ -2009,43 +2009,43 @@ w_common_override_dll()
     module="$2"
 
     # Remove wine's builtin manifest, if present. Use:
-    # wineboot ; find "$WINEPREFIX"/drive_c/windows/winsxs/ -iname \*deadbeef.manifest | sort
-    case "$W_PACKAGE" in
+    # wineboot ; find "${WINEPREFIX}"/drive_c/windows/winsxs/ -iname \*deadbeef.manifest | sort
+    case "${W_PACKAGE}" in
         comctl32)
-            w_try rm -rf "$W_WINDIR_UNIX"/winsxs/manifests/amd64_microsoft.windows.common-controls_6595b64144ccf1df_6.0.2600.2982_none_deadbeef.manifest
-            w_try rm -rf "$W_WINDIR_UNIX"/winsxs/manifests/x86_microsoft.windows.common-controls_6595b64144ccf1df_6.0.2600.2982_none_deadbeef.manifest
+            w_try rm -rf "${W_WINDIR_UNIX}"/winsxs/manifests/amd64_microsoft.windows.common-controls_6595b64144ccf1df_6.0.2600.2982_none_deadbeef.manifest
+            w_try rm -rf "${W_WINDIR_UNIX}"/winsxs/manifests/x86_microsoft.windows.common-controls_6595b64144ccf1df_6.0.2600.2982_none_deadbeef.manifest
             ;;
         vcrun2005)
-            w_try rm -rf "$W_WINDIR_UNIX"/winsxs/manifests/amd64_microsoft.vc80.atl_1fc8b3b9a1e18e3b_8.0.50727.4053_none_deadbeef.manifest
-            w_try rm -rf "$W_WINDIR_UNIX"/winsxs/manifests/amd64_microsoft.vc80.crt_1fc8b3b9a1e18e3b_8.0.50727.4053_none_deadbeef.manifest
-            w_try rm -rf "$W_WINDIR_UNIX"/winsxs/manifests/x86_microsoft.vc80.atl_1fc8b3b9a1e18e3b_8.0.50727.4053_none_deadbeef.manifest
-            w_try rm -rf "$W_WINDIR_UNIX"/winsxs/manifests/x86_microsoft.vc80.crt_1fc8b3b9a1e18e3b_8.0.50727.4053_none_deadbeef.manifest
+            w_try rm -rf "${W_WINDIR_UNIX}"/winsxs/manifests/amd64_microsoft.vc80.atl_1fc8b3b9a1e18e3b_8.0.50727.4053_none_deadbeef.manifest
+            w_try rm -rf "${W_WINDIR_UNIX}"/winsxs/manifests/amd64_microsoft.vc80.crt_1fc8b3b9a1e18e3b_8.0.50727.4053_none_deadbeef.manifest
+            w_try rm -rf "${W_WINDIR_UNIX}"/winsxs/manifests/x86_microsoft.vc80.atl_1fc8b3b9a1e18e3b_8.0.50727.4053_none_deadbeef.manifest
+            w_try rm -rf "${W_WINDIR_UNIX}"/winsxs/manifests/x86_microsoft.vc80.crt_1fc8b3b9a1e18e3b_8.0.50727.4053_none_deadbeef.manifest
 
             # These are 32-bit only?
-            w_try rm -rf "$W_WINDIR_UNIX"/winsxs/manifests/x86_microsoft.vc80.mfc_1fc8b3b9a1e18e3b_8.0.50727.6195_none_deadbeef.manifest
-            w_try rm -rf "$W_WINDIR_UNIX"/winsxs/manifests/x86_microsoft.vc80.mfcloc_1fc8b3b9a1e18e3b_8.0.50727.6195_none_deadbeef.manifest
-            w_try rm -rf "$W_WINDIR_UNIX"/winsxs/manifests/x86_microsoft.vc80.openmp_1fc8b3b9a1e18e3b_8.0.50727.6195_none_deadbeef.manifest
+            w_try rm -rf "${W_WINDIR_UNIX}"/winsxs/manifests/x86_microsoft.vc80.mfc_1fc8b3b9a1e18e3b_8.0.50727.6195_none_deadbeef.manifest
+            w_try rm -rf "${W_WINDIR_UNIX}"/winsxs/manifests/x86_microsoft.vc80.mfcloc_1fc8b3b9a1e18e3b_8.0.50727.6195_none_deadbeef.manifest
+            w_try rm -rf "${W_WINDIR_UNIX}"/winsxs/manifests/x86_microsoft.vc80.openmp_1fc8b3b9a1e18e3b_8.0.50727.6195_none_deadbeef.manifest
             ;;
         vcrun2008)
-            w_try rm -rf "$W_WINDIR_UNIX"/winsxs/manifests/amd64_microsoft.vc90.atl_1fc8b3b9a1e18e3b_9.0.30729.6161_none_deadbeef.manifest
-            w_try rm -rf "$W_WINDIR_UNIX"/winsxs/manifests/amd64_microsoft.vc90.crt_1fc8b3b9a1e18e3b_9.0.30729.6161_none_deadbeef.manifest
-            w_try rm -rf "$W_WINDIR_UNIX"/winsxs/manifests/x86_microsoft.vc90.atl_1fc8b3b9a1e18e3b_9.0.30729.6161_none_deadbeef.manifest
-            w_try rm -rf "$W_WINDIR_UNIX"/winsxs/manifests/x86_microsoft.vc90.crt_1fc8b3b9a1e18e3b_9.0.30729.6161_none_deadbeef.manifest
+            w_try rm -rf "${W_WINDIR_UNIX}"/winsxs/manifests/amd64_microsoft.vc90.atl_1fc8b3b9a1e18e3b_9.0.30729.6161_none_deadbeef.manifest
+            w_try rm -rf "${W_WINDIR_UNIX}"/winsxs/manifests/amd64_microsoft.vc90.crt_1fc8b3b9a1e18e3b_9.0.30729.6161_none_deadbeef.manifest
+            w_try rm -rf "${W_WINDIR_UNIX}"/winsxs/manifests/x86_microsoft.vc90.atl_1fc8b3b9a1e18e3b_9.0.30729.6161_none_deadbeef.manifest
+            w_try rm -rf "${W_WINDIR_UNIX}"/winsxs/manifests/x86_microsoft.vc90.crt_1fc8b3b9a1e18e3b_9.0.30729.6161_none_deadbeef.manifest
 
             # These are 32-bit only?
-            w_try rm -rf "$W_WINDIR_UNIX"/winsxs/manifests/x86_microsoft.vc90.mfc_1fc8b3b9a1e18e3b_9.0.30729.6161_none_deadbeef.manifest
-            w_try rm -rf "$W_WINDIR_UNIX"/winsxs/manifests/x86_microsoft.vc90.mfcloc_1fc8b3b9a1e18e3b_9.0.30729.6161_none_deadbeef.manifest
-            w_try rm -rf "$W_WINDIR_UNIX"/winsxs/manifests/x86_microsoft.vc90.openmp_1fc8b3b9a1e18e3b_9.0.30729.6161_none_deadbeef.manifest
+            w_try rm -rf "${W_WINDIR_UNIX}"/winsxs/manifests/x86_microsoft.vc90.mfc_1fc8b3b9a1e18e3b_9.0.30729.6161_none_deadbeef.manifest
+            w_try rm -rf "${W_WINDIR_UNIX}"/winsxs/manifests/x86_microsoft.vc90.mfcloc_1fc8b3b9a1e18e3b_9.0.30729.6161_none_deadbeef.manifest
+            w_try rm -rf "${W_WINDIR_UNIX}"/winsxs/manifests/x86_microsoft.vc90.openmp_1fc8b3b9a1e18e3b_9.0.30729.6161_none_deadbeef.manifest
             ;;
     esac
 
-    if [ "$_W_mode" = default ] ; then
+    if [ "${_W_mode}" = default ] ; then
         # To delete a registry key, give an unquoted dash as value
-        echo "\"*$module\"=-" >> "$W_TMP"/override-dll.reg
+        echo "\"*${module}\"=-" >> "${W_TMP}"/override-dll.reg
     else
         # Note: if you want to override even DLLs loaded with an absolute
         # path, you need to add an asterisk:
-        echo "\"*$module\"=\"$_W_mode\"" >> "$W_TMP"/override-dll.reg
+        echo "\"*${module}\"=\"${_W_mode}\"" >> "${W_TMP}"/override-dll.reg
     fi
 }
 
@@ -2054,9 +2054,9 @@ w_override_dlls()
     w_skip_windows w_override_dlls && return
 
     _W_mode=$1
-    case $_W_mode in
+    case ${_W_mode} in
         *=*)
-            w_die "w_override_dlls: unknown mode $_W_mode.
+            w_die "w_override_dlls: unknown mode ${_W_mode}.
 Usage: 'w_override_dlls mode[,mode] dll ...'." ;;
         disabled)
             _W_mode="" ;;
@@ -2064,18 +2064,18 @@ Usage: 'w_override_dlls mode[,mode] dll ...'." ;;
 
     shift
 
-    echo "Using $_W_mode override for following DLLs: $*"
-    cat > "$W_TMP"/override-dll.reg <<_EOF_
+    echo "Using ${_W_mode} override for following DLLs: $*"
+    cat > "${W_TMP}"/override-dll.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\DllOverrides]
 _EOF_
     while test "$1" != ""; do
-        w_common_override_dll "$_W_mode" "$1"
+        w_common_override_dll "${_W_mode}" "$1"
         shift
     done
 
-    w_try_regedit "$W_TMP_WIN"\\override-dll.reg
+    w_try_regedit "${W_TMP_WIN}"\\override-dll.reg
 
     unset _W_mode
 }
@@ -2475,30 +2475,30 @@ w_override_app_dlls()
     shift
 
     # Fixme: handle comma-separated list of modes
-    case $_W_mode in
+    case ${_W_mode} in
         b|builtin) _W_mode=builtin ;;
         n|native) _W_mode=native ;;
         default) _W_mode=default ;;
         d|disabled) _W_mode="" ;;
         *)
-        w_die "w_override_app_dlls: unknown mode $_W_mode.  (want native, builtin, default, or disabled)
+        w_die "w_override_app_dlls: unknown mode ${_W_mode}.  (want native, builtin, default, or disabled)
 Usage: 'w_override_app_dlls app mode dll ...'." ;;
     esac
 
-    echo "Using $_W_mode override for following DLLs when running $_W_app: $*"
+    echo "Using ${_W_mode} override for following DLLs when running ${_W_app}: $*"
     (
         echo REGEDIT4
         echo ""
-        echo "[HKEY_CURRENT_USER\\Software\\Wine\\AppDefaults\\$_W_app\\DllOverrides]"
-    ) > "$W_TMP"/override-dll.reg
+        echo "[HKEY_CURRENT_USER\\Software\\Wine\\AppDefaults\\${_W_app}\\DllOverrides]"
+    ) > "${W_TMP}"/override-dll.reg
 
     while test "$1" != ""; do
-        w_common_override_dll "$_W_mode" "$1"
+        w_common_override_dll "${_W_mode}" "$1"
         shift
     done
 
-    w_try_regedit "$W_TMP_WIN"\\override-dll.reg
-    w_try rm "$W_TMP"/override-dll.reg
+    w_try_regedit "${W_TMP_WIN}"\\override-dll.reg
+    w_try rm "${W_TMP}"/override-dll.reg
     unset _W_app _W_mode
 }
 
@@ -2511,7 +2511,7 @@ w_set_winver()
 
     if w_wine_version_in ,5.7 ; then
         # Make sure we pass the right version name:
-        case "$_W_winver" in
+        case "${_W_winver}" in
             # These are the mismatched ones:
             # winecfg doesn't accept 'default' as an option (as of wine-5.9):
             # https://bugs.winehq.org/show_bug.cgi?id=49241
@@ -2523,7 +2523,7 @@ w_set_winver()
 
             # xp has two entries (winxp/winxp64):
             winxp)
-                if [ "$W_ARCH" = "win64" ]; then
+                if [ "${W_ARCH}" = "win64" ]; then
                     _W_winver="winxp64"
                 else
                     _W_winver="winxp"
@@ -2531,45 +2531,45 @@ w_set_winver()
                 ;;
             # These are the same:
             nt351|nt40|vista|win10|win20|win2k|win30|win31|win7|win8|win81|win95|win98|winme) : ;;
-            *) w_die "Unsupported Windows version $_W_winver";;
+            *) w_die "Unsupported Windows version ${_W_winver}";;
         esac
 
-        w_try "$WINE" winecfg -v "$_W_winver"
+        w_try "${WINE}" winecfg -v "${_W_winver}"
     else
         # FIXME: remove this after wine-7.0 (i.e., after it's been in stable wine for a while):
 
         # First, delete any lingering version info, otherwise it may conflict:
         (
-        "$WINE" reg delete "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion" /v SubVersionNumber /f || true
-        "$WINE" reg delete "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion" /v VersionNumber /f || true
-        "$WINE" reg delete "HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion" /v CSDVersion /f || true
-        "$WINE" reg delete "HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion" /v CurrentBuildNumber /f || true
-        "$WINE" reg delete "HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion" /v CurrentVersion /f || true
-        "$WINE" reg delete "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /f || true
-        "$WINE" reg delete "HKLM\\System\\CurrentControlSet\\Control\\ServiceCurrent" /v OS /f || true
-        "$WINE" reg delete "HKLM\\System\\CurrentControlSet\\Control\\Windows" /v CSDVersion /f || true
-        "$WINE" reg delete "HKCU\\Software\\Wine" /v Version /f || true
-        "$WINE" reg delete "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /f || true
+        "${WINE}" reg delete "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion" /v SubVersionNumber /f || true
+        "${WINE}" reg delete "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion" /v VersionNumber /f || true
+        "${WINE}" reg delete "HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion" /v CSDVersion /f || true
+        "${WINE}" reg delete "HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion" /v CurrentBuildNumber /f || true
+        "${WINE}" reg delete "HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion" /v CurrentVersion /f || true
+        "${WINE}" reg delete "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /f || true
+        "${WINE}" reg delete "HKLM\\System\\CurrentControlSet\\Control\\ServiceCurrent" /v OS /f || true
+        "${WINE}" reg delete "HKLM\\System\\CurrentControlSet\\Control\\Windows" /v CSDVersion /f || true
+        "${WINE}" reg delete "HKCU\\Software\\Wine" /v Version /f || true
+        "${WINE}" reg delete "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /f || true
         ) > /dev/null 2>&1
 
-        case "$_W_winver" in
+        case "${_W_winver}" in
             win31)
-                echo "Setting Windows version to $_W_winver"
-                cat > "$W_TMP"/set-winver.reg <<_EOF_
+                echo "Setting Windows version to ${_W_winver}"
+                cat > "${W_TMP}"/set-winver.reg <<_EOF_
 REGEDIT4
 
 [HKEY_USERS\\S-1-5-4\\Software\\Wine]
 "Version"="win31"
 
 _EOF_
-                w_try_regedit "$W_TMP_WIN"\\set-winver.reg
+                w_try_regedit "${W_TMP_WIN}"\\set-winver.reg
                 return
                 ;;
             win95)
                 # This key is only used for Windows 95/98:
 
-                echo "Setting Windows version to $_W_winver"
-                cat > "$W_TMP"/set-winver.reg <<_EOF_
+                echo "Setting Windows version to ${_W_winver}"
+                cat > "${W_TMP}"/set-winver.reg <<_EOF_
 REGEDIT4
 
 [HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion]
@@ -2578,14 +2578,14 @@ REGEDIT4
 "VersionNumber"="4.0.950"
 
 _EOF_
-                w_try_regedit "$W_TMP_WIN"\\set-winver.reg
+                w_try_regedit "${W_TMP_WIN}"\\set-winver.reg
                 return
                 ;;
             win98)
                 # This key is only used for Windows 95/98:
 
-                echo "Setting Windows version to $_W_winver"
-                cat > "$W_TMP"/set-winver.reg <<_EOF_
+                echo "Setting Windows version to ${_W_winver}"
+                cat > "${W_TMP}"/set-winver.reg <<_EOF_
 REGEDIT4
 
 [HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion]
@@ -2594,14 +2594,14 @@ REGEDIT4
 "VersionNumber"="4.10.2222"
 
 _EOF_
-                w_try_regedit "$W_TMP_WIN"\\set-winver.reg
+                w_try_regedit "${W_TMP_WIN}"\\set-winver.reg
                 return
                 ;;
             nt40)
                 # Similar to modern version, but sets two extra keys:
 
-                echo "Setting Windows version to $_W_winver"
-                cat > "$W_TMP"/set-winver.reg <<_EOF_
+                echo "Setting Windows version to ${_W_winver}"
+                cat > "${W_TMP}"/set-winver.reg <<_EOF_
 REGEDIT4
 
 [HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion]
@@ -2619,7 +2619,7 @@ REGEDIT4
 "CSDVersion"=dword:00000600
 
 _EOF_
-                w_try_regedit "$W_TMP_WIN"\\set-winver.reg
+                w_try_regedit "${W_TMP_WIN}"\\set-winver.reg
                 return
                 ;;
             win2k)
@@ -2631,19 +2631,19 @@ _EOF_
             winxp)
                 # Special case, afaik it's the only Windows version that has different version numbers for 32/64-bit
                 # So ensure we set the arch appropriate version:
-                if [ "$W_ARCH" = "win32" ]; then
+                if [ "${W_ARCH}" = "win32" ]; then
                     csdversion="Service Pack 3"
                     currentbuildnumber="2600"
                     currentversion="5.1"
                     csdversion_hex=dword:00000300
-                elif [ "$W_ARCH" = "win64" ]; then
+                elif [ "${W_ARCH}" = "win64" ]; then
                     csdversion="Service Pack 2"
                     currentbuildnumber="3790"
                     currentversion="5.2"
                     csdversion_hex=dword:00000200
-                    "$WINE" reg add "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /d "WinNT" /f
+                    "${WINE}" reg add "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /d "WinNT" /f
                 else
-                    w_die "Invalid W_ARCH $W_ARCH"
+                    w_die "Invalid W_ARCH ${W_ARCH}"
                 fi
                 ;;
             win2k3)
@@ -2651,76 +2651,76 @@ _EOF_
                 currentbuildnumber="3790"
                 currentversion="5.2"
                 csdversion_hex=dword:00000200
-                "$WINE" reg add "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /d "ServerNT" /f
+                "${WINE}" reg add "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /d "ServerNT" /f
                 ;;
             vista)
                 csdversion="Service Pack 2"
                 currentbuildnumber="6002"
                 currentversion="6.0"
                 csdversion_hex=dword:00000200
-                "$WINE" reg add "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /d "WinNT" /f
+                "${WINE}" reg add "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /d "WinNT" /f
                 ;;
             win7|default)
                 csdversion="Service Pack 1"
                 currentbuildnumber="7601"
                 currentversion="6.1"
                 csdversion_hex=dword:00000100
-                "$WINE" reg add "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /d "WinNT" /f
+                "${WINE}" reg add "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /d "WinNT" /f
                 ;;
             win2k8)
                 csdversion="Service Pack 2"
                 currentbuildnumber="6002"
                 currentversion="6.0"
                 csdversion_hex=dword:00000200
-                "$WINE" reg add "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /d "ServerNT" /f
+                "${WINE}" reg add "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /d "ServerNT" /f
                 ;;
             win2k8r2)
                 csdversion="Service Pack 1"
                 currentbuildnumber="7601"
                 currentversion="6.1"
                 csdversion_hex=dword:00000100
-                "$WINE" reg add "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /d "ServerNT" /f
+                "${WINE}" reg add "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /d "ServerNT" /f
                 ;;
             win8)
                 csdversion=""
                 currentbuildnumber="9200"
                 currentversion="6.2"
                 csdversion_hex=dword:00000000
-                "$WINE" reg add "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /d "WinNT" /f
+                "${WINE}" reg add "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /d "WinNT" /f
                 ;;
             win81)
                 csdversion=""
                 currentbuildnumber="9600"
                 currentversion="6.3"
                 csdversion_hex=dword:00000000
-                "$WINE" reg add "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /d "WinNT" /f
+                "${WINE}" reg add "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /d "WinNT" /f
                 ;;
             win10)
                 csdversion=""
                 currentbuildnumber="10240"
                 currentversion="10.0"
                 csdversion_hex=dword:00000000
-                "$WINE" reg add "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /d "WinNT" /f
+                "${WINE}" reg add "HKLM\\System\\CurrentControlSet\\Control\\ProductOptions" /v ProductType /d "WinNT" /f
                 ;;
             *)
                 w_die "Invalid Windows version given."
                 ;;
         esac
 
-        echo "Setting Windows version to $_W_winver"
-        cat > "$W_TMP"/set-winver.reg <<_EOF_
+        echo "Setting Windows version to ${_W_winver}"
+        cat > "${W_TMP}"/set-winver.reg <<_EOF_
 REGEDIT4
 
 [HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion]
-"CSDVersion"="$csdversion"
-"CurrentBuildNumber"="$currentbuildnumber"
-"CurrentVersion"="$currentversion"
+"CSDVersion"="${csdversion}"
+"CurrentBuildNumber"="${currentbuildnumber}"
+"CurrentVersion"="${currentversion}"
 
 [HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\Windows]
-"CSDVersion"=$csdversion_hex
+"CSDVersion"=${csdversion_hex}
 
 _EOF_
-        w_try_regedit "$W_TMP_WIN"\\set-winver.reg
+        w_try_regedit "${W_TMP_WIN}"\\set-winver.reg
         fi # if w_wine_version_in ,5.7
 
     # Prevent a race when calling from another verb
@@ -2740,16 +2740,16 @@ w_set_app_winver()
 
     _W_app="$1"
     _W_version="$2"
-    echo "Setting $_W_app to $_W_version mode"
+    echo "Setting ${_W_app} to ${_W_version} mode"
     (
     echo REGEDIT4
     echo ""
-    echo "[HKEY_CURRENT_USER\\Software\\Wine\\AppDefaults\\$_W_app]"
-    echo "\"Version\"=\"$_W_version\""
-    ) > "$W_TMP"/set-winver.reg
+    echo "[HKEY_CURRENT_USER\\Software\\Wine\\AppDefaults\\${_W_app}]"
+    echo "\"Version\"=\"${_W_version}\""
+    ) > "${W_TMP}"/set-winver.reg
 
-    w_try_regedit "$W_TMP_WIN"\\set-winver.reg
-    rm "$W_TMP"/set-winver.reg
+    w_try_regedit "${W_TMP_WIN}"\\set-winver.reg
+    rm "${W_TMP}"/set-winver.reg
     unset _W_app
 }
 
@@ -2766,7 +2766,7 @@ w_compare_wine_version()
     known_wine_val1="$2"
     known_wine_val2="$3"
 
-    case "$comparison" in
+    case "${comparison}" in
         # expected value if the comparison is true
         -bn) _expected_pos_current_wine="2";;
         -ge) _expected_pos_current_wine="2";;
@@ -2780,12 +2780,12 @@ w_compare_wine_version()
     esac
 
     _pos_current_wine="$(printf "%s\\n%s\\n%s" "${known_wine_val1}" "${_wine_version_stripped}" "${known_wine_val2}" | sort -t. -k 1,1n -k 2,2n -k 3,3n | grep -n "^${_wine_version_stripped}\$" | cut -d : -f1)"
-    if [ "$_pos_current_wine" = "$_expected_pos_current_wine" ] ; then
-        #echo "true: known_wine_version=$2, comparison=$1, stripped wine=$_wine_version_stripped, expected_pos=$_expected_pos_known, pos_known=$_pos_known_wine"
+    if [ "${_pos_current_wine}" = "${_expected_pos_current_wine}" ] ; then
+        #echo "true: known_wine_version=$2, comparison=$1, stripped wine=${_wine_version_stripped}, expected_pos=$_expected_pos_known, pos_known=$_pos_known_wine"
         #echo "Wine version comparison is true"
         return "${FALSE}"
     else
-        #echo "false: known_wine_version=$2, comparison=$1, stripped wine=$_wine_version_stripped, expected_pos=$_expected_pos_known, pos_known=$_pos_known_wine"
+        #echo "false: known_wine_version=$2, comparison=$1, stripped wine=${_wine_version_stripped}, expected_pos=$_expected_pos_known, pos_known=$_pos_known_wine"
         #echo "Wine version comparison is false"
         return "${TRUE}"
     fi
@@ -2800,13 +2800,13 @@ w_compare_wine_version()
 w_wine_version_in()
 {
     for _W_range; do
-        _W_val1=$(echo "$_W_range" | sed 's/,.*//')
-        _W_val2=$(echo "$_W_range" | sed 's/.*,//')
+        _W_val1=$(echo "${_W_range}" | sed 's/,.*//')
+        _W_val2=$(echo "${_W_range}" | sed 's/.*,//')
         # If in this range, return true
-        case $_W_range in
-            ,*) w_compare_wine_version -le "$_W_val2"            && unset _W_range _W_val1 _W_val2 && return "${TRUE}";;
-            *,) w_compare_wine_version -ge "$_W_val1"            && unset _W_range _W_val1 _W_val2 && return "${TRUE}";;
-            *)  w_compare_wine_version -bn "$_W_val1" "$_W_val2" && unset _W_range _W_val1 _W_val2 && return "${TRUE}";;
+        case ${_W_range} in
+            ,*) w_compare_wine_version -le "${_W_val2}"            && unset _W_range _W_val1 _W_val2 && return "${TRUE}";;
+            *,) w_compare_wine_version -ge "${_W_val1}"            && unset _W_range _W_val1 _W_val2 && return "${TRUE}";;
+            *)  w_compare_wine_version -bn "${_W_val1}" "${_W_val2}" && unset _W_range _W_val1 _W_val2 && return "${TRUE}";;
         esac
     done
     unset _W_range _W_val1 _W_val2
@@ -2819,7 +2819,7 @@ w_wine_version_in()
 # the environment variable WINETRICKS_BLACKLIST to disable it.
 w_workaround_wine_bug()
 {
-    if test "$WINE" = ""; then
+    if test "${WINE}" = ""; then
         echo "No need to work around wine bug $1 on Windows"
         return "${FALSE}"
     fi
@@ -2836,21 +2836,21 @@ w_workaround_wine_bug()
     fi
 
     case "$1" in
-        "$WINETRICKS_BLACKLIST")
+        "${WINETRICKS_BLACKLIST}")
             echo "Wine bug $1 workaround blacklisted, skipping"
             return "${FALSE}"
             ;;
     esac
 
-    case $LANG in
-        da*) w_warn "Arbejder uden om wine-fejl ${1} $_W_msg" ;;
-        de*) w_warn "Wine-Fehler ${1} wird umgegangen $_W_msg" ;;
-        pl*) w_warn "Obchodzenie błędu w wine ${1} $_W_msg" ;;
-        ru*) w_warn "Обход ошибки ${1} $_W_msg" ;;
-        uk*) w_warn "Обхід помилки ${1} $_W_msg" ;;
-        zh_CN*)   w_warn "绕过 wine bug ${1} $_W_msg" ;;
-        zh_TW*|zh_HK*)   w_warn "繞過 wine bug ${1} $_W_msg" ;;
-        *)   w_warn "Working around wine bug ${1} $_W_msg" ;;
+    case ${LANG} in
+        da*) w_warn "Arbejder uden om wine-fejl ${1} ${_W_msg}" ;;
+        de*) w_warn "Wine-Fehler ${1} wird umgegangen ${_W_msg}" ;;
+        pl*) w_warn "Obchodzenie błędu w wine ${1} ${_W_msg}" ;;
+        ru*) w_warn "Обход ошибки ${1} ${_W_msg}" ;;
+        uk*) w_warn "Обхід помилки ${1} ${_W_msg}" ;;
+        zh_CN*)   w_warn "绕过 wine bug ${1} ${_W_msg}" ;;
+        zh_TW*|zh_HK*)   w_warn "繞過 wine bug ${1} ${_W_msg}" ;;
+        *)   w_warn "Working around wine bug ${1} ${_W_msg}" ;;
     esac
 
     winetricks_stats_log_command "w_workaround_wine_bug-$1"
@@ -2868,13 +2868,13 @@ w_workaround_wine_bug()
 
 w_metadata()
 {
-    case $WINETRICKS_OPT_VERBOSE in
+    case ${WINETRICKS_OPT_VERBOSE} in
         2) set -x ;;
         *) set +x ;;
     esac
 
     # shellcheck disable=SC2154
-    if test "$installed_exe1" || test "$installed_file1" || test "$publisher" || test "$year"; then
+    if test "${installed_exe1}" || test "${installed_file1}" || test "${publisher}" || test "${year}"; then
         w_die "bug: stray metadata tags set: somebody forgot a backslash in a w_metadata somewhere.  Run with sh -x to see where."
     fi
     if winetricks_metadata_exists "$1"; then
@@ -2883,32 +2883,32 @@ w_metadata()
 
     _W_md_cmd="$1"
     _W_category="$2"
-    file="$WINETRICKS_METADATA/$_W_category/$1.vars"
+    file="${WINETRICKS_METADATA}/${_W_category}/$1.vars"
     shift
     shift
     # Echo arguments to file, with double quotes around the values.
     # Used to use Perl here, but that was too slow on Cygwin.
     for arg; do
         # If _W_wine_not_needed is set, we're a list command that isn't list-installed, and can ignore the installed_* errors:
-        case "$arg" in
+        case "${arg}" in
             installed_exe1=/*)
-                if [ -n "$_W_wine_not_needed" ]; then
+                if [ -n "${_W_wine_not_needed}" ]; then
                     # "_W_wine_not_needed set, no installed_exe1"
                     :
                 else
-                    w_die "bug: w_metadata $_W_md_cmd has a unix path for installed_exe1, should be a windows path"
+                    w_die "bug: w_metadata ${_W_md_cmd} has a unix path for installed_exe1, should be a windows path"
                 fi
                 ;;
             installed_file1=/*)
-                if [ -n "$_W_wine_not_needed" ]; then
+                if [ -n "${_W_wine_not_needed}" ]; then
                     # "_W_wine_not_needed set, no installed_file1"
                     :
                 else
-                    w_die "bug: w_metadata $_W_md_cmd has a unix path for installed_file1, should be a windows path"
+                    w_die "bug: w_metadata ${_W_md_cmd} has a unix path for installed_file1, should be a windows path"
                 fi
                 ;;
             media=download_manual)
-                w_die "bug: verb $_W_md_cmd has media=download_manual, should be manual_download";;
+                w_die "bug: verb ${_W_md_cmd} has media=download_manual, should be manual_download";;
         esac
         # Use longest match when stripping value,
         # and shortest match when stripping name,
@@ -2917,26 +2917,26 @@ w_metadata()
         # installed_file1 fairly often.  Fortunately, we can use forward
         # slashes in that variable instead of backslashes.
         echo "${arg%%=*}"=\""${arg#*=}"\"
-    done > "$file"
-    echo category='"'"$_W_category"'"' >> "$file"
+    done > "${file}"
+    echo category='"'"${_W_category}"'"' >> "${file}"
     # If the problem described above happens, you'd see errors like this:
     # /tmp/w.dank.4650/metadata/dlls/comctl32.vars: 6: Syntax error: Unterminated quoted string
     # so check for lines that aren't properly quoted.
 
     # Do sanity check unless running on Cygwin, where it's way too slow.
-    case "$W_PLATFORM" in
+    case "${W_PLATFORM}" in
         windows_cmd)
             ;;
         *)
-            if grep '[^"]$' "$file"; then
-                w_die "bug: w_metadata $_W_md_cmd corrupt, might need forward slashes?"
+            if grep '[^"]$' "${file}"; then
+                w_die "bug: w_metadata ${_W_md_cmd} corrupt, might need forward slashes?"
             fi
             ;;
     esac
     unset _W_md_cmd
 
     # Restore verbosity:
-    case $WINETRICKS_OPT_VERBOSE in
+    case ${WINETRICKS_OPT_VERBOSE} in
         1|2) set -x ;;
         *) set +x ;;
     esac
@@ -2956,9 +2956,9 @@ w_conflicts()
     verb="$1"
     conflicting_verbs="$2"
 
-    for x in $conflicting_verbs; do
-        if grep -qw "$x" "$WINEPREFIX/winetricks.log" 2>/dev/null; then
-            w_die "error: $verb conflicts with $x, which is already installed. You can run \`$0 --force $verb\` to ignore this check and attempt installation."
+    for x in ${conflicting_verbs}; do
+        if grep -qw "${x}" "${WINEPREFIX}/winetricks.log" 2>/dev/null; then
+            w_die "error: ${verb} conflicts with ${x}, which is already installed. You can run \`$0 --force ${verb}\` to ignore this check and attempt installation."
         fi
     done
 }
@@ -2972,12 +2972,12 @@ w_do_call()
 {
     (
         # Hack..
-        if test "$cmd" = vd; then
-            load_vd "$arg"
+        if test "${cmd}" = vd; then
+            load_vd "${arg}"
             _W_status=$?
-            test "$W_OPT_NOCLEAN" = 1 || rm -rf "$W_TMP"
-            mkdir -p "$W_TMP"
-            return $_W_status
+            test "${W_OPT_NOCLEAN}" = 1 || rm -rf "${W_TMP}"
+            mkdir -p "${W_TMP}"
+            return ${_W_status}
         fi
 
         case "$1" in
@@ -2989,99 +2989,99 @@ w_do_call()
         # but use temp in Unix path because that's what Wine creates, and having both temp and Temp
         # causes confusion (e.g. makes vc2005trial fail)
         # FIXME: W_TMP is also set in winetricks_set_wineprefix, can we avoid the duplication?
-        W_TMP="$W_DRIVE_C/windows/temp/_$1"
+        W_TMP="${W_DRIVE_C}/windows/temp/_$1"
         W_TMP_WIN="C:\\windows\\Temp\\_$1"
-        test "$W_OPT_NOCLEAN" = 1 || rm -rf "$W_TMP"
-        mkdir -p "$W_TMP"
+        test "${W_OPT_NOCLEAN}" = 1 || rm -rf "${W_TMP}"
+        mkdir -p "${W_TMP}"
 
         # Unset all known used metadata values, in case this is a nested call
         unset conflicts installed_file1 installed_exe1
 
         if winetricks_metadata_exists "$1"; then
             # shellcheck disable=SC1090
-            . "$WINETRICKS_METADATA"/*/"${1}.vars"
-        elif winetricks_metadata_exists "$cmd"; then
+            . "${WINETRICKS_METADATA}"/*/"${1}.vars"
+        elif winetricks_metadata_exists "${cmd}"; then
             # shellcheck disable=SC1090
-            . "$WINETRICKS_METADATA"/*/"${cmd}.vars"
-        elif test "$cmd" = native || test "$cmd" = disabled || test "$cmd" = builtin || test "$cmd" = default; then
+            . "${WINETRICKS_METADATA}"/*/"${cmd}.vars"
+        elif test "${cmd}" = native || test "${cmd}" = disabled || test "${cmd}" = builtin || test "${cmd}" = default; then
             # ugly special case - can't have metadata for these verbs until we allow arbitrary parameters
-            w_override_dlls "$cmd" "$arg"
+            w_override_dlls "${cmd}" "${arg}"
             _W_status=$?
-            test "$W_OPT_NOCLEAN" = 1 || rm -rf "$W_TMP"
-            mkdir -p "$W_TMP"
-            return $_W_status
+            test "${W_OPT_NOCLEAN}" = 1 || rm -rf "${W_TMP}"
+            mkdir -p "${W_TMP}"
+            return ${_W_status}
         else
             w_die "No such verb $1"
         fi
 
         # If needed, set the app's wineprefix
-        case "$W_PLATFORM" in
+        case "${W_PLATFORM}" in
             windows_cmd|wine_cmd) ;;
             *)
                 case "${_W_category}-${WINETRICKS_OPT_SHAREDPREFIX}" in
-                    apps-0|benchmarks-0|games-0) winetricks_set_wineprefix "$cmd";;
-                    *) winetricks_set_wineprefix "$_W_prefix_name";;
+                    apps-0|benchmarks-0|games-0) winetricks_set_wineprefix "${cmd}";;
+                    *) winetricks_set_wineprefix "${_W_prefix_name}";;
                 esac
                 # If it's a new wineprefix, give it metadata
-                if test ! -f "$WINEPREFIX"/wrapper.cfg; then
-                    echo ww_name=\""$title"\" > "$WINEPREFIX"/wrapper.cfg
+                if test ! -f "${WINEPREFIX}"/wrapper.cfg; then
+                    echo ww_name=\""${title}"\" > "${WINEPREFIX}"/wrapper.cfg
                 fi
             ;;
         esac
 
-        test "$W_OPT_NOCLEAN" = 1 || rm -rf "$W_TMP"
-        mkdir -p "$W_TMP"
+        test "${W_OPT_NOCLEAN}" = 1 || rm -rf "${W_TMP}"
+        mkdir -p "${W_TMP}"
 
         # Don't install if a conflicting verb is already installed:
         # shellcheck disable=SC2154
-        if test "$WINETRICKS_FORCE" != 1 && test "$conflicts" && test -f "$WINEPREFIX/winetricks.log"; then
-            for x in $conflicts; do
-                w_conflicts "$1" "$x"
+        if test "${WINETRICKS_FORCE}" != 1 && test "${conflicts}" && test -f "${WINEPREFIX}/winetricks.log"; then
+            for x in ${conflicts}; do
+                w_conflicts "$1" "${x}"
             done
         fi
 
         # Allow verifying a verb separately from installing it
-        if test "$WINETRICKS_VERIFY" = 1 && winetricks_is_installed "$1" && test -z "$WINETRICKS_FORCE"; then
+        if test "${WINETRICKS_VERIFY}" = 1 && winetricks_is_installed "$1" && test -z "${WINETRICKS_FORCE}"; then
             echo "$1 is already installed. --force wasn't given, --verify was, so re-verifying."
             winetricks_verify
             return "${TRUE}"
         fi
 
         # Don't install if already installed
-        if test "$WINETRICKS_FORCE" != 1 && winetricks_is_installed "$1"; then
+        if test "${WINETRICKS_FORCE}" != 1 && winetricks_is_installed "$1"; then
             echo "$1 already installed, skipping"
             return "${TRUE}"
         fi
 
         # We'd like to get rid of W_PACKAGE, but for now, just set it as late as possible.
         W_PACKAGE=$1
-        w_try "load_$cmd" "$arg"
+        w_try "load_${cmd}" "${arg}"
         winetricks_stats_log_command "$@"
 
         # User-specific postinstall hook.
         # Source it so the script can call w_download() if needed.
-        postfile="$WINETRICKS_POST/$1/$1-postinstall.sh"
-        if test -f "$postfile"; then
-            chmod +x "$postfile"
+        postfile="${WINETRICKS_POST}/$1/$1-postinstall.sh"
+        if test -f "${postfile}"; then
+            chmod +x "${postfile}"
             # shellcheck disable=SC1090
-            . "$postfile"
+            . "${postfile}"
         fi
 
         # Verify install
-        if test "$installed_exe1" || test "$installed_file1"; then
+        if test "${installed_exe1}" || test "${installed_file1}"; then
             if ! winetricks_is_installed "$1"; then
-                w_die "$1 install completed, but installed file $_W_file_unix not found"
+                w_die "$1 install completed, but installed file ${_W_file_unix} not found"
             fi
         fi
 
         # If the user specified --verify, also run GUI tests:
-        if test "$WINETRICKS_VERIFY" = 1; then
+        if test "${WINETRICKS_VERIFY}" = 1; then
             winetricks_verify
         fi
 
         # Clean up after this verb
-        test "$W_OPT_NOCLEAN" = 1 || rm -rf "$W_TMP"
-        mkdir -p "$W_TMP"
+        test "${W_OPT_NOCLEAN}" = 1 || rm -rf "${W_TMP}"
+        mkdir -p "${W_TMP}"
 
         # Reset whether use of user mount tool
         unset W_USE_USERMOUNT
@@ -3100,9 +3100,9 @@ w_backup_reg_file()
 {
     W_reg_file=$1
 
-    w_get_sha256sum "$W_reg_file"
+    w_get_sha256sum "${W_reg_file}"
 
-    w_try cp "$W_reg_file" "$W_TMP_EARLY/_reg_$(echo "$_W_gotsha256sum" | cut -c1-8)"_$$.reg
+    w_try cp "${W_reg_file}" "${W_TMP_EARLY}/_reg_$(echo "${_W_gotsha256sum}" | cut -c1-8)"_$$.reg
 
     unset W_reg_file _W_gotsha256sum
 }
@@ -3113,30 +3113,30 @@ w_register_font()
     shift
     W_font=$1
 
-    case $(echo "$W_file" | tr "[:upper:]" "[:lower:]") in
-        *.ttf|*.ttc) W_font="$W_font (TrueType)";;
+    case $(echo "${W_file}" | tr "[:upper:]" "[:lower:]") in
+        *.ttf|*.ttc) W_font="${W_font} (TrueType)";;
     esac
 
     # Kludge: use _r to avoid \r expansion in w_try
-    cat > "$W_TMP"/_register-font.reg <<_EOF_
+    cat > "${W_TMP}"/_register-font.reg <<_EOF_
 REGEDIT4
 
 [HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Fonts]
-"$W_font"="$W_file"
+"${W_font}"="${W_file}"
 _EOF_
     # too verbose
-    w_try_regedit "$W_TMP_WIN"\\_register-font.reg
-    w_backup_reg_file "$W_TMP"/_register-font.reg
+    w_try_regedit "${W_TMP_WIN}"\\_register-font.reg
+    w_backup_reg_file "${W_TMP}"/_register-font.reg
 
     # Wine also updates the win9x fonts key, so let's do that, too
-    cat > "$W_TMP"/_register-font.reg <<_EOF_
+    cat > "${W_TMP}"/_register-font.reg <<_EOF_
 REGEDIT4
 
 [HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Fonts]
-"$W_font"="$W_file"
+"${W_font}"="${W_file}"
 _EOF_
-    w_try_regedit "$W_TMP_WIN"\\_register-font.reg
-    w_backup_reg_file "$W_TMP"/_register-font.reg
+    w_try_regedit "${W_TMP_WIN}"\\_register-font.reg
+    w_backup_reg_file "${W_TMP}"/_register-font.reg
 
     unset W_file W_font
 }
@@ -3148,17 +3148,17 @@ w_register_font_replacement()
     shift
     _W_font=$1
     # UTF-16 BOM (U+FEFF, "0xEF 0xBB 0xBF" in UTF-8)
-    printf "\357\273\277" | iconv -f UTF-8 -t UTF-16LE > "$W_TMP"/_register-font-replacements.reg
+    printf "\357\273\277" | iconv -f UTF-8 -t UTF-16LE > "${W_TMP}"/_register-font-replacements.reg
     # Kludge: use _r to avoid \r expansion in w_try
-    iconv -f UTF-8 -t UTF-16LE >> "$W_TMP"/_register-font-replacements.reg <<_EOF_
+    iconv -f UTF-8 -t UTF-16LE >> "${W_TMP}"/_register-font-replacements.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\Fonts\\Replacements]
-"$_W_alias"="$_W_font"
+"${_W_alias}"="${_W_font}"
 _EOF_
-    w_try_regedit "$W_TMP_WIN"\\_register-font-replacements.reg
+    w_try_regedit "${W_TMP_WIN}"\\_register-font-replacements.reg
 
-    w_backup_reg_file "$W_TMP"/_register-font-replacements.reg
+    w_backup_reg_file "${W_TMP}"/_register-font-replacements.reg
 
     unset _W_alias _W_font
 }
@@ -3172,15 +3172,15 @@ w_append_path()
     _W_WIN_PATH="$(w_expand_env PATH | sed 's,\\,\\\\,g')"
 
     # FIXME: OS X? https://github.com/Winetricks/winetricks/issues/697
-    sed 's/$/\r/' > "$W_TMP"/path.reg <<_EOF_
+    sed 's/$/\r/' > "${W_TMP}"/path.reg <<_EOF_
 REGEDIT4
 
 [HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\Session Manager\\Environment]
-"PATH"="$_W_NEW_PATH;$_W_WIN_PATH"
+"PATH"="${_W_NEW_PATH};${_W_WIN_PATH}"
 _EOF_
 
-    w_try_regedit "$W_TMP_WIN"\\path.reg
-    rm -f "$W_TMP"/path.reg
+    w_try_regedit "${W_TMP_WIN}"\\path.reg
+    rm -f "${W_TMP}"/path.reg
     unset _W_NEW_PATH _W_WIN_PATH
 }
 
@@ -3214,7 +3214,7 @@ winetricks_download_setup()
     # Connection timeout time (in seconds):
     WINETRICKS_DOWNLOADER_TIMEOUT=${WINETRICKS_DOWNLOADER_TIMEOUT:-15}
 
-    case "$WINETRICKS_OPT_TORIFY" in
+    case "${WINETRICKS_OPT_TORIFY}" in
         1) torify=torify
             # torify needs --async-dns=false, see https://github.com/tatsuhiro-t/aria2/issues/613
             aria2c_torify_opts="--async-dns=false"
@@ -3235,11 +3235,11 @@ winetricks_dl_url_to_stdout()
     # FIXME: add a w_try_quiet() wrapper around w_try() that doesn't print the
     # Executing ... stuff, but still does error checking
     if [ "${WINETRICKS_DOWNLOADER}" = "wget" ] ; then
-        $torify wget -q -O - --timeout "${WINETRICKS_DOWNLOADER_TIMEOUT}" \
-            --tries "$WINETRICKS_DOWNLOADER_RETRIES" "$1"
+        ${torify} wget -q -O - --timeout "${WINETRICKS_DOWNLOADER_TIMEOUT}" \
+            --tries "${WINETRICKS_DOWNLOADER_RETRIES}" "$1"
     elif [ "${WINETRICKS_DOWNLOADER}" = "curl" ] ; then
-        $torify curl -s --connect-timeout "${WINETRICKS_DOWNLOADER_TIMEOUT}" \
-               --retry "$WINETRICKS_DOWNLOADER_RETRIES" "$1"
+        ${torify} curl -s --connect-timeout "${WINETRICKS_DOWNLOADER_TIMEOUT}" \
+               --retry "${WINETRICKS_DOWNLOADER_RETRIES}" "$1"
     elif [ "${WINETRICKS_DOWNLOADER}" = "aria2c" ] ; then
         # aria2c doesn't have support downloading to stdout:
         # https://github.com/aria2/aria2/issues/190
@@ -3249,8 +3249,8 @@ winetricks_dl_url_to_stdout()
         if [ -e "${stdout_tmpfile}" ] ; then
             rm "${stdout_tmpfile}"
         fi
-                $torify aria2c \
-                ${aria2c_torify_opts:+"$aria2c_torify_opts"} \
+                ${torify} aria2c \
+                ${aria2c_torify_opts:+"${aria2c_torify_opts}"} \
                 --continue \
                 --daemon=false \
                 --dir="${W_TMP_EARLY}" \
@@ -3261,38 +3261,38 @@ winetricks_dl_url_to_stdout()
                 --save-session='' \
                 --stream-piece-selector=geom \
                 --connect-timeout="${WINETRICKS_DOWNLOADER_TIMEOUT}" \
-                --max-tries="$WINETRICKS_DOWNLOADER_RETRIES" \
+                --max-tries="${WINETRICKS_DOWNLOADER_RETRIES}" \
                 "$1" > /dev/null
         cat "${stdout_tmpfile}"
         rm "${stdout_tmpfile}"
     elif [ "${WINETRICKS_DOWNLOADER}" = "fetch" ] ; then
         # fetch does not support retry count
-        $torify fetch -o - -T "${WINETRICKS_DOWNLOADER_TIMEOUT}" "$1" 2>/dev/null
+        ${torify} fetch -o - -T "${WINETRICKS_DOWNLOADER_TIMEOUT}" "$1" 2>/dev/null
     else
         w_die "Please install aria2c, curl, or wget"
     fi
 }
 
 winetricks_dl_warning() {
-    case $LANG in
+    case ${LANG} in
         ru*) _W_countrymsg="Скрипт определил, что ваш IP-адрес принадлежит России. Если во время загрузки файлов вы увидите ошибки несоответствия сертификата, перезапустите скрипт с опцией '--torify' или скачайте файлы вручную, например, используя VPN." ;;
         pl*) _W_countrymsg="Wykryto, że twój adres IP należy do Rosji. W wypadku problemów z pobieraniem, uruchom z parametrem '--torify' lub pobierz plik manualnie, np. z użyciem VPN." ;;
         *)  _W_countrymsg="Your IP address has been determined to belong to Russia. If you encounter a certificate error while downloading, please relaunch with the '--torify' option, or download files manually, for instance using VPN." ;;
     esac
 
     # Lookup own country via IP address only once (i.e. don't run this function for every download invocation)
-    if [ -z "$W_COUNTRY" ] ; then
+    if [ -z "${W_COUNTRY}" ] ; then
         W_COUNTRY="$(winetricks_dl_url_to_stdout "https://ipinfo.io/$(winetricks_dl_url_to_stdout "https://ipinfo.io/ip")" | awk -F '"' '/country/{print $4}')"
         export W_COUNTRY
 
-        if [ -z "$W_COUNTRY" ] ; then
+        if [ -z "${W_COUNTRY}" ] ; then
             export W_COUNTRY="unknown"
         fi
     fi
 
     # TODO: Resolve a full country name via https://github.com/umpirsky/country-list/tree/master/data
-    case "$W_COUNTRY" in
-        "RU") w_warn "$_W_countrymsg" ;;
+    case "${W_COUNTRY}" in
+        "RU") w_warn "${_W_countrymsg}" ;;
         *) : ;;
     esac
 }
@@ -3330,19 +3330,19 @@ winetricks_get_platform()
 
 winetricks_latest_version_check()
 {
-    if [ "$WINETRICKS_LATEST_VERSION_CHECK" = 'disabled' ] || [ -f "${WINETRICKS_CONFIG}/disable-latest-version-check" ] ; then
+    if [ "${WINETRICKS_LATEST_VERSION_CHECK}" = 'disabled' ] || [ -f "${WINETRICKS_CONFIG}/disable-latest-version-check" ] ; then
         w_info "winetricks latest version check update disabled"
         return
-    # Used by ./src/release.sh, not for end users. Silently disables update check, without using $WINETRICKS_SUPER_QUIET
-    elif [ "$WINETRICKS_LATEST_VERSION_CHECK" = 'development' ] ; then
+    # Used by ./src/release.sh, not for end users. Silently disables update check, without using ${WINETRICKS_SUPER_QUIET}
+    elif [ "${WINETRICKS_LATEST_VERSION_CHECK}" = 'development' ] ; then
         return
     fi
 
     latest_version="$(winetricks_dl_url_to_stdout https://raw.githubusercontent.com/Winetricks/winetricks/master/files/LATEST)"
 
-    # Check that $latest_version is an actual number in case github is down
+    # Check that ${latest_version} is an actual number in case github is down
     if ! echo "${latest_version}" | grep -q -E "[0-9]{8}" || [ -z "${latest_version}" ] ; then
-        case $LANG in
+        case ${LANG} in
             pl*) w_warn "GitHub nie działa? Wersja '${latest_version}' nie wydaje się być prawdiłową wersją" ;;
             ru*) w_warn "Отсутствует подключение к Github? версия '${latest_version}' может быть неактуальной" ;;
             zh_CN*) w_warn "Github 提供的下载？${latest_version} 似乎不是个有效的版本号。" ;;
@@ -3354,14 +3354,14 @@ winetricks_latest_version_check()
         return
     fi
 
-    if [ ! "$WINETRICKS_VERSION" = "${latest_version}" ] && [ ! "$WINETRICKS_VERSION" = "${latest_version}-next" ]; then
+    if [ ! "${WINETRICKS_VERSION}" = "${latest_version}" ] && [ ! "${WINETRICKS_VERSION}" = "${latest_version}-next" ]; then
         if [ -f "${WINETRICKS_CONFIG}/enable-auto-update" ] ; then
             w_info "You are running winetricks-${WINETRICKS_VERSION}."
             w_info "New upstream release winetricks-${latest_version} is available."
             w_info "auto-update enabled: running winetricks_selfupdate"
             winetricks_selfupdate
         else
-            case $LANG in
+            case ${LANG} in
                 pl*)
                     w_warn "Korzystasz z winetricks-${WINETRICKS_VERSION}, a najnowszą wersją winetricks-${latest_version}!"
                     w_warn "Zalecana jest aktualizacja z użyciem menedżera pakietów Twojej dystrybucji, --self-update lub ręczna aktualizacja."
@@ -3395,7 +3395,7 @@ winetricks_print_version()
     winetricks_get_sha256sum_prog
 
     w_get_sha256sum "$0"
-    echo "$WINETRICKS_VERSION - sha256sum: $_W_gotsha256sum"
+    echo "${WINETRICKS_VERSION} - sha256sum: ${_W_gotsha256sum}"
 }
 
 # Run a small wine command for internal use
@@ -3411,15 +3411,15 @@ winetricks_early_wine()
     # Gecko (winezeug bug 223).
     # The tr removes carriage returns so expanded variables don't have crud on the end
     # The grep works around using new wineprefixes with old wine
-    WINEDEBUG=-all "$WINE" "$@" 2> "$W_TMP_EARLY"/early_wine.err.txt | ( sed 's/.*1h.=//' | tr -d '\r' | grep -v -e "Module not found" -e "Could not load wine-gecko" || true)
+    WINEDEBUG=-all "${WINE}" "$@" 2> "${W_TMP_EARLY}"/early_wine.err.txt | ( sed 's/.*1h.=//' | tr -d '\r' | grep -v -e "Module not found" -e "Could not load wine-gecko" || true)
 }
 
 # Wrapper around winetricks_early_wine()
-# Same idea, but use $WINE_ARCH, i.e., always use wine64 for 64-bit prefixes
+# Same idea, but use ${WINE_ARCH}, i.e., always use wine64 for 64-bit prefixes
 # Currently only used by w_expand_env()
 winetricks_early_wine_arch()
 {
-    WINE="$WINE_ARCH" winetricks_early_wine "$@"
+    WINE="${WINE_ARCH}" winetricks_early_wine "$@"
 }
 
 winetricks_detect_gui()
@@ -3441,8 +3441,8 @@ winetricks_detect_gui()
     fi
 
     # Print zenity/dialog version info for debugging:
-    if [ -z "$WINETRICKS_SUPER_QUIET" ] ; then
-       echo "winetricks GUI enabled, using $WINETRICKS_GUI $WINETRICKS_GUI_VERSION"
+    if [ -z "${WINETRICKS_SUPER_QUIET}" ] ; then
+       echo "winetricks GUI enabled, using ${WINETRICKS_GUI} ${WINETRICKS_GUI_VERSION}"
     fi
 }
 
@@ -3450,11 +3450,11 @@ winetricks_detect_gui()
 winetricks_detect_sudo()
 {
     WINETRICKS_SUDO=sudo
-    if test "$WINETRICKS_GUI" = "none"; then
+    if test "${WINETRICKS_GUI}" = "none"; then
         return
     fi
 
-    if test x"$DISPLAY" != x""; then
+    if test x"${DISPLAY}" != x""; then
         # This should be the default option because some of GUI sudo programs are unmaintained
         # See https://github.com/Winetricks/winetricks/issues/912
         if test -x "$(command -v pkexec 2>/dev/null)"; then
@@ -3495,7 +3495,7 @@ winetricks_detect_iso_mount()
     elif test -x "$(command -v archivemount 2>/dev/null)"; then
         # File/dir names may be uppercase and we may need
         # case-insensitive operations
-        #   e.g. w_try "$WINE" cmd /c "copy $W_ISO_MOUNT_LETTER:\\DOC.PDF C:\\doc.pdf"
+        #   e.g. w_try "${WINE}" cmd /c "copy ${W_ISO_MOUNT_LETTER}:\\DOC.PDF C:\\doc.pdf"
         # This tool had path issue in 0.8.8 or older versions
         #   e.g. office2013pro works in 0.8.9 or later but doesn't work in 0.8.8
         WINETRICKS_ISO_MOUNT=archivemount
@@ -3515,7 +3515,7 @@ winetricks_get_prefix_var()
 {
     (
         # shellcheck disable=SC1090
-        . "$W_PREFIXES_ROOT/$p/wrapper.cfg"
+        . "${W_PREFIXES_ROOT}/${p}/wrapper.cfg"
 
         # The cryptic sed is there to turn ' into '\''
         # shellcheck disable=SC1117
@@ -3526,7 +3526,7 @@ winetricks_get_prefix_var()
 # Display prefix menu, get which wineprefix the user wants to work with
 winetricks_prefixmenu()
 {
-    case $LANG in
+    case ${LANG} in
         ru*) _W_msg_title="Winetricks - выберите путь wine (wineprefix)"
              _W_msg_body='Что вы хотите сделать?'
              _W_msg_apps='Установить программу'
@@ -3605,85 +3605,85 @@ winetricks_prefixmenu()
              _W_msg_help="View help"
              ;;
     esac
-    case "$W_OPT_UNATTENDED" in
-        1) _W_cmd_unattended=attended; _W_msg_unattended="$_W_msg_unattended0" ;;
-        *) _W_cmd_unattended=unattended; _W_msg_unattended="$_W_msg_unattended1" ;;
+    case "${W_OPT_UNATTENDED}" in
+        1) _W_cmd_unattended=attended; _W_msg_unattended="${_W_msg_unattended0}" ;;
+        *) _W_cmd_unattended=unattended; _W_msg_unattended="${_W_msg_unattended1}" ;;
     esac
 
-    case $WINETRICKS_GUI in
+    case ${WINETRICKS_GUI} in
         zenity)
             printf %s "zenity \
-                --title '$_W_msg_title' \
-                --text '$_W_msg_body' \
+                --title '${_W_msg_title}' \
+                --text '${_W_msg_body}' \
                 --list \
                 --radiolist \
                 --column '' \
                 --column '' \
                 --column '' \
-                --height $WINETRICKS_MENU_HEIGHT \
-                --width $WINETRICKS_MENU_WIDTH \
+                --height ${WINETRICKS_MENU_HEIGHT} \
+                --width ${WINETRICKS_MENU_WIDTH} \
                 --hide-column 2 \
-                FALSE help       '$_W_msg_help' \
-                FALSE apps       '$_W_msg_apps' \
-                FALSE benchmarks '$_W_msg_benchmarks' \
-                FALSE games      '$_W_msg_games' \
-                TRUE  main       '$_W_msg_default' \
-                FALSE mkprefix   '$_W_msg_mkprefix' \
+                FALSE help       '${_W_msg_help}' \
+                FALSE apps       '${_W_msg_apps}' \
+                FALSE benchmarks '${_W_msg_benchmarks}' \
+                FALSE games      '${_W_msg_games}' \
+                TRUE  main       '${_W_msg_default}' \
+                FALSE mkprefix   '${_W_msg_mkprefix}' \
                 " \
-                > "$WINETRICKS_WORKDIR"/zenity.sh
+                > "${WINETRICKS_WORKDIR}"/zenity.sh
 
-            if ls -d "$W_PREFIXES_ROOT"/*/dosdevices > /dev/null 2>&1; then
-                for prefix in "$W_PREFIXES_ROOT"/*/dosdevices; do
+            if ls -d "${W_PREFIXES_ROOT}"/*/dosdevices > /dev/null 2>&1; then
+                for prefix in "${W_PREFIXES_ROOT}"/*/dosdevices; do
                     q="${prefix%%/dosdevices}"
                     p="${q##*/}"
-                    if test -f "$W_PREFIXES_ROOT/$p/wrapper.cfg"; then
-                        _W_msg_name="$p ($(winetricks_get_prefix_var name))"
+                    if test -f "${W_PREFIXES_ROOT}/${p}/wrapper.cfg"; then
+                        _W_msg_name="${p} ($(winetricks_get_prefix_var name))"
                     else
-                        _W_msg_name="$p"
+                        _W_msg_name="${p}"
                     fi
-                case $LANG in
-                    zh_CN*) printf %s " FALSE prefix='$p' '选择管理 $_W_msg_name' " ;;
-                    zh_TW*|zh_HK*) printf %s " FALSE prefix='$p' '選擇管理 $_W_msg_name' " ;;
-                    de*) printf %s " FALSE prefix='$p' '$_W_msg_name auswählen' " ;;
-                    pl*) printf %s " FALSE prefix='$p' 'Wybierz $_W_msg_name' " ;;
-                    *) printf %s " FALSE prefix='$p' 'Select $_W_msg_name' " ;;
+                case ${LANG} in
+                    zh_CN*) printf %s " FALSE prefix='${p}' '选择管理 ${_W_msg_name}' " ;;
+                    zh_TW*|zh_HK*) printf %s " FALSE prefix='${p}' '選擇管理 ${_W_msg_name}' " ;;
+                    de*) printf %s " FALSE prefix='${p}' '${_W_msg_name} auswählen' " ;;
+                    pl*) printf %s " FALSE prefix='${p}' 'Wybierz ${_W_msg_name}' " ;;
+                    *) printf %s " FALSE prefix='${p}' 'Select ${_W_msg_name}' " ;;
                 esac
-                done >> "$WINETRICKS_WORKDIR"/zenity.sh
+                done >> "${WINETRICKS_WORKDIR}"/zenity.sh
             fi
-            printf %s " FALSE $_W_cmd_unattended '$_W_msg_unattended'" >> "$WINETRICKS_WORKDIR"/zenity.sh
+            printf %s " FALSE ${_W_cmd_unattended} '${_W_msg_unattended}'" >> "${WINETRICKS_WORKDIR}"/zenity.sh
 
-            sh "$WINETRICKS_WORKDIR"/zenity.sh | tr '|' ' '
+            sh "${WINETRICKS_WORKDIR}"/zenity.sh | tr '|' ' '
             ;;
 
         kdialog)
             (
             printf %s "kdialog \
                 --geometry 600x400+100+100 \
-                --title '$_W_msg_title' \
+                --title '${_W_msg_title}' \
                 --separate-output \
-                --radiolist '$_W_msg_body' \
-                help       '$_W_msg_help'       off \
-                games      '$_W_msg_games'      off \
-                benchmarks '$_W_msg_benchmarks' off \
-                apps       '$_W_msg_apps'       off \
-                main       '$_W_msg_default'    on  \
-                mkprefix   '$_W_msg_mkprefix'   off \
+                --radiolist '${_W_msg_body}' \
+                help       '${_W_msg_help}'       off \
+                games      '${_W_msg_games}'      off \
+                benchmarks '${_W_msg_benchmarks}' off \
+                apps       '${_W_msg_apps}'       off \
+                main       '${_W_msg_default}'    on  \
+                mkprefix   '${_W_msg_mkprefix}'   off \
                 "
-            if ls -d "$W_PREFIXES_ROOT"/*/dosdevices > /dev/null 2>&1; then
-                for prefix in "$W_PREFIXES_ROOT"/*/dosdevices; do
+            if ls -d "${W_PREFIXES_ROOT}"/*/dosdevices > /dev/null 2>&1; then
+                for prefix in "${W_PREFIXES_ROOT}"/*/dosdevices; do
                     q="${prefix%%/dosdevices}"
                     p="${q##*/}"
-                    if test -f "$W_PREFIXES_ROOT/$p/wrapper.cfg"; then
-                        _W_msg_name="$p ($(winetricks_get_prefix_var name))"
+                    if test -f "${W_PREFIXES_ROOT}/${p}/wrapper.cfg"; then
+                        _W_msg_name="${p} ($(winetricks_get_prefix_var name))"
                     else
-                        _W_msg_name="$p"
+                        _W_msg_name="${p}"
                     fi
-                    printf %s "prefix='$p' 'Select $_W_msg_name' off "
+                    printf %s "prefix='${p}' 'Select ${_W_msg_name}' off "
                 done
             fi
-            printf %s " $_W_cmd_unattended '$_W_msg_unattended' off"
-            ) > "$WINETRICKS_WORKDIR"/kdialog.sh
-            sh "$WINETRICKS_WORKDIR"/kdialog.sh
+            printf %s " ${_W_cmd_unattended} '${_W_msg_unattended}' off"
+            ) > "${WINETRICKS_WORKDIR}"/kdialog.sh
+            sh "${WINETRICKS_WORKDIR}"/kdialog.sh
             ;;
     esac
     unset _W_msg_help _W_msg_body _W_msg_title _W_msg_new _W_msg_default _W_msg_name
@@ -3693,7 +3693,7 @@ winetricks_prefixmenu()
 # This returns two verbs: arch and prefix, e.g. "arch=32 prefix=test".
 winetricks_mkprefixmenu()
 {
-    case $LANG in
+    case ${LANG} in
         # TODO: translate to other languages
         de)  _W_msg_title="Winetricks - Neues Wineprefix erstellen"
              _W_msg_name="Name"
@@ -3705,18 +3705,18 @@ winetricks_mkprefixmenu()
              ;;
     esac
 
-    case $WINETRICKS_GUI in
+    case ${WINETRICKS_GUI} in
         zenity)
-            $WINETRICKS_GUI --forms --text="" --title "$_W_msg_title" \
-                --add-combo="$_W_msg_arch" --combo-values=32\|64 \
-                --add-entry="$_W_msg_name" \
+            ${WINETRICKS_GUI} --forms --text="" --title "${_W_msg_title}" \
+                --add-combo="${_W_msg_arch}" --combo-values=32\|64 \
+                --add-entry="${_W_msg_name}" \
                 | sed -e 's/^\s*|/64|/' -e 's/^/arch=/' -e 's/|/ prefix=/'
             ;;
         kdialog)
-            $WINETRICKS_GUI --title="$_W_msg_title" \
-                --radiolist="$_W_msg_arch" 32 32bit off 64 64bit on \
+            ${WINETRICKS_GUI} --title="${_W_msg_title}" \
+                --radiolist="${_W_msg_arch}" 32 32bit off 64 64bit on \
                 | sed -e 's/^$/64/' -e 's/^/arch=/'
-            $WINETRICKS_GUI --title="$_W_msg_title" --inputbox="$_W_msg_name" \
+            ${WINETRICKS_GUI} --title="${_W_msg_title}" --inputbox="${_W_msg_name}" \
                 | sed -e 's/^/prefix=/'
             ;;
     esac
@@ -3727,8 +3727,8 @@ winetricks_mkprefixmenu()
 # Display main menu, get which submenu the user wants
 winetricks_mainmenu()
 {
-    case $LANG in
-        da*) _W_msg_title="Vælg en pakke-kategori - Nuværende præfiks er \"$WINEPREFIX\""
+    case ${LANG} in
+        da*) _W_msg_title="Vælg en pakke-kategori - Nuværende præfiks er \"${WINEPREFIX}\""
              _W_msg_body='Hvad ønsker du at gøre?'
              _W_msg_dlls="Install a Windows DLL"
              _W_msg_fonts='Install a font'
@@ -3742,7 +3742,7 @@ winetricks_mainmenu()
              _W_msg_folder='Browse files'
              _W_msg_annihilate="Delete ALL DATA AND APPLICATIONS INSIDE THIS WINEPREFIX"
              ;;
-        de*) _W_msg_title="Pakettyp auswählen - Aktueller Präfix ist \"$WINEPREFIX\""
+        de*) _W_msg_title="Pakettyp auswählen - Aktueller Präfix ist \"${WINEPREFIX}\""
              _W_msg_body='Was möchten Sie tun?'
              _W_msg_dlls="Windows-DLL installieren"
              _W_msg_fonts='Schriftart installieren'
@@ -3756,7 +3756,7 @@ winetricks_mainmenu()
              _W_msg_folder='Ordner durchsuchen'
              _W_msg_annihilate="ALLE DATEIEN UND PROGRAMME IN DIESEM WINEPREFIX Löschen"
              ;;
-        pl*) _W_msg_title="Winetricks - obecny prefiks to \"$WINEPREFIX\""
+        pl*) _W_msg_title="Winetricks - obecny prefiks to \"${WINEPREFIX}\""
              _W_msg_body='Co chcesz zrobić w tym prefiksie?'
              _W_msg_dlls="Zainstalować windowsową bibliotekę DLL lub komponent"
              _W_msg_fonts='Zainstalować czcionkę'
@@ -3770,7 +3770,7 @@ winetricks_mainmenu()
              _W_msg_folder='Przeglądać pliki'
              _W_msg_annihilate="Usuńąć WSZYSTKIE DANE I APLIKACJE WEWNĄTRZ TEGO PREFIKSU WINE"
              ;;
-        ru*) _W_msg_title="Winetricks - текущий путь для wine (wineprefix) \"$WINEPREFIX\""
+        ru*) _W_msg_title="Winetricks - текущий путь для wine (wineprefix) \"${WINEPREFIX}\""
              _W_msg_body='Что вы хотите сделать с этим wineprefix?'
              _W_msg_dlls="Установить библиотеку DLL или компонент Windows"
              _W_msg_fonts='Установить шрифт'
@@ -3784,7 +3784,7 @@ winetricks_mainmenu()
              _W_msg_folder='Проводник файлов'
              _W_msg_annihilate="Удалить ВСЕ ДАННЫЕ И ПРИЛОЖЕНИЯ В ЭТОМ WINEPREFIX"
              ;;
-        uk*) _W_msg_title="Winetricks - поточний prefix \"$WINEPREFIX\""
+        uk*) _W_msg_title="Winetricks - поточний prefix \"${WINEPREFIX}\""
              _W_msg_body='Що Ви хочете зробити для цього wineprefix?'
              _W_msg_dlls="Встановити Windows DLL чи компонент(и)"
              _W_msg_fonts='Встановити шрифт'
@@ -3798,7 +3798,7 @@ winetricks_mainmenu()
              _W_msg_folder='Перегляд файлів'
              _W_msg_annihilate="Видалити УСІ ДАНІ ТА ПРОГРАМИ З ЦЬОГО WINEPREFIX"
              ;;
-        zh_CN*)   _W_msg_title="Winetricks - 当前容器路径是 \"$WINEPREFIX\""
+        zh_CN*)   _W_msg_title="Winetricks - 当前容器路径是 \"${WINEPREFIX}\""
              _W_msg_body='管理当前容器'
              _W_msg_dlls="安装 Windows DLL 或组件"
              _W_msg_fonts='安装字体'
@@ -3812,7 +3812,7 @@ winetricks_mainmenu()
              _W_msg_folder='浏览容器中的文件'
              _W_msg_annihilate="删除容器中所有数据和应用程序"
              ;;
-        zh_TW*|zh_HK*)   _W_msg_title="Winetricks - 目前容器路徑是 \"$WINEPREFIX\""
+        zh_TW*|zh_HK*)   _W_msg_title="Winetricks - 目前容器路徑是 \"${WINEPREFIX}\""
              _W_msg_body='管理目前容器'
              _W_msg_dlls="安裝 Windows DLL 或套件"
              _W_msg_fonts='安裝字型'
@@ -3826,7 +3826,7 @@ winetricks_mainmenu()
              _W_msg_folder='瀏覽容器中的檔案'
              _W_msg_annihilate="刪除容器中所有資料和應用程式"
              ;;
-        *)   _W_msg_title="Winetricks - current prefix is \"$WINEPREFIX\""
+        *)   _W_msg_title="Winetricks - current prefix is \"${WINEPREFIX}\""
              _W_msg_body='What would you like to do to this wineprefix?'
              _W_msg_dlls="Install a Windows DLL or component"
              _W_msg_fonts='Install a font'
@@ -3842,55 +3842,55 @@ winetricks_mainmenu()
              ;;
     esac
 
-    case $WINETRICKS_GUI in
+    case ${WINETRICKS_GUI} in
         zenity)
             (
                 printf %s "zenity \
-                    --title '$_W_msg_title' \
-                    --text '$_W_msg_body' \
+                    --title '${_W_msg_title}' \
+                    --text '${_W_msg_body}' \
                     --list \
                     --radiolist \
                     --column '' \
                     --column '' \
                     --column '' \
-                    --height $WINETRICKS_MENU_HEIGHT \
-                    --width $WINETRICKS_MENU_WIDTH \
+                    --height ${WINETRICKS_MENU_HEIGHT} \
+                    --width ${WINETRICKS_MENU_WIDTH} \
                     --hide-column 2 \
-                    FALSE dlls        '$_W_msg_dlls' \
-                    FALSE fonts       '$_W_msg_fonts' \
-                    FALSE settings    '$_W_msg_settings' \
-                    FALSE winecfg     '$_W_msg_winecfg' \
-                    FALSE regedit     '$_W_msg_regedit' \
-                    FALSE taskmgr     '$_W_msg_taskmgr' \
-                    FALSE explorer    '$_W_msg_explorer' \
-                    FALSE uninstaller '$_W_msg_uninstaller' \
-                    FALSE shell       '$_W_msg_shell' \
-                    FALSE folder      '$_W_msg_folder' \
-                    FALSE annihilate  '$_W_msg_annihilate' \
+                    FALSE dlls        '${_W_msg_dlls}' \
+                    FALSE fonts       '${_W_msg_fonts}' \
+                    FALSE settings    '${_W_msg_settings}' \
+                    FALSE winecfg     '${_W_msg_winecfg}' \
+                    FALSE regedit     '${_W_msg_regedit}' \
+                    FALSE taskmgr     '${_W_msg_taskmgr}' \
+                    FALSE explorer    '${_W_msg_explorer}' \
+                    FALSE uninstaller '${_W_msg_uninstaller}' \
+                    FALSE shell       '${_W_msg_shell}' \
+                    FALSE folder      '${_W_msg_folder}' \
+                    FALSE annihilate  '${_W_msg_annihilate}' \
                  "
-            ) > "$WINETRICKS_WORKDIR"/zenity.sh
+            ) > "${WINETRICKS_WORKDIR}"/zenity.sh
 
-            sh "$WINETRICKS_WORKDIR"/zenity.sh | tr '|' ' '
+            sh "${WINETRICKS_WORKDIR}"/zenity.sh | tr '|' ' '
             ;;
 
         kdialog)
-            $WINETRICKS_GUI --geometry 600x400+100+100 \
-                    --title "$_W_msg_title" \
+            ${WINETRICKS_GUI} --geometry 600x400+100+100 \
+                    --title "${_W_msg_title}" \
                     --separate-output \
                     --radiolist \
-                    "$_W_msg_body"\
-                    dlls        "$_W_msg_dlls" off \
-                    fonts       "$_W_msg_fonts" off \
-                    settings    "$_W_msg_settings" off \
-                    winecfg     "$_W_msg_winecfg" off \
-                    regedit     "$_W_msg_regedit" off \
-                    taskmgr     "$_W_msg_taskmgr" off \
-                    explorer    "$_W_msg_explorer" off \
-                    uninstaller "$_W_msg_uninstaller" off \
-                    shell       "$_W_msg_shell" off \
-                    folder      "$_W_msg_folder" off \
-                    annihilate  "$_W_msg_annihilate" off \
-                    $_W_cmd_unattended "$_W_msg_unattended" off \
+                    "${_W_msg_body}"\
+                    dlls        "${_W_msg_dlls}" off \
+                    fonts       "${_W_msg_fonts}" off \
+                    settings    "${_W_msg_settings}" off \
+                    winecfg     "${_W_msg_winecfg}" off \
+                    regedit     "${_W_msg_regedit}" off \
+                    taskmgr     "${_W_msg_taskmgr}" off \
+                    explorer    "${_W_msg_explorer}" off \
+                    uninstaller "${_W_msg_uninstaller}" off \
+                    shell       "${_W_msg_shell}" off \
+                    folder      "${_W_msg_folder}" off \
+                    annihilate  "${_W_msg_annihilate}" off \
+                    ${_W_cmd_unattended} "${_W_msg_unattended}" off \
 
             ;;
     esac
@@ -3900,168 +3900,168 @@ winetricks_mainmenu()
 winetricks_settings_menu()
 {
     # FIXME: these translations should really be centralized/reused:
-    case $LANG in
-        da*) _W_msg_title="Vælg en pakke - Nuværende præfiks er \"$WINEPREFIX\""
+    case ${LANG} in
+        da*) _W_msg_title="Vælg en pakke - Nuværende præfiks er \"${WINEPREFIX}\""
              _W_msg_body='Which settings would you like to change?'
              ;;
-        de*) _W_msg_title="Winetricks - Aktueller Präfix ist \"$WINEPREFIX\""
+        de*) _W_msg_title="Winetricks - Aktueller Präfix ist \"${WINEPREFIX}\""
              _W_msg_body='Welche Einstellungen möchten Sie ändern?'
              ;;
-        pl*) _W_msg_title="Winetricks - obecny prefiks to \"$WINEPREFIX\""
+        pl*) _W_msg_title="Winetricks - obecny prefiks to \"${WINEPREFIX}\""
              _W_msg_body='Jakie ustawienia chcesz zmienić?'
              ;;
-        ru*) _W_msg_title="Winetricks - текущий путь wine (wineprefix) \"$WINEPREFIX\""
+        ru*) _W_msg_title="Winetricks - текущий путь wine (wineprefix) \"${WINEPREFIX}\""
              _W_msg_body='Какие настройки вы хотите изменить?'
              ;;
-        uk*) _W_msg_title="Winetricks - поточний prefix \"$WINEPREFIX\""
+        uk*) _W_msg_title="Winetricks - поточний prefix \"${WINEPREFIX}\""
              _W_msg_body='Які налаштування Ви хочете змінити?'
              ;;
-        zh_CN*)   _W_msg_title="Winetricks - 当前容器路径是 \"$WINEPREFIX\""
+        zh_CN*)   _W_msg_title="Winetricks - 当前容器路径是 \"${WINEPREFIX}\""
              _W_msg_body='您想要更改哪项设置？'
              ;;
-        zh_TW*|zh_HK*)   _W_msg_title="Winetricks - 目前容器路徑是 \"$WINEPREFIX\""
+        zh_TW*|zh_HK*)   _W_msg_title="Winetricks - 目前容器路徑是 \"${WINEPREFIX}\""
              _W_msg_body='您想要變更哪項設定？'
              ;;
-        *)   _W_msg_title="Winetricks - current prefix is \"$WINEPREFIX\""
+        *)   _W_msg_title="Winetricks - current prefix is \"${WINEPREFIX}\""
              _W_msg_body='Which settings would you like to change?'
              ;;
     esac
 
-    case $WINETRICKS_GUI in
+    case ${WINETRICKS_GUI} in
         zenity)
-            case $LANG in
+            case ${LANG} in
                 da*) printf %s "zenity \
-                        --title '$_W_msg_title' \
-                        --text '$_W_msg_body' \
+                        --title '${_W_msg_title}' \
+                        --text '${_W_msg_body}' \
                         --list \
                         --checklist \
                         --column '' \
                         --column Pakke \
                         --column Navn \
-                        --height $WINETRICKS_MENU_HEIGHT \
-                        --width $WINETRICKS_MENU_WIDTH \
+                        --height ${WINETRICKS_MENU_HEIGHT} \
+                        --width ${WINETRICKS_MENU_WIDTH} \
                         "
                     ;;
                 de*) printf %s "zenity \
-                        --title '$_W_msg_title' \
-                        --text '$_W_msg_body' \
+                        --title '${_W_msg_title}' \
+                        --text '${_W_msg_body}' \
                         --list \
                         --checklist \
                         --column '' \
                         --column Einstellung \
                         --column Name \
-                        --height $WINETRICKS_MENU_HEIGHT \
-                        --width $WINETRICKS_MENU_WIDTH \
+                        --height ${WINETRICKS_MENU_HEIGHT} \
+                        --width ${WINETRICKS_MENU_WIDTH} \
                         "
                     ;;
                 pl*) printf %s "zenity \
-                        --title '$_W_msg_title' \
-                        --text '$_W_msg_body' \
+                        --title '${_W_msg_title}' \
+                        --text '${_W_msg_body}' \
                         --list \
                         --checklist \
                         --column '' \
                         --column Ustawienie \
                         --column Nazwa \
-                        --height $WINETRICKS_MENU_HEIGHT \
-                        --width $WINETRICKS_MENU_WIDTH \
+                        --height ${WINETRICKS_MENU_HEIGHT} \
+                        --width ${WINETRICKS_MENU_WIDTH} \
                         "
                     ;;
                 ru*) printf %s "zenity \
-                        --title '$_W_msg_title' \
-                        --text '$_W_msg_body' \
+                        --title '${_W_msg_title}' \
+                        --text '${_W_msg_body}' \
                         --list \
                         --checklist \
                         --column '' \
                         --column Установка \
                         --column Имя \
-                        --height $WINETRICKS_MENU_HEIGHT \
-                        --width $WINETRICKS_MENU_WIDTH \
+                        --height ${WINETRICKS_MENU_HEIGHT} \
+                        --width ${WINETRICKS_MENU_WIDTH} \
                         "
                     ;;
                 uk*) printf %s "zenity \
-                        --title '$_W_msg_title' \
-                        --text '$_W_msg_body' \
+                        --title '${_W_msg_title}' \
+                        --text '${_W_msg_body}' \
                         --list \
                         --checklist \
                         --column '' \
                         --column Установка \
                         --column Назва \
-                        --height $WINETRICKS_MENU_HEIGHT \
-                        --width $WINETRICKS_MENU_WIDTH \
+                        --height ${WINETRICKS_MENU_HEIGHT} \
+                        --width ${WINETRICKS_MENU_WIDTH} \
                         "
                     ;;
                 zh_CN*) printf %s "zenity \
-                        --title '$_W_msg_title' \
-                        --text '$_W_msg_body' \
+                        --title '${_W_msg_title}' \
+                        --text '${_W_msg_body}' \
                         --list \
                         --checklist \
                         --column '' \
                         --column 设置 \
                         --column 标题 \
-                        --height $WINETRICKS_MENU_HEIGHT \
-                        --width $WINETRICKS_MENU_WIDTH \
+                        --height ${WINETRICKS_MENU_HEIGHT} \
+                        --width ${WINETRICKS_MENU_WIDTH} \
                         "
                     ;;
                 zh_TW*|zh_HK*) printf %s "zenity \
-                        --title '$_W_msg_title' \
-                        --text '$_W_msg_body' \
+                        --title '${_W_msg_title}' \
+                        --text '${_W_msg_body}' \
                         --list \
                         --checklist \
                         --column '' \
                         --column 設定 \
                         --column 標題 \
-                        --height $WINETRICKS_MENU_HEIGHT \
-                        --width $WINETRICKS_MENU_WIDTH \
+                        --height ${WINETRICKS_MENU_HEIGHT} \
+                        --width ${WINETRICKS_MENU_WIDTH} \
                         "
                     ;;
                 *) printf %s "zenity \
-                        --title '$_W_msg_title' \
-                        --text '$_W_msg_body' \
+                        --title '${_W_msg_title}' \
+                        --text '${_W_msg_body}' \
                         --list \
                         --checklist \
                         --column '' \
                         --column Setting \
                         --column Title \
-                        --height $WINETRICKS_MENU_HEIGHT \
-                        --width $WINETRICKS_MENU_WIDTH \
+                        --height ${WINETRICKS_MENU_HEIGHT} \
+                        --width ${WINETRICKS_MENU_WIDTH} \
                         "
                     ;;
-            esac > "$WINETRICKS_WORKDIR"/zenity.sh
+            esac > "${WINETRICKS_WORKDIR}"/zenity.sh
 
-            for metadatafile in "$WINETRICKS_METADATA/$WINETRICKS_CURMENU"/*.vars; do
-                code=$(winetricks_metadata_basename "$metadatafile")
+            for metadatafile in "${WINETRICKS_METADATA}/${WINETRICKS_CURMENU}"/*.vars; do
+                code=$(winetricks_metadata_basename "${metadatafile}")
                 (
                     title='?'
                     # shellcheck disable=SC1090
-                    . "$metadatafile"
+                    . "${metadatafile}"
 
                     # Begin 'title' strings localization code
                     # shellcheck disable=SC2154
-                    case $LANG in
+                    case ${LANG} in
                     uk*)
-                        case "$title_uk" in
+                        case "${title_uk}" in
                             "") ;;
-                            *) title="$title_uk";;
+                            *) title="${title_uk}";;
                         esac
                     esac
 
                     # End of code
                     printf "%s %s %s %s" " " FALSE \
-                            "$code" \
-                            "\"$title\""
+                            "${code}" \
+                            "\"${title}\""
                 )
-            done >> "$WINETRICKS_WORKDIR"/zenity.sh
+            done >> "${WINETRICKS_WORKDIR}"/zenity.sh
 
-            sh "$WINETRICKS_WORKDIR"/zenity.sh | tr '|' ' '
+            sh "${WINETRICKS_WORKDIR}"/zenity.sh | tr '|' ' '
             ;;
 
         kdialog)
             (
-                printf %s "kdialog --geometry 600x400+100+100 --title '$_W_msg_title' --separate-output --checklist '$_W_msg_body' "
+                printf %s "kdialog --geometry 600x400+100+100 --title '${_W_msg_title}' --separate-output --checklist '${_W_msg_body}' "
                 winetricks_list_all | sed 's/\([^ ]*\)  *\(.*\)/\1 "\1 - \2" off /' | tr '\012' ' '
-            ) > "$WINETRICKS_WORKDIR"/kdialog.sh
+            ) > "${WINETRICKS_WORKDIR}"/kdialog.sh
 
-            sh "$WINETRICKS_WORKDIR"/kdialog.sh
+            sh "${WINETRICKS_WORKDIR}"/kdialog.sh
             ;;
     esac
 
@@ -4071,48 +4071,48 @@ winetricks_settings_menu()
 # Display the current menu, output list of verbs to execute to stdout
 winetricks_showmenu()
 {
-    case $LANG in
+    case ${LANG} in
         da*) _W_msg_title='Vælg en pakke'
              _W_msg_body='Vilken pakke vil du installere?'
              _W_cached="cached"
              ;;
-        de*) _W_msg_title="Winetricks - Aktueller Prefix ist \"$WINEPREFIX\""
+        de*) _W_msg_title="Winetricks - Aktueller Prefix ist \"${WINEPREFIX}\""
              _W_msg_body='Welche Paket(e) möchten Sie installieren?'
              _W_cached="gecached"
              ;;
-        pl*) _W_msg_title="Winetricks - obecny prefiks to \"$WINEPREFIX\""
+        pl*) _W_msg_title="Winetricks - obecny prefiks to \"${WINEPREFIX}\""
              _W_msg_body='Które paczki chesz zainstalować?'
              _W_cached="zarchiwizowane"
              ;;
-        ru*) _W_msg_title="Winetricks - текущий путь wine (wineprefix) \"$WINEPREFIX\""
+        ru*) _W_msg_title="Winetricks - текущий путь wine (wineprefix) \"${WINEPREFIX}\""
              _W_msg_body='Какое приложение(я) вы хотите установить?'
              _W_cached="в кэше"
              ;;
-        uk*) _W_msg_title="Winetricks - поточний prefix \"$WINEPREFIX\""
+        uk*) _W_msg_title="Winetricks - поточний prefix \"${WINEPREFIX}\""
              _W_msg_body='Які пакунки Ви хочете встановити?'
              _W_cached="кешовано"
              ;;
-        zh_CN*)   _W_msg_title="Winetricks - 当前容器路径是 \"$WINEPREFIX\""
+        zh_CN*)   _W_msg_title="Winetricks - 当前容器路径是 \"${WINEPREFIX}\""
              _W_msg_body='您想要安装什么应用程序？'
              _W_cached="已缓存"
              ;;
-        zh_TW*|zh_HK*)   _W_msg_title="Winetricks - 目前容器路徑是 \"$WINEPREFIX\""
+        zh_TW*|zh_HK*)   _W_msg_title="Winetricks - 目前容器路徑是 \"${WINEPREFIX}\""
              _W_msg_body='您想要安裝什麼應用程式？'
              _W_cached="已緩存"
              ;;
-        *)   _W_msg_title="Winetricks - current prefix is \"$WINEPREFIX\""
+        *)   _W_msg_title="Winetricks - current prefix is \"${WINEPREFIX}\""
              _W_msg_body='Which package(s) would you like to install?'
              _W_cached="cached"
              ;;
     esac
 
 
-    case $WINETRICKS_GUI in
+    case ${WINETRICKS_GUI} in
         zenity)
-            case $LANG in
+            case ${LANG} in
                 da*) printf %s "zenity \
-                        --title '$_W_msg_title' \
-                        --text '$_W_msg_body' \
+                        --title '${_W_msg_title}' \
+                        --text '${_W_msg_body}' \
                         --list \
                         --checklist \
                         --column '' \
@@ -4122,13 +4122,13 @@ winetricks_showmenu()
                         --column År \
                         --column Medie \
                         --column Status \
-                        --height $WINETRICKS_MENU_HEIGHT \
-                        --width $WINETRICKS_MENU_WIDTH \
+                        --height ${WINETRICKS_MENU_HEIGHT} \
+                        --width ${WINETRICKS_MENU_WIDTH} \
                         "
                     ;;
                 de*) printf %s "zenity \
-                        --title '$_W_msg_title' \
-                        --text '$_W_msg_body' \
+                        --title '${_W_msg_title}' \
+                        --text '${_W_msg_body}' \
                         --list \
                         --checklist \
                         --column '' \
@@ -4138,13 +4138,13 @@ winetricks_showmenu()
                         --column Jahr \
                         --column Media \
                         --column Status \
-                        --height $WINETRICKS_MENU_HEIGHT \
-                        --width $WINETRICKS_MENU_WIDTH \
+                        --height ${WINETRICKS_MENU_HEIGHT} \
+                        --width ${WINETRICKS_MENU_WIDTH} \
                         "
                      ;;
                 pl*) printf %s "zenity \
-                        --title '$_W_msg_title' \
-                        --text '$_W_msg_body' \
+                        --title '${_W_msg_title}' \
+                        --text '${_W_msg_body}' \
                         --list \
                         --checklist \
                         --column '' \
@@ -4154,13 +4154,13 @@ winetricks_showmenu()
                         --column Rok \
                         --column Media \
                         --column Status \
-                        --height $WINETRICKS_MENU_HEIGHT \
-                        --width $WINETRICKS_MENU_WIDTH \
+                        --height ${WINETRICKS_MENU_HEIGHT} \
+                        --width ${WINETRICKS_MENU_WIDTH} \
                         "
                      ;;
                 ru*) printf %s "zenity \
-                        --title '$_W_msg_title' \
-                        --text '$_W_msg_body' \
+                        --title '${_W_msg_title}' \
+                        --text '${_W_msg_body}' \
                         --list \
                         --checklist \
                         --column '' \
@@ -4170,13 +4170,13 @@ winetricks_showmenu()
                         --column Год \
                         --column Источник \
                         --column Статус \
-                        --height $WINETRICKS_MENU_HEIGHT \
-                        --width $WINETRICKS_MENU_WIDTH \
+                        --height ${WINETRICKS_MENU_HEIGHT} \
+                        --width ${WINETRICKS_MENU_WIDTH} \
                         "
                      ;;
                 uk*) printf %s "zenity \
-                        --title '$_W_msg_title' \
-                        --text '$_W_msg_body' \
+                        --title '${_W_msg_title}' \
+                        --text '${_W_msg_body}' \
                         --list \
                         --checklist \
                         --column '' \
@@ -4186,13 +4186,13 @@ winetricks_showmenu()
                         --column Рік \
                         --column Медіа \
                         --column Статус \
-                        --height $WINETRICKS_MENU_HEIGHT \
-                        --width $WINETRICKS_MENU_WIDTH \
+                        --height ${WINETRICKS_MENU_HEIGHT} \
+                        --width ${WINETRICKS_MENU_WIDTH} \
                         "
                      ;;
                 zh_CN*) printf %s "zenity \
-                        --title '$_W_msg_title' \
-                        --text '$_W_msg_body' \
+                        --title '${_W_msg_title}' \
+                        --text '${_W_msg_body}' \
                         --list \
                         --checklist \
                         --column '' \
@@ -4202,13 +4202,13 @@ winetricks_showmenu()
                         --column 发行年 \
                         --column 媒介 \
                         --column 状态 \
-                        --height $WINETRICKS_MENU_HEIGHT \
-                        --width $WINETRICKS_MENU_WIDTH \
+                        --height ${WINETRICKS_MENU_HEIGHT} \
+                        --width ${WINETRICKS_MENU_WIDTH} \
                         "
                      ;;
                 zh_TW*|zh_HK*) printf %s "zenity \
-                        --title '$_W_msg_title' \
-                        --text '$_W_msg_body' \
+                        --title '${_W_msg_title}' \
+                        --text '${_W_msg_body}' \
                         --list \
                         --checklist \
                         --column '' \
@@ -4218,13 +4218,13 @@ winetricks_showmenu()
                         --column 發行年 \
                         --column 媒介 \
                         --column 狀態 \
-                        --height $WINETRICKS_MENU_HEIGHT \
-                        --width $WINETRICKS_MENU_WIDTH \
+                        --height ${WINETRICKS_MENU_HEIGHT} \
+                        --width ${WINETRICKS_MENU_WIDTH} \
                         "
                      ;;
                 *) printf %s "zenity \
-                        --title '$_W_msg_title' \
-                        --text '$_W_msg_body' \
+                        --title '${_W_msg_title}' \
+                        --text '${_W_msg_body}' \
                         --list \
                         --checklist \
                         --column '' \
@@ -4234,53 +4234,53 @@ winetricks_showmenu()
                         --column Year \
                         --column Media \
                         --column Status \
-                        --height $WINETRICKS_MENU_HEIGHT \
-                        --width $WINETRICKS_MENU_WIDTH \
+                        --height ${WINETRICKS_MENU_HEIGHT} \
+                        --width ${WINETRICKS_MENU_WIDTH} \
                         "
                      ;;
-            esac > "$WINETRICKS_WORKDIR"/zenity.sh
+            esac > "${WINETRICKS_WORKDIR}"/zenity.sh
 
-            true > "$WINETRICKS_WORKDIR"/installed.txt
+            true > "${WINETRICKS_WORKDIR}"/installed.txt
 
-            for metadatafile in "$WINETRICKS_METADATA/$WINETRICKS_CURMENU"/*.vars; do
-                code=$(winetricks_metadata_basename "$metadatafile")
+            for metadatafile in "${WINETRICKS_METADATA}/${WINETRICKS_CURMENU}"/*.vars; do
+                code=$(winetricks_metadata_basename "${metadatafile}")
                 (
                     title='?'
                     # shellcheck disable=SC1090
-                    . "$metadatafile"
+                    . "${metadatafile}"
                     # Compute cached and downloadable flags
                     flags=""
-                    winetricks_is_cached "$code" && flags="$_W_cached"
+                    winetricks_is_cached "${code}" && flags="${_W_cached}"
                     installed=FALSE
-                    if winetricks_is_installed "$code"; then
+                    if winetricks_is_installed "${code}"; then
                         installed=TRUE
-                        echo "$code" >> "$WINETRICKS_WORKDIR"/installed.txt
+                        echo "${code}" >> "${WINETRICKS_WORKDIR}"/installed.txt
                     fi
-                    printf %s " $installed \
-                        $code \
-                        \"$title\" \
-                        \"$publisher\" \
-                        \"$year\" \
-                        \"$media\" \
-                        \"$flags\" \
+                    printf %s " ${installed} \
+                        ${code} \
+                        \"${title}\" \
+                        \"${publisher}\" \
+                        \"${year}\" \
+                        \"${media}\" \
+                        \"${flags}\" \
                     "
                 )
-            done >> "$WINETRICKS_WORKDIR"/zenity.sh
+            done >> "${WINETRICKS_WORKDIR}"/zenity.sh
 
             # Filter out any verb that's already installed
-            sh "$WINETRICKS_WORKDIR"/zenity.sh |
+            sh "${WINETRICKS_WORKDIR}"/zenity.sh |
                 tr '|' '\012' |
-                grep -F -v -x -f "$WINETRICKS_WORKDIR"/installed.txt |
+                grep -F -v -x -f "${WINETRICKS_WORKDIR}"/installed.txt |
                 tr '\012' ' '
             ;;
 
         kdialog)
             (
-                printf %s "kdialog --geometry 600x400+100+100 --title '$_W_msg_title' --separate-output --checklist '$_W_msg_body' "
+                printf %s "kdialog --geometry 600x400+100+100 --title '${_W_msg_title}' --separate-output --checklist '${_W_msg_body}' "
                 winetricks_list_all | sed 's/\([^ ]*\)  *\(.*\)/\1 "\1 - \2" off /' | tr '\012' ' '
-            ) > "$WINETRICKS_WORKDIR"/kdialog.sh
+            ) > "${WINETRICKS_WORKDIR}"/kdialog.sh
 
-            sh "$WINETRICKS_WORKDIR"/kdialog.sh
+            sh "${WINETRICKS_WORKDIR}"/kdialog.sh
             ;;
     esac
 
@@ -4303,7 +4303,7 @@ winetricks_metadata_basename()
 # Returns true if given verb has been registered
 winetricks_metadata_exists()
 {
-    test -f "$WINETRICKS_METADATA"/*/"${1}.vars"
+    test -f "${WINETRICKS_METADATA}"/*/"${1}.vars"
 }
 
 # Returns true if given verb has been cached
@@ -4313,16 +4313,16 @@ winetricks_is_cached()
     # FIXME: also check file2... if given
     # https://github.com/Winetricks/winetricks/issues/989
     # shellcheck disable=SC2154
-    _W_path="$W_CACHE/$1/$file1"
-    case "$_W_path" in
+    _W_path="${W_CACHE}/$1/${file1}"
+    case "${_W_path}" in
         *..*)
             # Remove /foo/.. so verbs that don't have their own cache directories
             # can refer to siblings
-            _W_path="$(echo "$_W_path" | sed 's,/[^/]*/\.\.,,')"
+            _W_path="$(echo "${_W_path}" | sed 's,/[^/]*/\.\.,,')"
             ;;
     esac
 
-    if test -f "$_W_path"; then
+    if test -f "${_W_path}"; then
         unset _W_path
         return "${TRUE}"
     fi
@@ -4336,25 +4336,25 @@ winetricks_is_cached()
 winetricks_is_installed()
 {
     unset _W_file _W_file_unix
-    if test "$installed_exe1"; then
-        _W_file="$installed_exe1"
-    elif test "$installed_file1"; then
-        _W_file="$installed_file1"
+    if test "${installed_exe1}"; then
+        _W_file="${installed_exe1}"
+    elif test "${installed_file1}"; then
+        _W_file="${installed_file1}"
     else
         return "${FALSE}"  # not installed
     fi
 
     # Test if the verb has been executed before
-    if ! grep -qw "$1" "$WINEPREFIX/winetricks.log" 2>/dev/null; then
+    if ! grep -qw "$1" "${WINEPREFIX}/winetricks.log" 2>/dev/null; then
         unset _W_file
         return "${FALSE}"  # not installed
     fi
 
-    case "$W_PLATFORM" in
+    case "${W_PLATFORM}" in
         windows_cmd|wine_cmd)
             # On Windows, there's no wineprefix, just check if file's there
-            _W_file_unix="$(w_pathconv -u "$_W_file")"
-            if test -f "$_W_file_unix"; then
+            _W_file_unix="$(w_pathconv -u "${_W_file}")"
+            if test -f "${_W_file_unix}"; then
                 unset _W_file _W_file_unix _W_prefix
                 return "${TRUE}"  # installed
             fi
@@ -4363,26 +4363,26 @@ winetricks_is_installed()
             # Compute wineprefix for this app
             case "${_W_category}-${WINETRICKS_OPT_SHAREDPREFIX}" in
                 apps-0|benchmarks-0|games-0)
-                    _W_prefix="$W_PREFIXES_ROOT/$1"
+                    _W_prefix="${W_PREFIXES_ROOT}/$1"
                     ;;
                 *)
-                    _W_prefix="$WINEPREFIX"
+                    _W_prefix="${WINEPREFIX}"
                     ;;
             esac
-            if test -d "$_W_prefix/dosdevices"; then
+            if test -d "${_W_prefix}/dosdevices"; then
               # 'win7 vcrun2005' creates different file than 'winxp vcrun2005'
               # so let it specify multiple, separated by |
-              _W_IFS="$IFS"
+              _W_IFS="${IFS}"
               IFS='|'
-              for _W_file_ in $_W_file; do
-                _W_file_unix="$(WINEPREFIX="$_W_prefix" w_pathconv -u "$_W_file_")"
-                if test -f "$_W_file_unix" && ! grep -q "Wine placeholder DLL" "$_W_file_unix"; then
-                    IFS="$_W_IFS"
+              for _W_file_ in ${_W_file}; do
+                _W_file_unix="$(WINEPREFIX="${_W_prefix}" w_pathconv -u "${_W_file_}")"
+                if test -f "${_W_file_unix}" && ! grep -q "Wine placeholder DLL" "${_W_file_unix}"; then
+                    IFS="${_W_IFS}"
                     unset _W_file _W_file_ _W_file_unix _W_prefix _W_IFS
                     return "${TRUE}"  # installed
                 fi
               done
-             IFS="$_W_IFS"
+             IFS="${_W_IFS}"
             fi
             ;;
     esac
@@ -4393,15 +4393,15 @@ winetricks_is_installed()
 # List verbs which are already fully cached locally
 winetricks_list_cached()
 {
-    for _W_metadatafile in "$WINETRICKS_METADATA"/*/*.vars; do
+    for _W_metadatafile in "${WINETRICKS_METADATA}"/*/*.vars; do
         # Use a subshell to avoid putting metadata in global space
         # If this is too slow, we can unset known metadata by hand
         (
-        code=$(winetricks_metadata_basename "$_W_metadatafile")
+        code=$(winetricks_metadata_basename "${_W_metadatafile}")
         # shellcheck disable=SC1090
-        . "$_W_metadatafile"
-        if winetricks_is_cached "$code"; then
-            echo "$code"
+        . "${_W_metadatafile}"
+        if winetricks_is_cached "${code}"; then
+            echo "${code}"
         fi
         )
     done | sort
@@ -4412,7 +4412,7 @@ winetricks_list_cached()
 winetricks_list_download()
 {
     # Piping output of w_try_cd to /dev/null since winetricks-test parses it:
-    w_try_cd "$WINETRICKS_METADATA" >/dev/null
+    w_try_cd "${WINETRICKS_METADATA}" >/dev/null
     grep -l 'media=.download' ./*/*.vars | sed 's,.*/,,;s/\.vars//' | sort -u
 }
 
@@ -4420,7 +4420,7 @@ winetricks_list_download()
 winetricks_list_manual_download()
 {
     # Piping output of w_try_cd to /dev/null since winetricks-test parses it:
-    w_try_cd "$WINETRICKS_METADATA" >/dev/null
+    w_try_cd "${WINETRICKS_METADATA}" >/dev/null
     grep -l 'media=.manual_download' ./*/*.vars | sed 's,.*/,,;s/\.vars//' | sort -u
 }
 
@@ -4428,18 +4428,18 @@ winetricks_list_installed()
 {
     # Rather than check individual metadata/files (which is slow/brittle, and also breaks settings and metaverbs)
     # just show winetricks.log (if it exists), which lists verbs in the order they were installed
-    if [ -f "$WINEPREFIX/winetricks.log" ]; then
-        cat "$WINEPREFIX/winetricks.log"
+    if [ -f "${WINEPREFIX}/winetricks.log" ]; then
+        cat "${WINEPREFIX}/winetricks.log"
     else
-        echo "warning: $WINEPREFIX/winetricks.log not found; winetricks has not installed anything in this prefix."
+        echo "warning: ${WINEPREFIX}/winetricks.log not found; winetricks has not installed anything in this prefix."
     fi
 }
 
 # Helper for adding a string to a list of flags
 winetricks_append_to_flags()
 {
-    if test "$flags"; then
-        flags="$flags,"
+    if test "${flags}"; then
+        flags="${flags},"
     fi
     flags="${flags}$1"
 }
@@ -4449,11 +4449,11 @@ winetricks_append_to_flags()
 winetricks_list_all()
 {
     # Note: doh123 relies on 'winetricks list' to list main menu categories
-    case $WINETRICKS_CURMENU in
-        prefix|main|mkprefix) echo "$WINETRICKS_CATEGORIES" | sed 's/ mkprefix//' | tr ' ' '\012' ; return;;
+    case ${WINETRICKS_CURMENU} in
+        prefix|main|mkprefix) echo "${WINETRICKS_CATEGORIES}" | sed 's/ mkprefix//' | tr ' ' '\012' ; return;;
     esac
 
-    case $LANG in
+    case ${LANG} in
         da*) _W_cached="cached"   ; _W_download="kan hentes"    ;;
         de*) _W_cached="gecached" ; _W_download="herunterladbar";;
         pl*) _W_cached="zarchiwizowane"   ; _W_download="do pobrania"  ;;
@@ -4464,24 +4464,24 @@ winetricks_list_all()
         *)   _W_cached="cached"   ; _W_download="downloadable"  ;;
     esac
 
-    for _W_metadatafile in "$WINETRICKS_METADATA/$WINETRICKS_CURMENU"/*.vars; do
+    for _W_metadatafile in "${WINETRICKS_METADATA}/${WINETRICKS_CURMENU}"/*.vars; do
         # Use a subshell to avoid putting metadata in global space
         # If this is too slow, we can unset known metadata by hand
         (
-        code=$(winetricks_metadata_basename "$_W_metadatafile")
+        code=$(winetricks_metadata_basename "${_W_metadatafile}")
         # shellcheck disable=SC1090
-        . "$_W_metadatafile"
+        . "${_W_metadatafile}"
 
         # Compute cached and downloadable flags
         flags=""
-        test "$media" = "download" && winetricks_append_to_flags "$_W_download"
-        winetricks_is_cached "$code" && winetricks_append_to_flags "$_W_cached"
-        test "$flags" && flags="[$flags]"
+        test "${media}" = "download" && winetricks_append_to_flags "${_W_download}"
+        winetricks_is_cached "${code}" && winetricks_append_to_flags "${_W_cached}"
+        test "${flags}" && flags="[${flags}]"
 
-        if ! test "$year" && ! test "$publisher"; then
-            printf "%-24s %s %s\\n" "$code" "$title" "$flags"
+        if ! test "${year}" && ! test "${publisher}"; then
+            printf "%-24s %s %s\\n" "${code}" "${title}" "${flags}"
         else
-            printf "%-24s %s (%s, %s) %s\\n" "$code" "$title" "$publisher" "$year" "$flags"
+            printf "%-24s %s (%s, %s) %s\\n" "${code}" "${title}" "${publisher}" "${year}" "${flags}"
         fi
         )
     done
@@ -4498,9 +4498,9 @@ winetricks_die_if_user_not_dirowner()
         _W_checkdir=$(dirname "$1")
     fi
     _W_nuser=$(id -u)
-    _W_nowner=$(stat -c '%u' "$_W_checkdir")
-    if test x"$_W_nuser" != x"$_W_nowner"; then
-        w_die "You ($(id -un)) don't own $_W_checkdir.  Don't run this tool as another user!"
+    _W_nowner=$(stat -c '%u' "${_W_checkdir}")
+    if test x"${_W_nuser}" != x"${_W_nowner}"; then
+        w_die "You ($(id -un)) don't own ${_W_checkdir}.  Don't run this tool as another user!"
     fi
 }
 
@@ -4563,37 +4563,37 @@ winetricks_read_udf_volume_name()
 
     # 1. check the 16 bit TagIdentifier of the descriptor tag, make sure it's 2
     tagid=$(winetricks_read_hex 524288 2 "$1")
-    : echo "tagid is $tagid"
-    case "$tagid" in
+    : echo "tagid is ${tagid}"
+    case "${tagid}" in
         "02 00") : echo "Found AVDP" ;;
-        *) echo "Did not find AVDP (tagid was $tagid)"; exit 1;;
+        *) echo "Did not find AVDP (tagid was ${tagid})"; exit 1;;
     esac
 
     # 2. read the location of the main volume descriptor:
     offset=$(winetricks_read_decimal 524308 "$1")
-    : echo "MVD is at sector $offset"
+    : echo "MVD is at sector ${offset}"
     offset=$((offset * 2048))
-    : echo "MVD is at byte $offset"
+    : echo "MVD is at byte ${offset}"
 
     # 3. check the TagIdentifier of the MVD's descriptor tag, make sure it's 1
-    tagid=$(winetricks_read_hex $offset 2 "$1")
-    : echo "tagid is $tagid"
-    case "$tagid" in
+    tagid=$(winetricks_read_hex ${offset} 2 "$1")
+    : echo "tagid is ${tagid}"
+    case "${tagid}" in
         "01 00") : echo Found MVD ;;
         *) echo Did not find MVD; exit 1;;
     esac
 
     # 4. Read whether the name is in 8 or 16 bit chars
     offset=$((offset + 24))
-    width=$(winetricks_read_hex $offset 1 "$1")
+    width=$(winetricks_read_hex ${offset} 1 "$1")
 
     offset=$((offset + 1))
 
     # 5. Profit!
-    case $width in
-        08)   winetricks_read_bytes $offset 30 "$1" | sed 's/  *$//' ;;
-        10)  winetricks_read_bytes $offset 30 "$1" | tr -d '\000' | sed 's/  *$//' ;;
-        *) echo "Unhandled dvd volname character width '$width'"; exit 1;;
+    case ${width} in
+        08)   winetricks_read_bytes ${offset} 30 "$1" | sed 's/  *$//' ;;
+        10)  winetricks_read_bytes ${offset} 30 "$1" | tr -d '\000' | sed 's/  *$//' ;;
+        *) echo "Unhandled dvd volname character width '${width}'"; exit 1;;
     esac
 
     echo ""
@@ -4616,39 +4616,39 @@ winetricks_read_volume_name()
     # "CDW02": ecma-168
 
     std_id=$(winetricks_read_bytes 32769 5 "$1")
-    : echo "std_id is $std_id"
+    : echo "std_id is ${std_id}"
 
-    case $std_id in
+    case ${std_id} in
         CD001) winetricks_read_iso9660_volume_name "$1" ;;
         BEA01) winetricks_read_udf_volume_name "$1" ;;
-        *) echo "Unrecognized disk type $std_id"; exit 1 ;;
+        *) echo "Unrecognized disk type ${std_id}"; exit 1 ;;
     esac
 }
 
 winetricks_volname()
 {
     x=$(volname "$1" 2> /dev/null| sed 's/  *$//')
-    if test "x$x" = "x"; then
+    if test "x${x}" = "x"; then
         # UDF?  See https://bugs.launchpad.net/bugs/678419
         x=$(winetricks_read_volume_name "$1")
     fi
-    echo "$x"
+    echo "${x}"
 }
 
 # Really, should take a volume name as argument, and use 'mount' to get
 # mount point if system automounted it.
 winetricks_detect_optical_drive()
 {
-    case "$WINETRICKS_DEV" in
+    case "${WINETRICKS_DEV}" in
         "") ;;
         *) return ;;
     esac
 
     for WINETRICKS_DEV in /dev/cdrom /dev/dvd /dev/sr0; do
-        test -b $WINETRICKS_DEV && break
+        test -b ${WINETRICKS_DEV} && break
     done
 
-    case "$WINETRICKS_DEV" in
+    case "${WINETRICKS_DEV}" in
         "x") w_die "can't find cd/dvd drive" ;;
     esac
 }
@@ -4658,22 +4658,22 @@ winetricks_cache_iso()
     # WINETRICKS_IMG has already been set by w_mount
     _W_expected_volname="$1"
 
-    winetricks_die_if_user_not_dirowner "$W_CACHE"
+    winetricks_die_if_user_not_dirowner "${W_CACHE}"
     winetricks_detect_optical_drive
 
     # Horrible hack for Gentoo - make sure we can read from the drive
-    if ! test -r $WINETRICKS_DEV; then
-        case "$WINETRICKS_SUDO" in
-            gksu*|kdesudo) $WINETRICKS_SUDO "chmod 666 $WINETRICKS_DEV" ;;
-            kdesu) $WINETRICKS_SUDO -c "chmod 666 $WINETRICKS_DEV" ;;
-            *) $WINETRICKS_SUDO chmod 666 $WINETRICKS_DEV ;;
+    if ! test -r ${WINETRICKS_DEV}; then
+        case "${WINETRICKS_SUDO}" in
+            gksu*|kdesudo) ${WINETRICKS_SUDO} "chmod 666 ${WINETRICKS_DEV}" ;;
+            kdesu) ${WINETRICKS_SUDO} -c "chmod 666 ${WINETRICKS_DEV}" ;;
+            *) ${WINETRICKS_SUDO} chmod 666 ${WINETRICKS_DEV} ;;
         esac
     fi
 
     while true; do
         # Wait for user to insert disc.
         # Sleep long to make it less likely to close the drive during insertion.
-        while ! dd if=$WINETRICKS_DEV of=/dev/null count=1; do
+        while ! dd if=${WINETRICKS_DEV} of=/dev/null count=1; do
             sleep 5
         done
 
@@ -4682,17 +4682,17 @@ winetricks_cache_iso()
             break
         fi
         # Otherwise try and read it straight from unmounted volume
-        _W_volname=$(winetricks_volname $WINETRICKS_DEV)
-        if test "$_W_expected_volname" != "$_W_volname"; then
-            case $LANG in
-                da*)  w_warn "Forkert disk [$_W_volname] indsat. Indsæt venligst disken [$_W_expected_volname]" ;;
-                de*)  w_warn "Falsche Disk [$_W_volname] eingelegt. Bitte legen Sie Disk [$_W_expected_volname] ein!" ;;
-                pl*)  w_warn "Umieszczono zły dysk [$_W_volname]. Proszę włożyć dysk [$_W_expected_volname]" ;;
-                ru*)  w_warn "Неверный диск [$_W_volname]. Пожалуйста, вставьте диск [$_W_expected_volname]" ;;
-                uk*)  w_warn "Неправильний диск [$_W_volname]. Будь ласка, вставте диск [$_W_expected_volname]" ;;
-                zh_CN*)    w_warn " [$_W_volname] 光盘插入错误，请插入光盘 [$_W_expected_volname]" ;;
-                zh_TW*|zh_HK*)    w_warn " [$_W_volname] 光碟插入錯誤，請插入光碟 [$_W_expected_volname]" ;;
-                *)    w_warn "Wrong disc [$_W_volname] inserted.  Please insert disc [$_W_expected_volname]" ;;
+        _W_volname=$(winetricks_volname ${WINETRICKS_DEV})
+        if test "${_W_expected_volname}" != "${_W_volname}"; then
+            case ${LANG} in
+                da*)  w_warn "Forkert disk [${_W_volname}] indsat. Indsæt venligst disken [${_W_expected_volname}]" ;;
+                de*)  w_warn "Falsche Disk [${_W_volname}] eingelegt. Bitte legen Sie Disk [${_W_expected_volname}] ein!" ;;
+                pl*)  w_warn "Umieszczono zły dysk [${_W_volname}]. Proszę włożyć dysk [${_W_expected_volname}]" ;;
+                ru*)  w_warn "Неверный диск [${_W_volname}]. Пожалуйста, вставьте диск [${_W_expected_volname}]" ;;
+                uk*)  w_warn "Неправильний диск [${_W_volname}]. Будь ласка, вставте диск [${_W_expected_volname}]" ;;
+                zh_CN*)    w_warn " [${_W_volname}] 光盘插入错误，请插入光盘 [${_W_expected_volname}]" ;;
+                zh_TW*|zh_HK*)    w_warn " [${_W_volname}] 光碟插入錯誤，請插入光碟 [${_W_expected_volname}]" ;;
+                *)    w_warn "Wrong disc [${_W_volname}] inserted.  Please insert disc [${_W_expected_volname}]" ;;
             esac
 
             sleep 10
@@ -4703,48 +4703,48 @@ winetricks_cache_iso()
 
     # Copy disc to .iso file, display progress every 5 seconds
     # Use conv=noerror,sync to replace unreadable blocks with zeroes
-    case $WINETRICKS_OPT_DD in
+    case ${WINETRICKS_OPT_DD} in
         dd)
-          $WINETRICKS_OPT_DD if=$WINETRICKS_DEV of="$W_CACHE"/temp.iso bs=2048 conv=noerror,sync &
+          ${WINETRICKS_OPT_DD} if=${WINETRICKS_DEV} of="${W_CACHE}"/temp.iso bs=2048 conv=noerror,sync &
           WINETRICKS_DD_PID=$!
           ;;
         ddrescue)
           if [ ! -x "$(command -v ddrescue)" ]; then
               w_die "Please install ddrescue first."
           fi
-          $WINETRICKS_OPT_DD -v -b 2048 $WINETRICKS_DEV "$W_CACHE"/temp.iso &
+          ${WINETRICKS_OPT_DD} -v -b 2048 ${WINETRICKS_DEV} "${W_CACHE}"/temp.iso &
           WINETRICKS_DD_PID=$!
           ;;
     esac
 
-    echo "$WINETRICKS_DD_PID" > "$WINETRICKS_WORKDIR"/dd-pid
+    echo "${WINETRICKS_DD_PID}" > "${WINETRICKS_WORKDIR}"/dd-pid
 
     # Note: if user presses ^C, winetricks_cleanup will call winetricks_iso_cleanup
     # FIXME: add progress bar for kde, too
-    case $WINETRICKS_GUI in
+    case ${WINETRICKS_GUI} in
         none|kdialog)
-            while ps -p "$WINETRICKS_DD_PID" > /dev/null 2>&1; do
+            while ps -p "${WINETRICKS_DD_PID}" > /dev/null 2>&1; do
                 sleep 5
-                ls -l "$W_CACHE"/temp.iso
+                ls -l "${W_CACHE}"/temp.iso
             done
             ;;
         zenity)
-            while ps -p "$WINETRICKS_DD_PID" > /dev/null 2>&1; do
+            while ps -p "${WINETRICKS_DD_PID}" > /dev/null 2>&1; do
                 echo 1
                 sleep 2
-            done | $WINETRICKS_GUI --title "Copying to $_W_expected_volname.iso" --progress --pulsate --auto-kill
+            done | ${WINETRICKS_GUI} --title "Copying to ${_W_expected_volname}.iso" --progress --pulsate --auto-kill
             ;;
     esac
-    rm "$WINETRICKS_WORKDIR"/dd-pid
+    rm "${WINETRICKS_WORKDIR}"/dd-pid
 
-    mv "$W_CACHE"/temp.iso "$WINETRICKS_IMG"
+    mv "${W_CACHE}"/temp.iso "${WINETRICKS_IMG}"
 
-    eject $WINETRICKS_DEV || true    # punt if eject not found (as on cygwin)
+    eject ${WINETRICKS_DEV} || true    # punt if eject not found (as on cygwin)
 }
 
 winetricks_load_vcdmount()
 {
-    if test "$WINE" != ""; then
+    if test "${WINE}" != ""; then
         return
     fi
 
@@ -4758,18 +4758,18 @@ winetricks_load_vcdmount()
 
     # Locate vcdmount.exe.
     VCD_DIR="Elaborate Bytes/VirtualCloneDrive"
-    if test ! -x "$W_PROGRAMS_UNIX/$VCD_DIR/vcdmount.exe" && test ! -x "$W_PROGRAMS_X86_UNIX/$VCD_DIR/vcdmount.exe"; then
+    if test ! -x "${W_PROGRAMS_UNIX}/${VCD_DIR}/vcdmount.exe" && test ! -x "${W_PROGRAMS_X86_UNIX}/${VCD_DIR}/vcdmount.exe"; then
         w_warn "Installing Virtual CloneDrive"
         w_download_to vcd http://static.slysoft.com/SetupVirtualCloneDrive.exe
         # have to use cmd else vista won't let cygwin run .exe's?
-        chmod +x "$W_CACHE"/vcd/SetupVirtualCloneDrive.exe
-        w_try_cd "$W_CACHE/vcd"
+        chmod +x "${W_CACHE}"/vcd/SetupVirtualCloneDrive.exe
+        w_try_cd "${W_CACHE}/vcd"
         cmd /c SetupVirtualCloneDrive.exe
     fi
-    if test -x "$W_PROGRAMS_UNIX/$VCD_DIR/vcdmount.exe"; then
-        VCD_DIR="$W_PROGRAMS_UNIX/$VCD_DIR"
-    elif test -x "$W_PROGRAMS_X86_UNIX/$VCD_DIR/vcdmount.exe"; then
-        VCD_DIR="$W_PROGRAMS_X86_UNIX/$VCD_DIR"
+    if test -x "${W_PROGRAMS_UNIX}/${VCD_DIR}/vcdmount.exe"; then
+        VCD_DIR="${W_PROGRAMS_UNIX}/${VCD_DIR}"
+    elif test -x "${W_PROGRAMS_X86_UNIX}/${VCD_DIR}/vcdmount.exe"; then
+        VCD_DIR="${W_PROGRAMS_X86_UNIX}/${VCD_DIR}"
     else
         w_die "can't find Virtual CloneDrive?"
     fi
@@ -4783,19 +4783,19 @@ winetricks_mount_cached_iso()
     # On entry, WINETRICKS_IMG is already set
     w_umount
 
-    if test "$WINE" = ""; then
+    if test "${WINE}" = ""; then
         winetricks_load_vcdmount
-        my_img_win="$(w_pathconv -w "$WINETRICKS_IMG" | tr '\012' ' ' | sed 's/ $//')"
-        w_try_cd "$VCD_DIR"
-        w_try vcdmount.exe /l="$letter" "$my_img_win"
+        my_img_win="$(w_pathconv -w "${WINETRICKS_IMG}" | tr '\012' ' ' | sed 's/ $//')"
+        w_try_cd "${VCD_DIR}"
+        w_try vcdmount.exe /l="${letter}" "${my_img_win}"
 
         tries=0
-        while test $tries -lt 20; do
+        while test ${tries} -lt 20; do
             for W_ISO_MOUNT_LETTER in e f g h i j k; do
                 # let user blacklist drive letters
-                echo "$WINETRICKS_MOUNT_LETTER_IGNORE" | grep -q "$W_ISO_MOUNT_LETTER" && continue
-                W_ISO_MOUNT_ROOT=/cygdrive/$W_ISO_MOUNT_LETTER
-                if find $W_ISO_MOUNT_ROOT -iname 'setup*' -o -iname '*.exe' -o -iname '*.msi'; then
+                echo "${WINETRICKS_MOUNT_LETTER_IGNORE}" | grep -q "${W_ISO_MOUNT_LETTER}" && continue
+                W_ISO_MOUNT_ROOT=/cygdrive/${W_ISO_MOUNT_LETTER}
+                if find ${W_ISO_MOUNT_ROOT} -iname 'setup*' -o -iname '*.exe' -o -iname '*.msi'; then
                     break 2
                 fi
             done
@@ -4804,45 +4804,45 @@ winetricks_mount_cached_iso()
             sleep 1
         done
     else
-        if test "$W_USE_USERMOUNT"; then
+        if test "${W_USE_USERMOUNT}"; then
             # Linux (FUSE-based tools), macOS (hdiutil)
-            if test "$WINETRICKS_ISO_MOUNT" = "none"; then
+            if test "${WINETRICKS_ISO_MOUNT}" = "none"; then
                 # If no tools found, fall back to sudo + mount
                 w_warn "No user mount tools detected, using sudo + mount"
                 unset W_USE_USERMOUNT
                 winetricks_mount_cached_iso
                 return
             fi
-            echo "Running mkdir -p $W_ISO_USER_MOUNT_ROOT"
-            mkdir -p "$W_ISO_USER_MOUNT_ROOT"
+            echo "Running mkdir -p ${W_ISO_USER_MOUNT_ROOT}"
+            mkdir -p "${W_ISO_USER_MOUNT_ROOT}"
             if test $? -ne 0; then
-                w_warn "mkdir -p $W_ISO_USER_MOUNT_ROOT failed, falling back to sudo + mount"
+                w_warn "mkdir -p ${W_ISO_USER_MOUNT_ROOT} failed, falling back to sudo + mount"
                 unset W_USE_USERMOUNT
                 winetricks_mount_cached_iso
                 return
             fi
-            case "$WINETRICKS_ISO_MOUNT" in
+            case "${WINETRICKS_ISO_MOUNT}" in
                 fuseiso)
-                    echo "Running $WINETRICKS_ISO_MOUNT $WINETRICKS_IMG $W_ISO_USER_MOUNT_ROOT"
-                    $WINETRICKS_ISO_MOUNT "$WINETRICKS_IMG" "$W_ISO_USER_MOUNT_ROOT"
+                    echo "Running ${WINETRICKS_ISO_MOUNT} ${WINETRICKS_IMG} ${W_ISO_USER_MOUNT_ROOT}"
+                    ${WINETRICKS_ISO_MOUNT} "${WINETRICKS_IMG}" "${W_ISO_USER_MOUNT_ROOT}"
                     ;;
                 archivemount)
-                    echo "Running $WINETRICKS_ISO_MOUNT $WINETRICKS_IMG $W_ISO_USER_MOUNT_ROOT -o readonly"
-                    $WINETRICKS_ISO_MOUNT "$WINETRICKS_IMG" "$W_ISO_USER_MOUNT_ROOT" -o readonly
+                    echo "Running ${WINETRICKS_ISO_MOUNT} ${WINETRICKS_IMG} ${W_ISO_USER_MOUNT_ROOT} -o readonly"
+                    ${WINETRICKS_ISO_MOUNT} "${WINETRICKS_IMG}" "${W_ISO_USER_MOUNT_ROOT}" -o readonly
                     ;;
                 hdiutil)
-                    echo "Running $WINETRICKS_ISO_MOUNT attach -mountpoint $W_ISO_USER_MOUNT_ROOT $WINETRICKS_IMG"
-                    $WINETRICKS_ISO_MOUNT attach -mountpoint "$W_ISO_USER_MOUNT_ROOT" "$WINETRICKS_IMG"
+                    echo "Running ${WINETRICKS_ISO_MOUNT} attach -mountpoint ${W_ISO_USER_MOUNT_ROOT} ${WINETRICKS_IMG}"
+                    ${WINETRICKS_ISO_MOUNT} attach -mountpoint "${W_ISO_USER_MOUNT_ROOT}" "${WINETRICKS_IMG}"
                     ;;
                 *)
-                    w_warn "Unknown ISO mount tool $WINETRICKS_ISO_MOUNT, using sudo + mount"
+                    w_warn "Unknown ISO mount tool ${WINETRICKS_ISO_MOUNT}, using sudo + mount"
                     unset W_USE_USERMOUNT
                     winetricks_mount_cached_iso
                     return
                     ;;
             esac
             if test $? -ne 0; then
-                w_warn "$WINETRICKS_ISO_MOUNT failed, falling back to sudo + mount"
+                w_warn "${WINETRICKS_ISO_MOUNT} failed, falling back to sudo + mount"
                 unset W_USE_USERMOUNT
                 winetricks_mount_cached_iso
                 return
@@ -4850,46 +4850,46 @@ winetricks_mount_cached_iso()
 
             echo "Mounting as drive ${W_ISO_MOUNT_LETTER}:"
             # Gotta provide a symlink to the raw disc, else installers that check volume names will fail
-            rm -f "$WINEPREFIX/dosdevices/${W_ISO_MOUNT_LETTER}:"*
-            ln -sf "$WINETRICKS_IMG" "$WINEPREFIX/dosdevices/${W_ISO_MOUNT_LETTER}::"
-            ln -sf "$W_ISO_USER_MOUNT_ROOT" "$WINEPREFIX/dosdevices/${W_ISO_MOUNT_LETTER}:"
+            rm -f "${WINEPREFIX}/dosdevices/${W_ISO_MOUNT_LETTER}:"*
+            ln -sf "${WINETRICKS_IMG}" "${WINEPREFIX}/dosdevices/${W_ISO_MOUNT_LETTER}::"
+            ln -sf "${W_ISO_USER_MOUNT_ROOT}" "${WINEPREFIX}/dosdevices/${W_ISO_MOUNT_LETTER}:"
             # Gotta set the type to "cdrom", else "wine eject" will fail
-            cat > "$W_TMP"/set_type_cdrom.reg <<_EOF_
+            cat > "${W_TMP}"/set_type_cdrom.reg <<_EOF_
 REGEDIT4
 
 [HKEY_LOCAL_MACHINE\\Software\\Wine\\Drives]
 "${W_ISO_MOUNT_LETTER}:"="cdrom"
 _EOF_
-            w_try_regedit "$W_TMP"/set_type_cdrom.reg
+            w_try_regedit "${W_TMP}"/set_type_cdrom.reg
             # The new drive is not recognized without waiting
             # FIXME: not sure if the duration is appropriate
             sleep 5
 
-            W_ISO_MOUNT_ROOT="$W_ISO_USER_MOUNT_ROOT"
+            W_ISO_MOUNT_ROOT="${W_ISO_USER_MOUNT_ROOT}"
         else
             # Linux (sudo + mount)
             _W_USERID=$(id -u)
             # WINETRICKS_IMG may contain spaces and needs to be quoted
-            case "$WINETRICKS_SUDO" in
+            case "${WINETRICKS_SUDO}" in
                 gksu*|kdesudo)
-                    w_try $WINETRICKS_SUDO "mkdir -p $W_ISO_MOUNT_ROOT"
-                    w_try $WINETRICKS_SUDO "mount -o ro,loop,uid=$_W_USERID,unhide '$WINETRICKS_IMG' $W_ISO_MOUNT_ROOT"
+                    w_try ${WINETRICKS_SUDO} "mkdir -p ${W_ISO_MOUNT_ROOT}"
+                    w_try ${WINETRICKS_SUDO} "mount -o ro,loop,uid=${_W_USERID},unhide '${WINETRICKS_IMG}' ${W_ISO_MOUNT_ROOT}"
                     ;;
                 kdesu)
-                    w_try $WINETRICKS_SUDO -c "mkdir -p $W_ISO_MOUNT_ROOT"
-                    w_try $WINETRICKS_SUDO -c "mount -o ro,loop,uid=$_W_USERID,unhide '$WINETRICKS_IMG' $W_ISO_MOUNT_ROOT"
+                    w_try ${WINETRICKS_SUDO} -c "mkdir -p ${W_ISO_MOUNT_ROOT}"
+                    w_try ${WINETRICKS_SUDO} -c "mount -o ro,loop,uid=${_W_USERID},unhide '${WINETRICKS_IMG}' ${W_ISO_MOUNT_ROOT}"
                     ;;
                 *)
-                    w_try $WINETRICKS_SUDO mkdir -p "$W_ISO_MOUNT_ROOT"
-                    w_try $WINETRICKS_SUDO mount -o ro,loop,uid="$_W_USERID",unhide "$WINETRICKS_IMG" "$W_ISO_MOUNT_ROOT"
+                    w_try ${WINETRICKS_SUDO} mkdir -p "${W_ISO_MOUNT_ROOT}"
+                    w_try ${WINETRICKS_SUDO} mount -o ro,loop,uid="${_W_USERID}",unhide "${WINETRICKS_IMG}" "${W_ISO_MOUNT_ROOT}"
                     ;;
             esac
 
             echo "Mounting as drive ${W_ISO_MOUNT_LETTER}:"
             # Gotta provide a symlink to the raw disc, else installers that check volume names will fail
-            rm -f "$WINEPREFIX/dosdevices/${W_ISO_MOUNT_LETTER}:"*
-            ln -sf "$WINETRICKS_IMG" "$WINEPREFIX/dosdevices/${W_ISO_MOUNT_LETTER}::"
-            ln -sf "$W_ISO_MOUNT_ROOT" "$WINEPREFIX/dosdevices/${W_ISO_MOUNT_LETTER}:"
+            rm -f "${WINEPREFIX}/dosdevices/${W_ISO_MOUNT_LETTER}:"*
+            ln -sf "${WINETRICKS_IMG}" "${WINEPREFIX}/dosdevices/${W_ISO_MOUNT_LETTER}::"
+            ln -sf "${W_ISO_MOUNT_ROOT}" "${WINEPREFIX}/dosdevices/${W_ISO_MOUNT_LETTER}:"
             unset _W_USERID
         fi
     fi
@@ -4916,35 +4916,35 @@ winetricks_is_mounted()
 {
     # First, check for matching mountpoint
     _W_tmp="$(winetricks_list_mounts "$1")"
-    if test "$_W_tmp"; then
-        _W_dev=$(echo "$_W_tmp" | sed 's/ .*//')
-        _W_mountpoint="$(echo "$_W_tmp" | sed 's/^[^ ]* //')"
+    if test "${_W_tmp}"; then
+        _W_dev=$(echo "${_W_tmp}" | sed 's/ .*//')
+        _W_mountpoint="$(echo "${_W_tmp}" | sed 's/^[^ ]* //')"
         # Volume found!
         return "${TRUE}"
     fi
 
     # If that fails, read volume name the hard way for each volume
     # Have to use file to return results from implicit subshell
-    rm -f "$W_TMP_EARLY/_W_tmp.$LOGNAME"
+    rm -f "${W_TMP_EARLY}/_W_tmp.${LOGNAME}"
     winetricks_list_mounts . | while true; do
         IFS= read -r _W_tmp
 
-        _W_dev=$(echo "$_W_tmp" | sed 's/ .*//')
-        test "$_W_dev" || break
-        _W_mountpoint="$(echo "$_W_tmp" | sed 's/^[^ ]* //')"
-        _W_volname=$(winetricks_volname "$_W_dev")
-        if test "$1" = "$_W_volname"; then
+        _W_dev=$(echo "${_W_tmp}" | sed 's/ .*//')
+        test "${_W_dev}" || break
+        _W_mountpoint="$(echo "${_W_tmp}" | sed 's/^[^ ]* //')"
+        _W_volname=$(winetricks_volname "${_W_dev}")
+        if test "$1" = "${_W_volname}"; then
             # Volume found!  Want to return from function here, but can't
-            echo "$_W_tmp" > "$W_TMP_EARLY/_W_tmp.$LOGNAME"
+            echo "${_W_tmp}" > "${W_TMP_EARLY}/_W_tmp.${LOGNAME}"
             break
         fi
     done
 
-    if test -f "$W_TMP_EARLY/_W_tmp.$LOGNAME"; then
+    if test -f "${W_TMP_EARLY}/_W_tmp.${LOGNAME}"; then
         # Volume found!  Return from function.
-        _W_dev=$(sed 's/ .*//' "$W_TMP_EARLY/_W_tmp.$LOGNAME")
-        _W_mountpoint="$(sed 's/^[^ ]* //' "$W_TMP_EARLY/_W_tmp.$LOGNAME")"
-        rm -f "$W_TMP_EARLY/_W_tmp.$LOGNAME"
+        _W_dev=$(sed 's/ .*//' "${W_TMP_EARLY}/_W_tmp.${LOGNAME}")
+        _W_mountpoint="$(sed 's/^[^ ]* //' "${W_TMP_EARLY}/_W_tmp.${LOGNAME}")"
+        rm -f "${W_TMP_EARLY}/_W_tmp.${LOGNAME}"
         return "${TRUE}"
     fi
 
@@ -4959,34 +4959,34 @@ winetricks_mount_real_volume()
 
     # Wait for user to insert disc.
 
-    case $LANG in
-        da*)_W_mountmsg="Indsæt venligst disken '$_W_expected_volname' (krævet af pakken '$W_PACKAGE')" ;;
-        de*)_W_mountmsg="Bitte Disk '$_W_expected_volname' einlegen (für Paket '$W_PACKAGE')" ;;
-        pl*)  _W_mountmsg="Proszę włożyć dysk '$_W_expected_volname' (potrzebny paczce '$W_PACKAGE')" ;;
-        ru*)  _W_mountmsg="Пожалуйста, вставьте том '$_W_expected_volname' (требуется для пакета '$W_PACKAGE')" ;;
-        uk*)  _W_mountmsg="Будь ласка, вставте том '$_W_expected_volname' (потрібний для пакунка '$W_PACKAGE')" ;;
-        zh_CN*)  _W_mountmsg="请插入卷 '$_W_expected_volname' (为包 '$W_PACKAGE 所需')" ;;
-        zh_TW*|zh_HK*)  _W_mountmsg="請插入卷 '$_W_expected_volname' (為包 '$W_PACKAGE 所需')" ;;
-        *)  _W_mountmsg="Please insert volume '$_W_expected_volname' (needed for package '$W_PACKAGE')" ;;
+    case ${LANG} in
+        da*)_W_mountmsg="Indsæt venligst disken '${_W_expected_volname}' (krævet af pakken '${W_PACKAGE}')" ;;
+        de*)_W_mountmsg="Bitte Disk '${_W_expected_volname}' einlegen (für Paket '${W_PACKAGE}')" ;;
+        pl*)  _W_mountmsg="Proszę włożyć dysk '${_W_expected_volname}' (potrzebny paczce '${W_PACKAGE}')" ;;
+        ru*)  _W_mountmsg="Пожалуйста, вставьте том '${_W_expected_volname}' (требуется для пакета '${W_PACKAGE}')" ;;
+        uk*)  _W_mountmsg="Будь ласка, вставте том '${_W_expected_volname}' (потрібний для пакунка '${W_PACKAGE}')" ;;
+        zh_CN*)  _W_mountmsg="请插入卷 '${_W_expected_volname}' (为包 '${W_PACKAGE} 所需')" ;;
+        zh_TW*|zh_HK*)  _W_mountmsg="請插入卷 '${_W_expected_volname}' (為包 '${W_PACKAGE} 所需')" ;;
+        *)  _W_mountmsg="Please insert volume '${_W_expected_volname}' (needed for package '${W_PACKAGE}')" ;;
     esac
 
-    if test "$WINE" = ""; then
+    if test "${WINE}" = ""; then
         # Assume already mounted, just get drive letter
         W_ISO_MOUNT_LETTER=$(awk '/iso/ {print $1}' < /proc/mounts | tr -d :)
         W_ISO_MOUNT_ROOT=$(awk '/iso/ {print $2}' < /proc/mounts)
     else
-        while ! winetricks_is_mounted "$_W_expected_volname"; do
-            w_try w_warn_cancel "$_W_mountmsg"
+        while ! winetricks_is_mounted "${_W_expected_volname}"; do
+            w_try w_warn_cancel "${_W_mountmsg}"
             # In non-gui case, give user two seconds to futz with disc drive before spamming him again
             sleep 2
         done
-        WINETRICKS_DEV=$_W_dev
-        W_ISO_MOUNT_ROOT="$_W_mountpoint"
+        WINETRICKS_DEV=${_W_dev}
+        W_ISO_MOUNT_ROOT="${_W_mountpoint}"
 
         # Gotta provide a symlink to the raw disc, else installers that check volume names will fail
-        rm -f "$WINEPREFIX/dosdevices/${W_ISO_MOUNT_LETTER}:"*
-        ln -sf "$WINETRICKS_DEV" "$WINEPREFIX/dosdevices/${W_ISO_MOUNT_LETTER}::"
-        ln -sf "$W_ISO_MOUNT_ROOT" "$WINEPREFIX/dosdevices/${W_ISO_MOUNT_LETTER}:"
+        rm -f "${WINEPREFIX}/dosdevices/${W_ISO_MOUNT_LETTER}:"*
+        ln -sf "${WINETRICKS_DEV}" "${WINEPREFIX}/dosdevices/${W_ISO_MOUNT_LETTER}::"
+        ln -sf "${W_ISO_MOUNT_ROOT}" "${WINEPREFIX}/dosdevices/${W_ISO_MOUNT_LETTER}:"
     fi
 
     # FIXME: need to remount some discs with unhide option,
@@ -4998,20 +4998,20 @@ winetricks_mount_real_volume()
 winetricks_cleanup()
 {
     # We don't want to run this multiple times, so unfortunately we have to run it here:
-    if test "$W_NGEN_CMD"; then
-        "$W_NGEN_CMD"
+    if test "${W_NGEN_CMD}"; then
+        "${W_NGEN_CMD}"
     fi
 
     set +e
-    if test -f "$WINETRICKS_WORKDIR/dd-pid"; then
+    if test -f "${WINETRICKS_WORKDIR}/dd-pid"; then
         # shellcheck disable=SC2046
-        kill $(cat "$WINETRICKS_WORKDIR/dd-pid")
+        kill $(cat "${WINETRICKS_WORKDIR}/dd-pid")
     fi
-    test "$WINETRICKS_CACHE_SYMLINK" && rm -f "$WINETRICKS_CACHE_SYMLINK"
-    test "$W_OPT_NOCLEAN" = 1 || rm -rf "$WINETRICKS_WORKDIR"
-    # if $W_TMP_EARLY was created by mktemp, remove it (but not if W_OPT_NOCLEAN is set to 1):
-    test "$W_OPT_NOCLEAN" = 1 || rm -rf "$W_TMP_EARLY"
-    test "$W_OPT_NOCLEAN" = 1 || rm -rf "$WINEPREFIX"/wrapper.cfg
+    test "${WINETRICKS_CACHE_SYMLINK}" && rm -f "${WINETRICKS_CACHE_SYMLINK}"
+    test "${W_OPT_NOCLEAN}" = 1 || rm -rf "${WINETRICKS_WORKDIR}"
+    # if ${W_TMP_EARLY} was created by mktemp, remove it (but not if W_OPT_NOCLEAN is set to 1):
+    test "${W_OPT_NOCLEAN}" = 1 || rm -rf "${W_TMP_EARLY}"
+    test "${W_OPT_NOCLEAN}" = 1 || rm -rf "${WINEPREFIX}"/wrapper.cfg
 }
 
 winetricks_set_unattended()
@@ -5023,7 +5023,7 @@ winetricks_set_unattended()
 }
 
 # Usage: winetricks_print_wineprefix_info
-# Print some useful info about $WINEPREFIX if things fail in winetricks_set_wineprefix()
+# Print some useful info about ${WINEPREFIX} if things fail in winetricks_set_wineprefix()
 winetricks_print_wineprefix_info()
 {
     printf "WINEPREFIX INFO:\\n"
@@ -5058,25 +5058,25 @@ winetricks_set_wineprefix()
     # Note: these are arch independent, but are needed by some arch dependent variables
     # Defining here to avoid having two arch checks:
     if ! test "$1"; then
-        WINEPREFIX="$WINETRICKS_ORIGINAL_WINEPREFIX"
+        WINEPREFIX="${WINETRICKS_ORIGINAL_WINEPREFIX}"
     else
-        WINEPREFIX="$W_PREFIXES_ROOT/$1"
+        WINEPREFIX="${W_PREFIXES_ROOT}/$1"
     fi
 
     export WINEPREFIX
-    w_try mkdir -p "$(dirname "$WINEPREFIX")"
+    w_try mkdir -p "$(dirname "${WINEPREFIX}")"
 
-    case "$W_PLATFORM" in
+    case "${W_PLATFORM}" in
         windows_cmd)
             W_DRIVE_C="/cygdrive/c" ;;
         *)
-            W_DRIVE_C="$WINEPREFIX/dosdevices/c:" ;;
+            W_DRIVE_C="${WINEPREFIX}/dosdevices/c:" ;;
     esac
-    W_WINDIR_UNIX="$W_DRIVE_C/windows"
+    W_WINDIR_UNIX="${W_DRIVE_C}/windows"
 
-    if [ ! -d "$WINEPREFIX" ] && [ -n "$WINEARCH" ]; then
-        w_info "Creating WINEPREFIX \"$WINEPREFIX\" with WINEARCH=$WINEARCH"
-        "$WINE" wineboot
+    if [ ! -d "${WINEPREFIX}" ] && [ -n "${WINEARCH}" ]; then
+        w_info "Creating WINEPREFIX \"${WINEPREFIX}\" with WINEARCH=${WINEARCH}"
+        "${WINE}" wineboot
     fi
 
     # Make sure the prefix is initialized:
@@ -5085,55 +5085,55 @@ winetricks_set_wineprefix()
     # Win(e) 32/64?
     # Using the variable W_SYSTEM32_DLLS instead of SYSTEM32 because some stuff does go under system32 for both arch's
     # e.g., spool/drivers/color
-    if test -d "$W_DRIVE_C/windows/syswow64"; then
+    if test -d "${W_DRIVE_C}/windows/syswow64"; then
         # Probably need fancier handling/checking, but for a basic start:
         # Note 'wine' may be named 'wine-stable'/'wine-staging'/etc.):
         # WINE64 = wine64, available on 64-bit prefixes
         # WINE_ARCH = the native wine for the prefix (wine for 32-bit, wine64 for 64-bit)
         # WINE_MULTI = generic wine, new name
-        if [ -n "$WINE64" ]; then
+        if [ -n "${WINE64}" ]; then
             true
-        elif [ "${WINE%??}64" = "$WINE" ]; then
+        elif [ "${WINE%??}64" = "${WINE}" ]; then
             WINE64="${WINE}"
         elif command -v "${WINE}64" >/dev/null 2>&1; then
             WINE64="${WINE}64"
         else
             # Handle case where wine binaries (or binary wrappers) have a suffix
-            WINE64="$(dirname "$WINE")/"
-            [ "$WINE64" = "./" ] && WINE64=""
-            WINE64="${WINE64}$(basename "$WINE" | sed 's/^wine/wine64/')"
+            WINE64="$(dirname "${WINE}")/"
+            [ "${WINE64}" = "./" ] && WINE64=""
+            WINE64="${WINE64}$(basename "${WINE}" | sed 's/^wine/wine64/')"
         fi
         WINE_ARCH="${WINE64}"
         WINE_MULTI="${WINE}"
         W_ARCH=win64
 
         W_PROGRAMS_WIN="$(w_expand_env ProgramFiles)"
-        W_PROGRAMS_UNIX="$(w_pathconv -u "$W_PROGRAMS_WIN")"
+        W_PROGRAMS_UNIX="$(w_pathconv -u "${W_PROGRAMS_WIN}")"
 
         # Common variable for 32-bit dlls on win32/win64:
-        W_SYSTEM32_DLLS="$W_WINDIR_UNIX/syswow64"
+        W_SYSTEM32_DLLS="${W_WINDIR_UNIX}/syswow64"
         W_SYSTEM32_DLLS_WIN="C:\\windows\\syswow64"
 
-        W_SYSTEM64_DLLS="$W_WINDIR_UNIX/system32"
+        W_SYSTEM64_DLLS="${W_WINDIR_UNIX}/system32"
         W_SYSTEM64_DLLS_WIN32="C:\\windows\\sysnative" # path to access 64-bit dlls from 32-bit apps
         W_SYSTEM64_DLLS_WIN64="C:\\windows\\system32"  # path to access 64-bit dlls from 64-bit apps
 
         # There's also ProgramW6432, which =%ProgramFiles%(but only available when running under a 64 bit OS)
         # See https://ss64.com/nt/syntax-variables.html
         W_PROGRAMW6432_WIN="$(w_expand_env ProgramW6432)"
-        W_PROGRAMW6432_UNIX="$(w_pathconv -u "$W_PROGRAMW6432_WIN")"
+        W_PROGRAMW6432_UNIX="$(w_pathconv -u "${W_PROGRAMW6432_WIN}")"
 
         # 64-bit Windows has a second directory for program files
         W_PROGRAMS_X86_WIN="${W_PROGRAMS_WIN} (x86)"
         W_PROGRAMS_X86_UNIX="${W_PROGRAMS_UNIX} (x86)"
 
         W_COMMONFILES_X86_WIN="$(w_expand_env CommonProgramFiles\(x86\))"
-        W_COMMONFILES_X86="$(w_pathconv -u "$W_COMMONFILES_X86_WIN")"
+        W_COMMONFILES_X86="$(w_pathconv -u "${W_COMMONFILES_X86_WIN}")"
         W_COMMONFILES_WIN="$(w_expand_env CommonProgramW6432)"
-        W_COMMONFILES="$(w_pathconv -u "$W_COMMONFILES_WIN")"
+        W_COMMONFILES="$(w_pathconv -u "${W_COMMONFILES_WIN}")"
 
         # 64-bit prefixes still have plenty of issues:
-        case $LANG in
+        case ${LANG} in
             ru*) w_warn "Вы используете 64-битный WINEPREFIX. Важно: многие ветки устанавливают только 32-битные версии пакетов. Если у вас возникли проблемы, пожалуйста, проверьте еще раз на чистом 32-битном WINEPREFIX до отправки отчета об ошибке." ;;
             *) w_warn "You are using a 64-bit WINEPREFIX. Note that many verbs only install 32-bit versions of packages. If you encounter problems, please retest in a clean 32-bit WINEPREFIX before reporting a bug." ;;
         esac
@@ -5144,10 +5144,10 @@ winetricks_set_wineprefix()
         W_ARCH=win32
 
         W_PROGRAMS_WIN="$(w_expand_env ProgramFiles)"
-        W_PROGRAMS_UNIX="$(w_pathconv -u "$W_PROGRAMS_WIN")"
+        W_PROGRAMS_UNIX="$(w_pathconv -u "${W_PROGRAMS_WIN}")"
 
         # Common variable for 32-bit dlls on win32/win64:
-        W_SYSTEM32_DLLS="$W_WINDIR_UNIX/system32"
+        W_SYSTEM32_DLLS="${W_WINDIR_UNIX}/system32"
         W_SYSTEM32_DLLS_WIN="C:\\windows\\system32"
 
         # These don't exist on win32, but are defined in case they are used on 32-bit.
@@ -5160,45 +5160,45 @@ winetricks_set_wineprefix()
         W_PROGRAMS_X86_UNIX="${W_PROGRAMS_UNIX}"
 
         W_COMMONFILES_X86_WIN="$(w_expand_env CommonProgramFiles)"
-        W_COMMONFILES_X86="$(w_pathconv -u "$W_COMMONFILES_X86_WIN")"
+        W_COMMONFILES_X86="$(w_pathconv -u "${W_COMMONFILES_X86_WIN}")"
         W_COMMONFILES_WIN="$(w_expand_env CommonProgramFiles)"
-        W_COMMONFILES="$(w_pathconv -u "$W_COMMONFILES_WIN")"
+        W_COMMONFILES="$(w_pathconv -u "${W_COMMONFILES_WIN}")"
     fi
 
     ## Arch independent variables:
 
     # Note: using AppData since it's arch indepedent
     W_APPDATA_WIN="$(w_expand_env AppData)"
-    W_APPDATA_UNIX="$(w_pathconv -u "$W_APPDATA_WIN")"
+    W_APPDATA_UNIX="$(w_pathconv -u "${W_APPDATA_WIN}")"
 
-    case "$W_APPDATA_WIN" in
-        "") w_info "$(winetricks_print_wineprefix_info)" ; w_die "$WINE cmd.exe /c echo '%AppData%' returned empty string, error message \"$(cat $W_TMP_EARLY/early_wine.err.txt)\" ";;
-        %*) w_info "$(winetricks_print_wineprefix_info)" ; w_die "$WINE cmd.exe /c echo '%AppData%' returned unexpanded string '$W_PROGRAMS_WIN' ... this can be caused by a corrupt wineprefix (\`wineboot -u\` may help), by an old wine, or by not owning $WINEPREFIX" ;;
+    case "${W_APPDATA_WIN}" in
+        "") w_info "$(winetricks_print_wineprefix_info)" ; w_die "${WINE} cmd.exe /c echo '%AppData%' returned empty string, error message \"$(cat ${W_TMP_EARLY}/early_wine.err.txt)\" ";;
+        %*) w_info "$(winetricks_print_wineprefix_info)" ; w_die "${WINE} cmd.exe /c echo '%AppData%' returned unexpanded string '${W_PROGRAMS_WIN}' ... this can be caused by a corrupt wineprefix (\`wineboot -u\` may help), by an old wine, or by not owning ${WINEPREFIX}" ;;
     esac
 
     # Kludge: use Temp instead of temp to avoid \t expansion in w_try
     # but use temp in Unix path because that's what Wine creates, and having both temp and Temp
     # causes confusion (e.g. makes vc2005trial fail)
     if ! test "$1"; then
-        W_TMP="$W_DRIVE_C/windows/temp"
+        W_TMP="${W_DRIVE_C}/windows/temp"
         W_TMP_WIN="C:\\windows\\Temp"
     else
         # Verbs can rely on W_TMP being empty at entry, deleted after return, and a subdir of C:
-        W_TMP="$W_DRIVE_C/windows/temp/_$1"
+        W_TMP="${W_DRIVE_C}/windows/temp/_$1"
         W_TMP_WIN="C:\\windows\\Temp\\_$1"
     fi
 
-    case "$W_PLATFORM" in
-        "windows_cmd|wine_cmd") W_CACHE_WIN="$(w_pathconv -w "$W_CACHE")" ;;
+    case "${W_PLATFORM}" in
+        "windows_cmd|wine_cmd") W_CACHE_WIN="$(w_pathconv -w "${W_CACHE}")" ;;
         *)
             # For case where Z: doesn't exist or / is writable (!),
             # make a drive letter for W_CACHE. Clean it up on exit.
-            test "$WINETRICKS_CACHE_SYMLINK" && rm -f "$WINETRICKS_CACHE_SYMLINK"
+            test "${WINETRICKS_CACHE_SYMLINK}" && rm -f "${WINETRICKS_CACHE_SYMLINK}"
             for letter in y x w v u t s r q p o n m; do
-                if ! test -d "$WINEPREFIX"/dosdevices/${letter}:; then
-                    mkdir -p "$WINEPREFIX"/dosdevices
-                    WINETRICKS_CACHE_SYMLINK="$WINEPREFIX"/dosdevices/${letter}:
-                    ln -sf "$W_CACHE" "$WINETRICKS_CACHE_SYMLINK"
+                if ! test -d "${WINEPREFIX}"/dosdevices/${letter}:; then
+                    mkdir -p "${WINEPREFIX}"/dosdevices
+                    WINETRICKS_CACHE_SYMLINK="${WINEPREFIX}"/dosdevices/${letter}:
+                    ln -sf "${W_CACHE}" "${WINETRICKS_CACHE_SYMLINK}"
                     break
                 fi
             done
@@ -5206,7 +5206,7 @@ winetricks_set_wineprefix()
             ;;
     esac
 
-    W_WINDIR_UNIX="$W_DRIVE_C/windows"
+    W_WINDIR_UNIX="${W_DRIVE_C}/windows"
 
     # FIXME: get fonts path from SHGetFolderPath
     # See also https://blogs.msdn.microsoft.com/oldnewthing/20031103-00/?p=41973/
@@ -5214,10 +5214,10 @@ winetricks_set_wineprefix()
 
     # FIXME: just convert path from Windows to Unix?
     # Did the user rename Fonts to fonts?
-    if test ! -d "$W_WINDIR_UNIX"/Fonts && test -d "$W_WINDIR_UNIX"/fonts; then
-        W_FONTSDIR_UNIX="$W_WINDIR_UNIX"/fonts
+    if test ! -d "${W_WINDIR_UNIX}"/Fonts && test -d "${W_WINDIR_UNIX}"/fonts; then
+        W_FONTSDIR_UNIX="${W_WINDIR_UNIX}"/fonts
     else
-        W_FONTSDIR_UNIX="$W_WINDIR_UNIX"/Fonts
+        W_FONTSDIR_UNIX="${W_WINDIR_UNIX}"/Fonts
     fi
     mkdir -p "${W_FONTSDIR_UNIX}"
 
@@ -5232,26 +5232,26 @@ winetricks_annihilate_wineprefix()
 {
     w_skip_windows "No wineprefix to delete on windows" && return
 
-    case $LANG in
-        uk*) w_askpermission "Бажаєте видалити '$WINEPREFIX'?" ;;
-        pl*) w_askpermission "Czy na pewno chcesz usunąć prefiks $WINEPREFIX i wszystkie jego elementy?" ;;
-        *) w_askpermission "Delete $WINEPREFIX, its apps, icons, and menu items?" ;;
+    case ${LANG} in
+        uk*) w_askpermission "Бажаєте видалити '${WINEPREFIX}'?" ;;
+        pl*) w_askpermission "Czy na pewno chcesz usunąć prefiks ${WINEPREFIX} i wszystkie jego elementy?" ;;
+        *) w_askpermission "Delete ${WINEPREFIX}, its apps, icons, and menu items?" ;;
     esac
 
-    rm -rf "$WINEPREFIX"
+    rm -rf "${WINEPREFIX}"
 
     # Also remove menu items.
-    find "$XDG_DATA_HOME/applications" -type f -name '*.desktop' -exec grep -q -l "$WINEPREFIX" '{}' ';' -exec rm '{}' ';'
+    find "${XDG_DATA_HOME}/applications" -type f -name '*.desktop' -exec grep -q -l "${WINEPREFIX}" '{}' ';' -exec rm '{}' ';'
 
     # Also remove desktop items.
     # Desktop might be synonym for home directory, so only go one level
     # deep to avoid extreme slowdown if user has lots of files
     (
-    if ! test "$XDG_DESKTOP_DIR" && test -f "$XDG_CONFIG_HOME/user-dirs.dirs"; then
+    if ! test "${XDG_DESKTOP_DIR}" && test -f "${XDG_CONFIG_HOME}/user-dirs.dirs"; then
         # shellcheck disable=SC1090
-        . "$XDG_CONFIG_HOME/user-dirs.dirs"
+        . "${XDG_CONFIG_HOME}/user-dirs.dirs"
     fi
-    find "$XDG_DESKTOP_DIR" -maxdepth 1 -type f -name '*.desktop' -exec grep -q -l "$WINEPREFIX" '{}' ';' -exec rm '{}' ';'
+    find "${XDG_DESKTOP_DIR}" -maxdepth 1 -type f -name '*.desktop' -exec grep -q -l "${WINEPREFIX}" '{}' ';' -exec rm '{}' ';'
     )
 
     # FIXME: recover more nicely.  At moment, have to restart to avoid trouble.
@@ -5262,13 +5262,13 @@ winetricks_init()
 {
     #---- Private Variables ----
 
-    if ! test "$USERNAME"; then
+    if ! test "${USERNAME}"; then
         # Posix only requires LOGNAME to be defined, and sure enough, when
         # logging in via console and startx in Ubuntu 11.04, USERNAME isn't set!
         # And even normal logins in Ubuntu 13.04 doesn't set it.
         # I tried using only LOGNAME in this script, but it's so easy to slip
         # and use USERNAME, so define it here if needed.
-        USERNAME="$LOGNAME"
+        USERNAME="${LOGNAME}"
     fi
 
     # Running Wine as root is (generally) bad, mmkay?
@@ -5277,16 +5277,16 @@ winetricks_init()
     fi
 
     # Ephemeral files for this run
-    WINETRICKS_WORKDIR="$W_TMP_EARLY/w.$LOGNAME.$$"
-    test "$W_OPT_NOCLEAN" = 1 || rm -rf "$WINETRICKS_WORKDIR"
+    WINETRICKS_WORKDIR="${W_TMP_EARLY}/w.${LOGNAME}.$$"
+    test "${W_OPT_NOCLEAN}" = 1 || rm -rf "${WINETRICKS_WORKDIR}"
 
     # Registering a verb creates a file in WINETRICKS_METADATA
-    WINETRICKS_METADATA="$WINETRICKS_WORKDIR/metadata"
+    WINETRICKS_METADATA="${WINETRICKS_WORKDIR}/metadata"
 
     # The list of categories is also hardcoded in winetricks_mainmenu() :-(
     WINETRICKS_CATEGORIES="apps benchmarks dlls fonts games settings mkprefix"
-    for _W_cat in $WINETRICKS_CATEGORIES; do
-        mkdir -p "$WINETRICKS_METADATA/$_W_cat"
+    for _W_cat in ${WINETRICKS_CATEGORIES}; do
+        mkdir -p "${WINETRICKS_METADATA}/${_W_cat}"
     done
 
     # Which subdirectory of WINETRICKS_METADATA is currently active (or main, if none)
@@ -5315,34 +5315,34 @@ winetricks_init()
     # See https://standards.freedesktop.org/basedir-spec/latest/ar01s03.html
     # OSX: https://developer.apple.com/library/content/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/MacOSXDirectories/MacOSXDirectories.html
 
-    if test -d "$HOME/Library"; then
+    if test -d "${HOME}/Library"; then
         # OS X
-        XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/Library/Caches}"
-        XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/Library/Preferences}"
+        XDG_CACHE_HOME="${XDG_CACHE_HOME:-${HOME}/Library/Caches}"
+        XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-${HOME}/Library/Preferences}"
     else
-        XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
-        XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+        XDG_CACHE_HOME="${XDG_CACHE_HOME:-${HOME}/.cache}"
+        XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-${HOME}/.config}"
     fi
 
     # shellcheck disable=SC2153
-    if test "$WINETRICKS_DIR"; then
+    if test "${WINETRICKS_DIR}"; then
         # For backwards compatibility
-        W_CACHE="${W_CACHE:-$WINETRICKS_DIR/cache}"
-        WINETRICKS_POST="${WINETRICKS_POST:-$WINETRICKS_DIR/postinstall}"
+        W_CACHE="${W_CACHE:-${WINETRICKS_DIR}/cache}"
+        WINETRICKS_POST="${WINETRICKS_POST:-${WINETRICKS_DIR}/postinstall}"
     else
-        W_CACHE="${W_CACHE:-$XDG_CACHE_HOME/winetricks}"
-        WINETRICKS_POST="${WINETRICKS_POST:-$XDG_DATA_HOME/winetricks/postinstall}"
+        W_CACHE="${W_CACHE:-${XDG_CACHE_HOME}/winetricks}"
+        WINETRICKS_POST="${WINETRICKS_POST:-${XDG_DATA_HOME}/winetricks/postinstall}"
     fi
 
-    WINETRICKS_AUTH="${WINETRICKS_AUTH:-$XDG_DATA_HOME/winetricks/auth}"
+    WINETRICKS_AUTH="${WINETRICKS_AUTH:-${XDG_DATA_HOME}/winetricks/auth}"
 
     # Config options are currently opt-in and not required, so not creating the config
     # directory unless there's demand:
     WINETRICKS_CONFIG="${XDG_CONFIG_HOME}/winetricks"
-    #test -d "$WINETRICKS_CONFIG" || mkdir -p "$WINETRICKS_CONFIG"
+    #test -d "${WINETRICKS_CONFIG}" || mkdir -p "${WINETRICKS_CONFIG}"
 
     # Load country code from config file only when "--country=" option is not specified
-    if test -z "$W_COUNTRY" -a -f "${WINETRICKS_CONFIG}"/country; then
+    if test -z "${W_COUNTRY}" -a -f "${WINETRICKS_CONFIG}"/country; then
         W_COUNTRY="$(cat "${WINETRICKS_CONFIG}"/country)"
     fi
 
@@ -5373,7 +5373,7 @@ winetricks_init()
 winetricks_wine_setup()
 {
     # This used to be part of winetricks_init(), factored out because not everything needs Wine.
-    if [ -n "$_W_wine_not_needed" ]; then
+    if [ -n "${_W_wine_not_needed}" ]; then
         # no-op
         :
         return
@@ -5383,12 +5383,12 @@ winetricks_wine_setup()
 
     # Overridden for windows
     W_ISO_MOUNT_ROOT=/mnt/winetricks
-    W_ISO_USER_MOUNT_ROOT="$HOME"/winetricks-iso
+    W_ISO_USER_MOUNT_ROOT="${HOME}"/winetricks-iso
     W_ISO_MOUNT_LETTER=i
 
     ######################
     # System-specific variables
-    case "$W_PLATFORM" in
+    case "${W_PLATFORM}" in
         windows_cmd)
             WINE=""
             WINE64=""
@@ -5402,10 +5402,10 @@ winetricks_wine_setup()
             # Find wineserver.
             # Some distributions (Debian before wine 1.8-2) don't have it on the path.
             for x in \
-                "$WINESERVER" \
+                "${WINESERVER}" \
                 "${WINE}server" \
                 "$(command -v wineserver 2> /dev/null)" \
-                "$(dirname "$WINE")/server/wineserver" \
+                "$(dirname "${WINE}")/server/wineserver" \
                 /usr/bin/wineserver-development \
                 /usr/lib/wine/wineserver \
                 /usr/lib/i386-kfreebsd-gnu/wine/wineserver \
@@ -5421,8 +5421,8 @@ winetricks_wine_setup()
                 /usr/lib/x86_64-linux-gnu/wine-development/wineserver \
                 file-not-found; do
 
-                if test -x "$x"; then
-                    case "$x" in
+                if test -x "${x}"; then
+                    case "${x}" in
                         /usr/lib/*/wine-development/wineserver|/usr/bin/wineserver-development)
                             if test -x /usr/bin/wine-development; then
                                 WINE="/usr/bin/wine-development"
@@ -5433,19 +5433,19 @@ winetricks_wine_setup()
                 fi
             done
 
-                case "$x" in
+                case "${x}" in
                     file-not-found) w_die "wineserver not found!" ;;
-                    *) WINESERVER="$x" ;;
+                    *) WINESERVER="${x}" ;;
                 esac
 
-                if test "$WINEPREFIX"; then
-                    WINETRICKS_ORIGINAL_WINEPREFIX="$WINEPREFIX"
+                if test "${WINEPREFIX}"; then
+                    WINETRICKS_ORIGINAL_WINEPREFIX="${WINEPREFIX}"
                 else
-                    WINETRICKS_ORIGINAL_WINEPREFIX="$HOME/.wine"
+                    WINETRICKS_ORIGINAL_WINEPREFIX="${HOME}/.wine"
                 fi
-                _abswine="$(command -v "$WINE" 2>/dev/null)"
-                if ! test -x "$_abswine" || ! test -f "$_abswine"; then
-                    w_die "WINE is $WINE, which is neither on the path nor an executable file"
+                _abswine="$(command -v "${WINE}" 2>/dev/null)"
+                if ! test -x "${_abswine}" || ! test -f "${_abswine}"; then
+                    w_die "WINE is ${WINE}, which is neither on the path nor an executable file"
                 fi
                 unset _abswine
                 ;;
@@ -5461,24 +5461,24 @@ winetricks_wine_setup()
     # wine-2.0 (Debian 2.0-1)
     # wine-2.0-rc1
     # wine-2.8
-    _wine_version_stripped="$(echo "$WINETRICKS_WINE_VERSION" | cut -d ' ' -f1 | sed -e 's/wine-//' -e 's/-rc.*//')"
+    _wine_version_stripped="$(echo "${WINETRICKS_WINE_VERSION}" | cut -d ' ' -f1 | sed -e 's/wine-//' -e 's/-rc.*//')"
 
     # If WINE is < 4.0, warn user:
     # 4.0 doesn't do what I thought it would
     if w_wine_version_in 3.99, ; then
-        w_warn "Your version of wine $_wine_version_stripped is no longer supported upstream. You should upgrade to 4.x"
+        w_warn "Your version of wine ${_wine_version_stripped} is no longer supported upstream. You should upgrade to 4.x"
     fi
 
     winetricks_set_wineprefix "$1"
 
-    if [ -z "$WINETRICKS_SUPER_QUIET" ] ; then
+    if [ -z "${WINETRICKS_SUPER_QUIET}" ] ; then
         echo "Using winetricks $(winetricks_print_version) with ${WINETRICKS_ORIG_WINE_VERSION} and WINEARCH=${W_ARCH}"
     fi
 }
 
 winetricks_usage()
 {
-    case $LANG in
+    case ${LANG} in
         da*)
             cat <<_EOF_
 Brug: $0 [tilvalg] [verbum|sti-til-verbum] ...
@@ -5516,7 +5516,7 @@ list-installed        list already-installed applications
 arch=32|64            create wineprefix with 32 or 64 bit, this option must be
                       given before prefix=foobar and will not work in case of
                       the default wineprefix.
-prefix=foobar         select WINEPREFIX=$W_PREFIXES_ROOT/foobar
+prefix=foobar         select WINEPREFIX=${W_PREFIXES_ROOT}/foobar
 annihilate            Delete ALL DATA AND APPLICATIONS INSIDE THIS WINEPREFIX
 _EOF_
             ;;
@@ -5559,7 +5559,7 @@ list-installed        Bereits installierte Verben auflisten
 arch=32|64            Neues wineprefix mit 32 oder 64 bit erstellen, diese Option
                       muss vor prefix=foobar angegeben werden und funktioniert
                       nicht im Falle des Standard Wineprefix.
-prefix=foobar         WINEPREFIX=$W_PREFIXES_ROOT/foobar auswählen
+prefix=foobar         WINEPREFIX=${W_PREFIXES_ROOT}/foobar auswählen
 annihilate            ALLE DATEIEN UND PROGRAMME IN DIESEM WINEPREFIX Löschen
 _EOF_
             ;;
@@ -5601,7 +5601,7 @@ list-installed        list already-installed verbs
 arch=32|64            create wineprefix with 32 or 64 bit, this option must be
                       given before prefix=foobar and will not work in case of
                       the default wineprefix.
-prefix=foobar         select WINEPREFIX=$W_PREFIXES_ROOT/foobar
+prefix=foobar         select WINEPREFIX=${W_PREFIXES_ROOT}/foobar
 annihilate            Delete ALL DATA AND APPLICATIONS INSIDE THIS WINEPREFIX
 _EOF_
             ;;
@@ -5638,13 +5638,13 @@ winetricks_handle_option()
 }
 
 # Test whether temporary directory is valid - before initialising script
-[ -d "$W_TMP_EARLY" ] || w_die "temporary directory: '$W_TMP_EARLY' ; does not exist"
-[ -w "$W_TMP_EARLY" ] || w_die "temporary directory: '$W_TMP_EARLY' ; is not user writeable"
+[ -d "${W_TMP_EARLY}" ] || w_die "temporary directory: '${W_TMP_EARLY}' ; does not exist"
+[ -w "${W_TMP_EARLY}" ] || w_die "temporary directory: '${W_TMP_EARLY}' ; is not user writeable"
 
 # Must initialize variables before calling w_metadata
-if ! test "$WINETRICKS_LIB"; then
+if ! test "${WINETRICKS_LIB}"; then
     WINETRICKS_SRCDIR=$(dirname "$0")
-    WINETRICKS_SRCDIR=$(w_try_cd "$WINETRICKS_SRCDIR"; pwd)
+    WINETRICKS_SRCDIR=$(w_try_cd "${WINETRICKS_SRCDIR}"; pwd)
 
     # Which GUI helper to use (none/zenity/kdialog).  See winetricks_detect_gui.
     WINETRICKS_GUI=none
@@ -5665,8 +5665,8 @@ if ! test "$WINETRICKS_LIB"; then
 
     # Workaround for https://github.com/Winetricks/winetricks/issues/599
     # If --isolate is used, pass verb to winetricks_init, so it can set the wineprefix using winetricks_set_wineprefix()
-    # Otherwise, an arch mismatch between ${WINEPREFIX:-$HOME/.wine} and the prefix to be made for the isolated app would cause it to fail
-    case $WINETRICKS_OPT_SHAREDPREFIX in
+    # Otherwise, an arch mismatch between ${WINEPREFIX:-${HOME}/.wine} and the prefix to be made for the isolated app would cause it to fail
+    case ${WINETRICKS_OPT_SHAREDPREFIX} in
         0) winetricks_init "$1" ;;
         *) winetricks_init ;;
     esac
@@ -5674,7 +5674,7 @@ fi
 
 winetricks_install_app()
 {
-    case $LANG in
+    case ${LANG} in
         da*) fail_msg="Installationen af pakken $1 fejlede" ;;
         de*) fail_msg="Installieren von Paket $1 gescheitert" ;;
         pl*) fail_msg="Niepowodzenie przy instalacji paczki $1" ;;
@@ -5687,18 +5687,18 @@ winetricks_install_app()
 
     # FIXME: initialize a new wineprefix for this app, set lots of global variables
     if ! w_do_call "$1" "$2"; then
-        w_die "$fail_msg"
+        w_die "${fail_msg}"
     fi
 }
 
 winetricks_verify()
 {
-    "verify_$cmd" 2>/dev/null
+    "verify_${cmd}" 2>/dev/null
     verify_status=$?
-    case $verify_status in
-        0) w_warn "verify_$cmd succeeded!" ;;
-        127) echo "verify_$cmd not found, not verifying $cmd" ;;
-        *) w_die "verify_$cmd failed!" ;;
+    case ${verify_status} in
+        0) w_warn "verify_${cmd} succeeded!" ;;
+        127) echo "verify_${cmd} not found, not verifying ${cmd}" ;;
+        *) w_die "verify_${cmd} failed!" ;;
     esac
 }
 
@@ -5741,21 +5741,21 @@ helper_d3dx9_xx()
     helper_directx_Jun2010
 
     # Even kinder, less invasive directx - only extract and override d3dx9_xx.dll
-    w_try_cabextract -d "$W_TMP" -L -F "*$dllname*x86*" "$W_CACHE"/directx9/$DIRECTX_NAME
+    w_try_cabextract -d "${W_TMP}" -L -F "*${dllname}*x86*" "${W_CACHE}"/directx9/${DIRECTX_NAME}
 
-    for x in "$W_TMP"/*.cab; do
-      w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F "$dllname.dll" "$x"
+    for x in "${W_TMP}"/*.cab; do
+      w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F "${dllname}.dll" "${x}"
     done
 
-    if test "$W_ARCH" = "win64"; then
-        w_try_cabextract -d "$W_TMP" -L -F "*$dllname*x64*" "$W_CACHE"/directx9/$DIRECTX_NAME
+    if test "${W_ARCH}" = "win64"; then
+        w_try_cabextract -d "${W_TMP}" -L -F "*${dllname}*x64*" "${W_CACHE}"/directx9/${DIRECTX_NAME}
 
-        for x in "$W_TMP"/*x64.cab; do
-            w_try_cabextract -d "$W_SYSTEM64_DLLS" -L -F "$dllname.dll" "$x"
+        for x in "${W_TMP}"/*x64.cab; do
+            w_try_cabextract -d "${W_SYSTEM64_DLLS}" -L -F "${dllname}.dll" "${x}"
         done
     fi
 
-    w_override_dlls native "$dllname"
+    w_override_dlls native "${dllname}"
 }
 
 # Filelist at ./misc/filelists/vb6sp6.txt
@@ -5768,7 +5768,7 @@ helper_vb6sp6()
     shift
 
     w_download_to vb6sp6 https://download.microsoft.com/download/5/6/3/5635D6A9-885E-4C80-A2E7-8A7F4488FBF1/VB60SP6-KB2708437-x86-ENU.msi 350602b2e084b39c97d1394c8594b18e41ef622315d4a9635c5e8ea6aa977b5e
-    w_try_7z "$destdir" "$W_CACHE"/vb6sp6/VB60SP6-KB2708437-x86-ENU.msi "$@"
+    w_try_7z "${destdir}" "${W_CACHE}"/vb6sp6/VB60SP6-KB2708437-x86-ENU.msi "$@"
 }
 
 # Filelist at ./misc/filelists/win2ksp4.txt
@@ -5781,7 +5781,7 @@ helper_win2ksp4()
     # This URL doesn't need rename from w2ksp4_en.exe to W2KSP4_EN.EXE
     # to avoid users having to redownload for a file rename
     w_download_to win2ksp4 https://ftp.gnome.org/mirror/archive/ftp.sunet.se/pub/security/vendor/microsoft/win2000/Service_Packs/usa/W2KSP4_EN.EXE 167bb78d4adc957cc39fb4902517e1f32b1e62092353be5f8fb9ee647642de7e
-    w_try_cabextract -d "$W_TMP" -L -F "$filename" "$W_CACHE"/win2ksp4/W2KSP4_EN.EXE
+    w_try_cabextract -d "${W_TMP}" -L -F "${filename}" "${W_CACHE}"/win2ksp4/W2KSP4_EN.EXE
 }
 
 # Filelist at ./misc/filelists/winxpsp2_support_tools.txt
@@ -5792,8 +5792,8 @@ helper_winxpsp2_support_tools()
     # https://www.microsoft.com/en-us/download/details.aspx?id=18546
     w_download_to winxpsp2_support_tools https://download.microsoft.com/download/d/3/8/d38066aa-4e37-4ae8-bce3-a4ce662b2024/WindowsXP-KB838079-SupportTools-ENU.exe 7927e87af616d2fb8d4ead0db0103eb845a4e6651b20a5bffea9eebc3035c24d
 
-    w_try_cabextract -d "$W_TMP" -L -F support.cab "$W_CACHE"/winxpsp2_support_tools/WindowsXP-KB838079-SupportTools-ENU.exe
-    w_try_cabextract -d "$W_TMP" -L -F "$filename" "$W_TMP"/support.cab
+    w_try_cabextract -d "${W_TMP}" -L -F support.cab "${W_CACHE}"/winxpsp2_support_tools/WindowsXP-KB838079-SupportTools-ENU.exe
+    w_try_cabextract -d "${W_TMP}" -L -F "${filename}" "${W_TMP}"/support.cab
 }
 
 # Filelist at ./misc/filelists/winxpsp3.txt
@@ -5804,8 +5804,8 @@ helper_winxpsp3()
     # 2017/03/15: helper was renamed from winxpsp3 to winxpsp3, to match win2k/win7 service pack helpers
     # To minimize user impact, renaming directory automagically.
     # This could be removed after a transition period (1 year or so):
-    if [ -d "$W_CACHE/xpsp3" ] ; then
-        w_try mv "$W_CACHE/xpsp3" "$W_CACHE/winxpsp3"
+    if [ -d "${W_CACHE}/xpsp3" ] ; then
+        w_try mv "${W_CACHE}/xpsp3" "${W_CACHE}/winxpsp3"
     fi
 
     # Formerly at:
@@ -5815,7 +5815,7 @@ helper_winxpsp3()
     # 2018/04/04: http://www.download.windowsupdate.com/msdownload/update/software/dflt/2008/04/windowsxp-kb936929-sp3-x86-enu_c81472f7eeea2eca421e116cd4c03e2300ebfde4.exe
     w_download_to winxpsp3 https://ftp.gnome.org/mirror/archive/ftp.sunet.se/pub/security/vendor/microsoft/winxp/Service_Packs/WindowsXP-KB936929-SP3-x86-ENU.exe 62e524a552db9f6fd22d469010ea4d7e28ee06fa615a1c34362129f808916654
 
-    w_try_cabextract -d "$W_TMP" -L -F "$filename" "$W_CACHE"/winxpsp3/WindowsXP-KB936929-SP3-x86-ENU.exe
+    w_try_cabextract -d "${W_TMP}" -L -F "${filename}" "${W_CACHE}"/winxpsp3/WindowsXP-KB936929-SP3-x86-ENU.exe
 }
 
 # Filelist at ./misc/filelists/win7sp1.txt
@@ -5826,7 +5826,7 @@ helper_win7sp1()
     # https://www.microsoft.com/en-us/download/details.aspx?id=5842
     w_download_to win7sp1 https://download.microsoft.com/download/0/A/F/0AFB5316-3062-494A-AB78-7FB0D4461357/windows6.1-KB976932-X86.exe e5449839955a22fc4dd596291aff1433b998f9797e1c784232226aba1f8abd97
 
-    w_try_cabextract -d "$W_TMP" -L -F "$filename" "$W_CACHE"/win7sp1/windows6.1-KB976932-X86.exe
+    w_try_cabextract -d "${W_TMP}" -L -F "${filename}" "${W_CACHE}"/win7sp1/windows6.1-KB976932-X86.exe
 }
 
 # Filelist at ./misc/filelists/win7sp1_x64.txt
@@ -5837,7 +5837,7 @@ helper_win7sp1_x64()
     # https://www.microsoft.com/en-us/download/details.aspx?id=5842
     w_download_to win7sp1 https://download.microsoft.com/download/0/A/F/0AFB5316-3062-494A-AB78-7FB0D4461357/windows6.1-KB976932-X64.exe f4d1d418d91b1619688a482680ee032ffd2b65e420c6d2eaecf8aa3762aa64c8
 
-    w_try_cabextract -d "$W_TMP" -L -F "$filename" "$W_CACHE"/win7sp1/windows6.1-KB976932-X64.exe
+    w_try_cabextract -d "${W_TMP}" -L -F "${filename}" "${W_CACHE}"/win7sp1/windows6.1-KB976932-X64.exe
 }
 
 #######################
@@ -5852,7 +5852,7 @@ w_metadata adobeair dlls \
     year="2018" \
     media="download" \
     file1="AdobeAIRInstaller.exe" \
-    installed_file1="$W_COMMONFILES_X86_WIN/Adobe AIR/Versions/1.0/Adobe AIR.dll" \
+    installed_file1="${W_COMMONFILES_X86_WIN}/Adobe AIR/Versions/1.0/Adobe AIR.dll" \
     homepage="https://www.adobe.com/products/air/"
 
 load_adobeair()
@@ -5865,14 +5865,14 @@ load_adobeair()
     # 2018/12/22: 32.0.0.89 (strings 'Adobe AIR.dll' | grep -E "^32\..+\..+" ) sha256sum 24532d41ef2588c0daac4b6f8b7f863ee3c1a1b1e90b2d8d8b3eb4faa657e5e3
     # 2019/06/11: 32.0.0.125 (strings 'Adobe AIR.dll' | grep -E "^32\..+\..+" ) sha256sum 6718308e10a45176155d0ecc8458bd3606308925b91f26a7d08c148cf52c9db3
     w_download https://airdownload.adobe.com/air/win/download/latest/AdobeAIRInstaller.exe 6718308e10a45176155d0ecc8458bd3606308925b91f26a7d08c148cf52c9db3
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
     # See https://bugs.winehq.org/show_bug.cgi?id=43506
     # and https://github.com/Winetricks/winetricks/issues/821
     if w_workaround_wine_bug 43506 "Forcing quiet install"; then
-        w_try "$WINE" AdobeAIRInstaller.exe -silent
+        w_try "${WINE}" AdobeAIRInstaller.exe -silent
     else
-        w_try "$WINE" AdobeAIRInstaller.exe ${W_OPT_UNATTENDED:+-silent}
+        w_try "${WINE}" AdobeAIRInstaller.exe ${W_OPT_UNATTENDED:+-silent}
     fi
 }
 
@@ -5884,20 +5884,20 @@ w_metadata amstream dlls \
     year="2011" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/amstream.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/amstream.dll"
 
 load_amstream()
 {
     helper_win7sp1 x86_microsoft-windows-directshow-other_31bf3856ad364e35_6.1.7601.17514_none_0f58f1e53efca91e/amstream.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-directshow-other_31bf3856ad364e35_6.1.7601.17514_none_0f58f1e53efca91e/amstream.dll" "$W_SYSTEM32_DLLS/amstream.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-directshow-other_31bf3856ad364e35_6.1.7601.17514_none_0f58f1e53efca91e/amstream.dll" "${W_SYSTEM32_DLLS}/amstream.dll"
 
     w_override_dlls native,builtin amstream
 
     w_try_regsvr amstream.dll
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-directshow-other_31bf3856ad364e35_6.1.7601.17514_none_6b778d68f75a1a54/amstream.dll
-        w_try cp "$W_TMP/amd64_microsoft-windows-directshow-other_31bf3856ad364e35_6.1.7601.17514_none_6b778d68f75a1a54/amstream.dll" "$W_SYSTEM64_DLLS/amstream.dll"
+        w_try cp "${W_TMP}/amd64_microsoft-windows-directshow-other_31bf3856ad364e35_6.1.7601.17514_none_6b778d68f75a1a54/amstream.dll" "${W_SYSTEM64_DLLS}/amstream.dll"
         w_try_regsvr64 amstream.dll
     fi
 }
@@ -5910,7 +5910,7 @@ w_metadata art2kmin dlls \
     year="2007" \
     media="download" \
     file1="AccessRuntime.exe" \
-    installed_file1="$W_COMMONFILES_X86_WIN/Microsoft Shared/OFFICE12/ACEES.DLL"
+    installed_file1="${W_COMMONFILES_X86_WIN}/Microsoft Shared/OFFICE12/ACEES.DLL"
 
 load_art2kmin()
 {
@@ -5918,8 +5918,8 @@ load_art2kmin()
     # Originally at https://download.microsoft.com/download/D/2/A/D2A2FC8B-0447-491C-A5EF-E8AA3A74FB98/AccessRuntime.exe
     # 2019/11/22: moved to https://www.fmsinc.com/microsoftaccess/runtime/AccessRuntime2007.exe
     w_download https://www.fmsinc.com/microsoftaccess/runtime/AccessRuntime2007.exe a00a92fdc4ddc0dcf5d1964214a8d7e4c61bb036908a4b43b3700063eda9f4fb AccessRuntime.exe
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" AccessRuntime.exe ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" AccessRuntime.exe ${W_OPT_UNATTENDED:+/q}
 }
 
 #----------------------------------------------------------------
@@ -5930,12 +5930,12 @@ w_metadata atmlib dlls \
     year="2009" \
     media="download" \
     file1="../win2ksp4/W2KSP4_EN.EXE" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/atmlib.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/atmlib.dll"
 
 load_atmlib()
 {
     helper_win2ksp4 i386/atmlib.dl_
-    w_try_cabextract --directory="$W_SYSTEM32_DLLS" "$W_TMP"/i386/atmlib.dl_
+    w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_TMP}"/i386/atmlib.dl_
 }
 
 #----------------------------------------------------------------
@@ -5946,12 +5946,12 @@ w_metadata avifil32 dlls \
     year="2004" \
     media="download" \
     file1="../winxpsp3/WindowsXP-KB936929-SP3-x86-ENU.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/avifil32.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/avifil32.dll"
 
 load_avifil32()
 {
     helper_winxpsp3 i386/avifil32.dl_
-    w_try_cabextract --directory="$W_SYSTEM32_DLLS" "$W_TMP"/i386/avifil32.dl_
+    w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_TMP}"/i386/avifil32.dl_
 
     w_override_dlls native avifil32
 }
@@ -5964,7 +5964,7 @@ w_metadata cabinet dlls \
     year="2002" \
     media="download" \
     file1="MDAC_TYP.EXE" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/cabinet.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/cabinet.dll"
 
 load_cabinet()
 {
@@ -5988,14 +5988,14 @@ w_metadata cmd dlls \
     year="2004" \
     media="download" \
     file1="Q811493_W2K_SP4_X86_EN.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/cmd.exe"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/cmd.exe"
 
 load_cmd()
 {
     # Originally at: https://download.microsoft.com/download/8/d/c/8dc79965-dfbc-4b25-9546-e23bc4b791c6/Q811493_W2K_SP4_X86_EN.exe
     # Mirror list: http://www.filewatcher.com/_/?q=Q811493_W2K_SP4_X86_EN.exe
     w_download https://ftp.gnome.org/mirror/archive/ftp.sunet.se/pub/security/vendor/microsoft/win2000/Security_Bulletins/Q811493_W2K_SP4_X86_EN.exe b5574b3516a724c2cba0d864162a3d1d684db1cf30de8db4b0e0ea6a1f6f1480
-    w_try_cabextract --directory="$W_SYSTEM32_DLLS" "$W_CACHE/$W_PACKAGE/$file1" -F cmd.exe
+    w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_CACHE}/${W_PACKAGE}/${file1}" -F cmd.exe
 
     w_override_dlls native,builtin cmd.exe
 }
@@ -6009,13 +6009,13 @@ w_metadata cnc_ddraw dlls \
     year="2018" \
     media="download" \
     file1="cnc-ddraw.zip" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/Shaders/readme.txt"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/Shaders/readme.txt"
 
 load_cnc_ddraw()
 {
     # Note: only works if ddraw.ini contains settings for the executable
     w_download https://github.com/CnCNet/cnc-ddraw/releases/download/1.3.4.0/cnc-ddraw.zip c1f85053223ab04a573cc482b43b93a58077e928a401f3364c9dc5542ad090ae
-    w_try_unzip "$W_SYSTEM32_DLLS" "$W_CACHE/$W_PACKAGE/$file1"
+    w_try_unzip "${W_SYSTEM32_DLLS}" "${W_CACHE}/${W_PACKAGE}/${file1}"
 
     w_override_dlls native,builtin ddraw
 }
@@ -6028,7 +6028,7 @@ w_metadata comctl32 dlls \
     year="2001" \
     media="download" \
     file1="cc32inst.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/comctl32.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/comctl32.dll"
 
 load_comctl32()
 {
@@ -6040,10 +6040,10 @@ load_comctl32()
 
     w_download https://downloads.sourceforge.net/project/pocmin/Win%2095_98%20Controls/Win%2095_98%20Controls/CC32inst.exe d68c0cca721870aed39f5f2efd80dfb74f3db66d5f9a49e7578b18279edfa4a7
 
-    w_try "$WINE" "$W_CACHE"/comctl32/cc32inst.exe "/T:$W_TMP_WIN" /c ${W_OPT_UNATTENDED:+/q}
-    w_try_unzip "$W_TMP" "$W_TMP"/comctl32.exe
-    w_try "$WINE" "$W_TMP"/x86/50ComUpd.Exe "/T:$W_TMP_WIN" /c ${W_OPT_UNATTENDED:+/q}
-    w_try cp "$W_TMP"/comcnt.dll "$W_SYSTEM32_DLLS"/comctl32.dll
+    w_try "${WINE}" "${W_CACHE}"/comctl32/cc32inst.exe "/T:${W_TMP_WIN}" /c ${W_OPT_UNATTENDED:+/q}
+    w_try_unzip "${W_TMP}" "${W_TMP}"/comctl32.exe
+    w_try "${WINE}" "${W_TMP}"/x86/50ComUpd.Exe "/T:${W_TMP_WIN}" /c ${W_OPT_UNATTENDED:+/q}
+    w_try cp "${W_TMP}"/comcnt.dll "${W_SYSTEM32_DLLS}"/comctl32.dll
 
     w_override_dlls native,builtin comctl32
 
@@ -6061,11 +6061,11 @@ w_metadata comctl32ocx dlls \
     year="2012" \
     media="download" \
     file1="../vb6sp6/VB60SP6-KB2708437-x86-ENU.msi" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/mscomctl.ocx"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/mscomctl.ocx"
 
 load_comctl32ocx()
 {
-    helper_vb6sp6 "$W_SYSTEM32_DLLS" comctl32.ocx mscomctl.ocx mscomct2.ocx
+    helper_vb6sp6 "${W_SYSTEM32_DLLS}" comctl32.ocx mscomctl.ocx mscomct2.ocx
 
     w_try_regsvr comctl32.ocx
     w_try_regsvr mscomctl.ocx
@@ -6080,12 +6080,12 @@ w_metadata comdlg32ocx dlls \
     year="2012" \
     media="download" \
     file1="../vb6sp6/VB60SP6-KB2708437-x86-ENU.msi" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/comdlg32.ocx"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/comdlg32.ocx"
 
 load_comdlg32ocx()
 {
-    helper_vb6sp6 "$W_TMP" ComDlg32.ocx
-    w_try mv "$W_TMP/ComDlg32.ocx" "$W_SYSTEM32_DLLS/comdlg32.ocx"
+    helper_vb6sp6 "${W_TMP}" ComDlg32.ocx
+    w_try mv "${W_TMP}/ComDlg32.ocx" "${W_SYSTEM32_DLLS}/comdlg32.ocx"
     w_try_regsvr comdlg32.ocx
 }
 
@@ -6097,14 +6097,14 @@ w_metadata crypt32 dlls \
     year="2004" \
     media="download" \
     file1="../winxpsp3/WindowsXP-KB936929-SP3-x86-ENU.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/crypt32.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/crypt32.dll"
 
 load_crypt32()
 {
     w_call msasn1
 
     helper_winxpsp3 i386/crypt32.dl_
-    w_try_cabextract --directory="$W_SYSTEM32_DLLS" "$W_TMP"/i386/crypt32.dl_
+    w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_TMP}"/i386/crypt32.dl_
 
     w_override_dlls native crypt32
 }
@@ -6117,7 +6117,7 @@ w_metadata binkw32 dlls \
     year="2000" \
     media="download" \
     file1="__32-binkw32.dll3.0.0.0.zip" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/binkw32.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/binkw32.dll"
 
 load_binkw32()
 {
@@ -6128,8 +6128,8 @@ load_binkw32()
     # 2015/12/27: 1d5efda8e4af796319b94034ba67b453cbbfddd81eb7d94fd059b40e237fa75d
     w_download https://web.archive.org/web/20160221223726if_/http://www.down-dll.com/dll/b/__32-binkw32.dll3.0.0.0.zip 1d5efda8e4af796319b94034ba67b453cbbfddd81eb7d94fd059b40e237fa75d
 
-    w_try_unzip "$W_TMP" "$W_CACHE"/binkw32/__32-binkw32.dll3.0.0.0.zip
-    w_try cp "$W_TMP"/binkw32.dll "$W_SYSTEM32_DLLS"/binkw32.dll
+    w_try_unzip "${W_TMP}" "${W_CACHE}"/binkw32/__32-binkw32.dll3.0.0.0.zip
+    w_try cp "${W_TMP}"/binkw32.dll "${W_SYSTEM32_DLLS}"/binkw32.dll
 
     w_override_dlls native binkw32
 }
@@ -6142,7 +6142,7 @@ w_metadata d3dcompiler_42 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dcompiler_42.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dcompiler_42.dll"
 
 load_d3dcompiler_42()
 {
@@ -6150,18 +6150,18 @@ load_d3dcompiler_42()
 
     helper_directx_Jun2010
 
-    w_try_cabextract -d "$W_TMP" -L -F "*$dllname*x86*" "$W_CACHE"/directx9/$DIRECTX_NAME
-    for x in "$W_TMP"/*.cab; do
-      w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F "$dllname.dll" "$x"
+    w_try_cabextract -d "${W_TMP}" -L -F "*${dllname}*x86*" "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    for x in "${W_TMP}"/*.cab; do
+      w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F "${dllname}.dll" "${x}"
     done
-    if test "$W_ARCH" = "win64"; then
-        w_try_cabextract -d "$W_TMP" -L -F "*$dllname*x64*" "$W_CACHE"/directx9/$DIRECTX_NAME
-        for x in "$W_TMP"/*x64.cab; do
-            w_try_cabextract -d "$W_SYSTEM64_DLLS" -L -F "$dllname.dll" "$x"
+    if test "${W_ARCH}" = "win64"; then
+        w_try_cabextract -d "${W_TMP}" -L -F "*${dllname}*x64*" "${W_CACHE}"/directx9/${DIRECTX_NAME}
+        for x in "${W_TMP}"/*x64.cab; do
+            w_try_cabextract -d "${W_SYSTEM64_DLLS}" -L -F "${dllname}.dll" "${x}"
         done
     fi
 
-    w_override_dlls native $dllname
+    w_override_dlls native ${dllname}
 }
 
 #----------------------------------------------------------------
@@ -6172,7 +6172,7 @@ w_metadata d3dcompiler_43 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dcompiler_43.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dcompiler_43.dll"
 
 load_d3dcompiler_43()
 {
@@ -6184,18 +6184,18 @@ load_d3dcompiler_43()
 
     helper_directx_Jun2010
 
-    w_try_cabextract -d "$W_TMP" -L -F "*$dllname*x86*" "$W_CACHE"/directx9/$DIRECTX_NAME
-    for x in "$W_TMP"/*.cab; do
-      w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F "$dllname.dll" "$x"
+    w_try_cabextract -d "${W_TMP}" -L -F "*${dllname}*x86*" "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    for x in "${W_TMP}"/*.cab; do
+      w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F "${dllname}.dll" "${x}"
     done
-    if test "$W_ARCH" = "win64"; then
-        w_try_cabextract -d "$W_TMP" -L -F "*$dllname*x64*" "$W_CACHE"/directx9/$DIRECTX_NAME
-        for x in "$W_TMP"/*x64.cab; do
-            w_try_cabextract -d "$W_SYSTEM64_DLLS" -L -F "$dllname.dll" "$x"
+    if test "${W_ARCH}" = "win64"; then
+        w_try_cabextract -d "${W_TMP}" -L -F "*${dllname}*x64*" "${W_CACHE}"/directx9/${DIRECTX_NAME}
+        for x in "${W_TMP}"/*x64.cab; do
+            w_try_cabextract -d "${W_SYSTEM64_DLLS}" -L -F "${dllname}.dll" "${x}"
         done
     fi
 
-    w_override_dlls native $dllname
+    w_override_dlls native ${dllname}
 }
 
 #----------------------------------------------------------------
@@ -6206,20 +6206,20 @@ w_metadata d3dcompiler_47 dlls \
     year="FIXME" \
     media="download" \
     file1="FirefoxSetup62.0.3-win32.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dcompiler_47.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dcompiler_47.dll"
 
 load_d3dcompiler_47()
 {
     # FIXME: would be awesome to find a small download that has both 32/64bit dlls, but this works for now:
 
     w_download https://download-installer.cdn.mozilla.net/pub/firefox/releases/62.0.3/win32/ach/Firefox%20Setup%2062.0.3.exe "d6edb4ff0a713f417ebd19baedfe07527c6e45e84a6c73ed8c66a33377cc0aca" "FirefoxSetup62.0.3-win32.exe"
-    w_try_7z "$W_TMP/win32" "$W_CACHE/d3dcompiler_47/FirefoxSetup62.0.3-win32.exe" "core/d3dcompiler_47.dll"
-    w_try cp "$W_TMP/win32/core/d3dcompiler_47.dll" "$W_SYSTEM32_DLLS/d3dcompiler_47.dll"
+    w_try_7z "${W_TMP}/win32" "${W_CACHE}/d3dcompiler_47/FirefoxSetup62.0.3-win32.exe" "core/d3dcompiler_47.dll"
+    w_try cp "${W_TMP}/win32/core/d3dcompiler_47.dll" "${W_SYSTEM32_DLLS}/d3dcompiler_47.dll"
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         w_download https://download-installer.cdn.mozilla.net/pub/firefox/releases/62.0.3/win64/ach/Firefox%20Setup%2062.0.3.exe "721977f36c008af2b637aedd3f1b529f3cfed6feb10f68ebe17469acb1934986" "FirefoxSetup62.0.3-win64.exe"
-        w_try_7z "$W_TMP/win64" "$W_CACHE/d3dcompiler_47/FirefoxSetup62.0.3-win64.exe" "core/d3dcompiler_47.dll"
-        w_try cp "$W_TMP/win64/core/d3dcompiler_47.dll" "$W_SYSTEM64_DLLS/d3dcompiler_47.dll"
+        w_try_7z "${W_TMP}/win64" "${W_CACHE}/d3dcompiler_47/FirefoxSetup62.0.3-win64.exe" "core/d3dcompiler_47.dll"
+        w_try cp "${W_TMP}/win64/core/d3dcompiler_47.dll" "${W_SYSTEM64_DLLS}/d3dcompiler_47.dll"
     fi
 
     w_override_dlls native d3dcompiler_47
@@ -6233,14 +6233,14 @@ w_metadata d3drm dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3drm.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3drm.dll"
 
 load_d3drm()
 {
     helper_directx_dl
 
-    w_try_cabextract -d "$W_TMP" -L -F "dxnt.cab" "$W_CACHE"/directx9/$DIRECTX_NAME
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F "d3drm.dll" "$W_TMP/dxnt.cab"
+    w_try_cabextract -d "${W_TMP}" -L -F "dxnt.cab" "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F "d3drm.dll" "${W_TMP}/dxnt.cab"
 
     w_override_dlls native d3drm
 }
@@ -6253,21 +6253,21 @@ w_metadata d3dx9 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx9_43.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx9_43.dll"
 
 load_d3dx9()
 {
     helper_directx_Jun2010
 
     # Kinder, less invasive directx - only extract and override d3dx9_??.dll
-    w_try_cabextract -d "$W_TMP" -L -F '*d3dx9*x86*' "$W_CACHE"/directx9/$DIRECTX_NAME
-    for x in "$W_TMP"/*.cab; do
-      w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'd3dx9*.dll' "$x"
+    w_try_cabextract -d "${W_TMP}" -L -F '*d3dx9*x86*' "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    for x in "${W_TMP}"/*.cab; do
+      w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'd3dx9*.dll' "${x}"
     done
-    if test "$W_ARCH" = "win64"; then
-        w_try_cabextract -d "$W_TMP" -L -F '*d3dx9*x64*' "$W_CACHE"/directx9/$DIRECTX_NAME
-        for x in "$W_TMP"/*x64.cab; do
-            w_try_cabextract -d "$W_SYSTEM64_DLLS" -L -F 'd3dx9*.dll' "$x"
+    if test "${W_ARCH}" = "win64"; then
+        w_try_cabextract -d "${W_TMP}" -L -F '*d3dx9*x64*' "${W_CACHE}"/directx9/${DIRECTX_NAME}
+        for x in "${W_TMP}"/*x64.cab; do
+            w_try_cabextract -d "${W_SYSTEM64_DLLS}" -L -F 'd3dx9*.dll' "${x}"
         done
     fi
 
@@ -6285,7 +6285,7 @@ w_metadata d3dx9_24 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx9_24.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx9_24.dll"
 
 load_d3dx9_24()
 {
@@ -6300,7 +6300,7 @@ w_metadata d3dx9_25 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx9_25.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx9_25.dll"
 
 load_d3dx9_25()
 {
@@ -6315,7 +6315,7 @@ w_metadata d3dx9_26 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx9_26.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx9_26.dll"
 
 load_d3dx9_26()
 {
@@ -6330,7 +6330,7 @@ w_metadata d3dx9_27 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx9_27.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx9_27.dll"
 
 load_d3dx9_27()
 {
@@ -6345,7 +6345,7 @@ w_metadata d3dx9_28 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx9_28.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx9_28.dll"
 
 load_d3dx9_28()
 {
@@ -6360,7 +6360,7 @@ w_metadata d3dx9_29 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx9_29.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx9_29.dll"
 
 load_d3dx9_29()
 {
@@ -6375,7 +6375,7 @@ w_metadata d3dx9_30 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx9_30.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx9_30.dll"
 
 load_d3dx9_30()
 {
@@ -6390,7 +6390,7 @@ w_metadata d3dx9_31 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx9_31.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx9_31.dll"
 
 load_d3dx9_31()
 {
@@ -6405,7 +6405,7 @@ w_metadata d3dx9_32 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx9_32.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx9_32.dll"
 
 load_d3dx9_32()
 {
@@ -6420,7 +6420,7 @@ w_metadata d3dx9_33 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx9_33.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx9_33.dll"
 
 load_d3dx9_33()
 {
@@ -6435,7 +6435,7 @@ w_metadata d3dx9_34 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx9_34.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx9_34.dll"
 
 load_d3dx9_34()
 {
@@ -6450,7 +6450,7 @@ w_metadata d3dx9_35 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx9_35.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx9_35.dll"
 
 load_d3dx9_35()
 {
@@ -6465,7 +6465,7 @@ w_metadata d3dx9_36 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx9_36.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx9_36.dll"
 
 load_d3dx9_36()
 {
@@ -6480,7 +6480,7 @@ w_metadata d3dx9_37 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx9_37.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx9_37.dll"
 
 load_d3dx9_37()
 {
@@ -6495,7 +6495,7 @@ w_metadata d3dx9_38 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx9_38.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx9_38.dll"
 
 load_d3dx9_38()
 {
@@ -6510,7 +6510,7 @@ w_metadata d3dx9_39 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx9_39.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx9_39.dll"
 
 load_d3dx9_39()
 {
@@ -6525,7 +6525,7 @@ w_metadata d3dx9_40 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx9_40.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx9_40.dll"
 
 load_d3dx9_40()
 {
@@ -6540,7 +6540,7 @@ w_metadata d3dx9_41 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx9_41.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx9_41.dll"
 
 load_d3dx9_41()
 {
@@ -6555,7 +6555,7 @@ w_metadata d3dx9_42 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx9_42.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx9_42.dll"
 
 load_d3dx9_42()
 {
@@ -6570,7 +6570,7 @@ w_metadata d3dx9_43 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx9_43.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx9_43.dll"
 
 load_d3dx9_43()
 {
@@ -6585,7 +6585,7 @@ w_metadata d3dx11_42 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx11_42.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx11_42.dll"
 
 load_d3dx11_42()
 {
@@ -6593,18 +6593,18 @@ load_d3dx11_42()
 
     helper_directx_Jun2010
 
-    w_try_cabextract -d "$W_TMP" -L -F "*$dllname*x86*" "$W_CACHE"/directx9/$DIRECTX_NAME
-    for x in "$W_TMP"/*.cab; do
-      w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F "$dllname.dll" "$x"
+    w_try_cabextract -d "${W_TMP}" -L -F "*${dllname}*x86*" "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    for x in "${W_TMP}"/*.cab; do
+      w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F "${dllname}.dll" "${x}"
     done
-    if test "$W_ARCH" = "win64"; then
-        w_try_cabextract -d "$W_TMP" -L -F "*$dllname*x64*" "$W_CACHE"/directx9/$DIRECTX_NAME
-        for x in "$W_TMP"/*x64.cab; do
-            w_try_cabextract -d "$W_SYSTEM64_DLLS" -L -F "$dllname.dll" "$x"
+    if test "${W_ARCH}" = "win64"; then
+        w_try_cabextract -d "${W_TMP}" -L -F "*${dllname}*x64*" "${W_CACHE}"/directx9/${DIRECTX_NAME}
+        for x in "${W_TMP}"/*x64.cab; do
+            w_try_cabextract -d "${W_SYSTEM64_DLLS}" -L -F "${dllname}.dll" "${x}"
         done
     fi
 
-    w_override_dlls native $dllname
+    w_override_dlls native ${dllname}
 }
 
 #----------------------------------------------------------------
@@ -6615,7 +6615,7 @@ w_metadata d3dx11_43 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx11_43.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx11_43.dll"
 
 load_d3dx11_43()
 {
@@ -6623,18 +6623,18 @@ load_d3dx11_43()
 
     helper_directx_Jun2010
 
-    w_try_cabextract -d "$W_TMP" -L -F "*$dllname*x86*" "$W_CACHE"/directx9/$DIRECTX_NAME
-    for x in "$W_TMP"/*.cab; do
-      w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F "$dllname.dll" "$x"
+    w_try_cabextract -d "${W_TMP}" -L -F "*${dllname}*x86*" "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    for x in "${W_TMP}"/*.cab; do
+      w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F "${dllname}.dll" "${x}"
     done
-    if test "$W_ARCH" = "win64"; then
-        w_try_cabextract -d "$W_TMP" -L -F "*$dllname*x64*" "$W_CACHE"/directx9/$DIRECTX_NAME
-        for x in "$W_TMP"/*x64.cab; do
-            w_try_cabextract -d "$W_SYSTEM64_DLLS" -L -F "$dllname.dll" "$x"
+    if test "${W_ARCH}" = "win64"; then
+        w_try_cabextract -d "${W_TMP}" -L -F "*${dllname}*x64*" "${W_CACHE}"/directx9/${DIRECTX_NAME}
+        for x in "${W_TMP}"/*x64.cab; do
+            w_try_cabextract -d "${W_SYSTEM64_DLLS}" -L -F "${dllname}.dll" "${x}"
         done
     fi
 
-    w_override_dlls native $dllname
+    w_override_dlls native ${dllname}
 }
 
 #----------------------------------------------------------------
@@ -6645,21 +6645,21 @@ w_metadata d3dx10 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx10_33.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx10_33.dll"
 
 load_d3dx10()
 {
     helper_directx_Jun2010
 
     # Kinder, less invasive directx10 - only extract and override d3dx10_??.dll
-    w_try_cabextract -d "$W_TMP" -L -F '*d3dx10*x86*' "$W_CACHE"/directx9/$DIRECTX_NAME
-    for x in "$W_TMP"/*.cab; do
-      w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'd3dx10*.dll' "$x"
+    w_try_cabextract -d "${W_TMP}" -L -F '*d3dx10*x86*' "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    for x in "${W_TMP}"/*.cab; do
+      w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'd3dx10*.dll' "${x}"
     done
-    if test "$W_ARCH" = "win64"; then
-        w_try_cabextract -d "$W_TMP" -L -F '*d3dx10*x64*' "$W_CACHE"/directx9/$DIRECTX_NAME
-        for x in "$W_TMP"/*x64.cab; do
-            w_try_cabextract -d "$W_SYSTEM64_DLLS" -L -F 'd3dx10*.dll' "$x"
+    if test "${W_ARCH}" = "win64"; then
+        w_try_cabextract -d "${W_TMP}" -L -F '*d3dx10*x64*' "${W_CACHE}"/directx9/${DIRECTX_NAME}
+        for x in "${W_TMP}"/*x64.cab; do
+            w_try_cabextract -d "${W_SYSTEM64_DLLS}" -L -F 'd3dx10*.dll' "${x}"
         done
     fi
 
@@ -6676,7 +6676,7 @@ w_metadata d3dx10_43 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dx10_43.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dx10_43.dll"
 
 load_d3dx10_43()
 {
@@ -6684,18 +6684,18 @@ load_d3dx10_43()
 
     helper_directx_Jun2010
 
-    w_try_cabextract -d "$W_TMP" -L -F "*$dllname*x86*" "$W_CACHE"/directx9/$DIRECTX_NAME
-    for x in "$W_TMP"/*.cab; do
-      w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F "$dllname.dll" "$x"
+    w_try_cabextract -d "${W_TMP}" -L -F "*${dllname}*x86*" "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    for x in "${W_TMP}"/*.cab; do
+      w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F "${dllname}.dll" "${x}"
     done
-    if test "$W_ARCH" = "win64"; then
-        w_try_cabextract -d "$W_TMP" -L -F "*$dllname*x64*" "$W_CACHE"/directx9/$DIRECTX_NAME
-        for x in "$W_TMP"/*x64.cab; do
-            w_try_cabextract -d "$W_SYSTEM64_DLLS" -L -F "$dllname.dll" "$x"
+    if test "${W_ARCH}" = "win64"; then
+        w_try_cabextract -d "${W_TMP}" -L -F "*${dllname}*x64*" "${W_CACHE}"/directx9/${DIRECTX_NAME}
+        for x in "${W_TMP}"/*x64.cab; do
+            w_try_cabextract -d "${W_SYSTEM64_DLLS}" -L -F "${dllname}.dll" "${x}"
         done
     fi
 
-    w_override_dlls native $dllname
+    w_override_dlls native ${dllname}
 }
 
 #----------------------------------------------------------------
@@ -6706,14 +6706,14 @@ w_metadata d3dxof dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3dxof.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3dxof.dll"
 
 load_d3dxof()
 {
     helper_directx_dl
 
-    w_try_cabextract -d "$W_TMP" -L -F 'dxnt.cab' "$W_CACHE"/directx9/$DIRECTX_NAME
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'd3dxof.dll' "$W_TMP/dxnt.cab"
+    w_try_cabextract -d "${W_TMP}" -L -F 'dxnt.cab' "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'd3dxof.dll' "${W_TMP}/dxnt.cab"
 
     w_override_dlls native d3dxof
 }
@@ -6726,13 +6726,13 @@ w_metadata dbghelp dlls \
     year="2008" \
     media="download" \
     file1="../winxpsp3/WindowsXP-KB936929-SP3-x86-ENU.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dbghelp.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dbghelp.dll"
 
 load_dbghelp()
 {
     helper_winxpsp3 i386/dbghelp.dll
 
-    w_try cp -f "$W_TMP"/i386/dbghelp.dll "$W_SYSTEM32_DLLS"
+    w_try cp -f "${W_TMP}"/i386/dbghelp.dll "${W_SYSTEM32_DLLS}"
 
     w_override_dlls native dbghelp
 }
@@ -6745,14 +6745,14 @@ w_metadata devenum dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/devenum.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/devenum.dll"
 
 load_devenum()
 {
     helper_directx_dl
 
-    w_try_cabextract -d "$W_TMP" -L -F 'dxnt.cab' "$W_CACHE/directx9/$DIRECTX_NAME"
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'devenum.dll' "$W_TMP/dxnt.cab"
+    w_try_cabextract -d "${W_TMP}" -L -F 'dxnt.cab' "${W_CACHE}/directx9/${DIRECTX_NAME}"
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'devenum.dll' "${W_TMP}/dxnt.cab"
     w_override_dlls native devenum
     w_try_regsvr devenum.dll
 }
@@ -6765,14 +6765,14 @@ w_metadata dinput dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dinput.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dinput.dll"
 
 load_dinput()
 {
     helper_directx_dl
 
-    w_try_cabextract -d "$W_TMP" -L -F 'dxnt.cab' "$W_CACHE"/directx9/$DIRECTX_NAME
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dinput.dll' "$W_TMP/dxnt.cab"
+    w_try_cabextract -d "${W_TMP}" -L -F 'dxnt.cab' "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dinput.dll' "${W_TMP}/dxnt.cab"
     w_override_dlls native dinput
     w_try_regsvr dinput
 }
@@ -6785,14 +6785,14 @@ w_metadata dinput8 dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dinput8.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dinput8.dll"
 
 load_dinput8()
 {
     helper_directx_dl
 
-    w_try_cabextract -d "$W_TMP" -L -F 'dxnt.cab' "$W_CACHE"/directx9/$DIRECTX_NAME
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dinput8.dll' "$W_TMP/dxnt.cab"
+    w_try_cabextract -d "${W_TMP}" -L -F 'dxnt.cab' "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dinput8.dll' "${W_TMP}/dxnt.cab"
 
     # Don't try to register native dinput8; it doesn't export DllRegisterServer().
     w_try_regsvr dinput8
@@ -6807,7 +6807,7 @@ w_metadata directmusic dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dmusic.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dmusic.dll"
 
 load_directmusic()
 {
@@ -6860,19 +6860,19 @@ w_metadata directplay dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dplayx.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dplayx.dll"
 
 load_directplay()
 {
     helper_directx_dl
 
-    w_try_cabextract -d "$W_TMP" -L -F dxnt.cab "$W_CACHE"/directx9/$DIRECTX_NAME
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dplaysvr.exe' "$W_TMP/dxnt.cab"
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dplayx.dll' "$W_TMP/dxnt.cab"
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dpnet.dll' "$W_TMP/dxnt.cab"
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dpnhpast.dll' "$W_TMP/dxnt.cab"
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dpnsvr.exe' "$W_TMP/dxnt.cab"
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dpwsockx.dll' "$W_TMP/dxnt.cab"
+    w_try_cabextract -d "${W_TMP}" -L -F dxnt.cab "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dplaysvr.exe' "${W_TMP}/dxnt.cab"
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dplayx.dll' "${W_TMP}/dxnt.cab"
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dpnet.dll' "${W_TMP}/dxnt.cab"
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dpnhpast.dll' "${W_TMP}/dxnt.cab"
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dpnsvr.exe' "${W_TMP}/dxnt.cab"
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dpwsockx.dll' "${W_TMP}/dxnt.cab"
 
     w_override_dlls native dplayx dpnet dpnhpast dpnsvr.exe dpwsockx
 
@@ -6904,19 +6904,19 @@ w_metadata dpvoice dlls \
     year="2002" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dpvoice.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/dpvvox.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/dpvacm.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dpvoice.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/dpvvox.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/dpvacm.dll"
 
 load_dpvoice()
 {
     helper_directx_dl
 
-    w_try_cabextract -d "$W_TMP" -L -F 'dxnt.cab' "$W_CACHE"/directx9/$DIRECTX_NAME
-    for x in "$W_TMP"/*.cab; do
-      w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dpvoice.dll' "$x"
-      w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dpvvox.dll' "$x"
-      w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dpvacm.dll' "$x"
+    w_try_cabextract -d "${W_TMP}" -L -F 'dxnt.cab' "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    for x in "${W_TMP}"/*.cab; do
+      w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dpvoice.dll' "${x}"
+      w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dpvvox.dll' "${x}"
+      w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dpvacm.dll' "${x}"
     done
     w_override_dlls native dpvoice dpvvox dpvacm
     w_try_regsvr dpvoice.dll
@@ -6932,15 +6932,15 @@ w_metadata dsdmo dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dsdmo.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dsdmo.dll"
 
 load_dsdmo()
 {
     helper_directx_dl
 
-    w_try_cabextract -d "$W_TMP" -L -F dxnt.cab "$W_CACHE"/directx9/$DIRECTX_NAME
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dsdmo.dll' "$W_TMP/dxnt.cab"
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dsdmoprp.dll' "$W_TMP/dxnt.cab"
+    w_try_cabextract -d "${W_TMP}" -L -F dxnt.cab "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dsdmo.dll' "${W_TMP}/dxnt.cab"
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dsdmoprp.dll' "${W_TMP}/dxnt.cab"
     w_try_regsvr dsdmo.dll
     w_try_regsvr dsdmoprp.dll
 }
@@ -6953,7 +6953,7 @@ w_metadata dxsdk_nov2006 apps \
     year="2006" \
     media="download" \
     file1="dxsdk_aug2006.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/Microsoft DirectX SDK (August 2006)/Lib/x86/d3d10.lib"
+    installed_file1="${W_PROGRAMS_X86_WIN}/Microsoft DirectX SDK (August 2006)/Lib/x86/d3d10.lib"
 
 load_dxsdk_nov2006()
 {
@@ -6962,10 +6962,10 @@ load_dxsdk_nov2006()
     # dxview.dll uses mfc42u while registering
     w_call mfc42
 
-    w_try_cabextract "$W_CACHE"/dxsdk_nov2006/dxsdk_aug2006.exe
-    w_try_unzip "$W_TMP" dxsdk.exe
-    w_try_cd "$W_TMP"
-    w_try "$WINE" msiexec /i Microsoft_DirectX_SDK.msi ${W_OPT_UNATTENDED:+/q}
+    w_try_cabextract "${W_CACHE}"/dxsdk_nov2006/dxsdk_aug2006.exe
+    w_try_unzip "${W_TMP}" dxsdk.exe
+    w_try_cd "${W_TMP}"
+    w_try "${WINE}" msiexec /i Microsoft_DirectX_SDK.msi ${W_OPT_UNATTENDED:+/q}
 }
 
 #----------------------------------------------------------------
@@ -6976,7 +6976,7 @@ w_metadata dxsdk_jun2010 apps \
     year="2010" \
     media="download" \
     file1="DXSDK_Jun10.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/Microsoft DirectX SDK (June 2010)/Lib/x86/d3d11.lib"
+    installed_file1="${W_PROGRAMS_X86_WIN}/Microsoft DirectX SDK (June 2010)/Lib/x86/d3d11.lib"
 
 load_dxsdk_jun2010()
 {
@@ -6985,8 +6985,8 @@ load_dxsdk_jun2010()
     # Without dotnet20, install aborts halfway through
     w_call dotnet20
 
-    w_try_cd "$W_TMP"
-    w_try "$WINE" "$W_CACHE"/dxsdk_jun2010/DXSDK_Jun10.exe ${W_OPT_UNATTENDED:+/U}
+    w_try_cd "${W_TMP}"
+    w_try "${WINE}" "${W_CACHE}"/dxsdk_jun2010/DXSDK_Jun10.exe ${W_OPT_UNATTENDED:+/U}
 }
 
 #----------------------------------------------------------------
@@ -6997,12 +6997,12 @@ w_metadata dxtrans dlls \
     year="2002" \
     media="download" \
     file1="../winxpsp3/WindowsXP-KB936929-SP3-x86-ENU.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dxtrans.dll" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dxtrans.dll" \
 
 load_dxtrans()
 {
     helper_winxpsp3 i386/dxtrans.dl_
-    w_try_cabextract --directory="$W_SYSTEM32_DLLS" "$W_TMP"/i386/dxtrans.dl_
+    w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_TMP}"/i386/dxtrans.dl_
     w_override_dlls native,builtin dxtrans
     w_try_regsvr dxtrans.dll
 }
@@ -7064,7 +7064,7 @@ helper_dxvk_d9vk()
     fi
 
     if [ "${_W_package_archive##*.}" = "zip" ]; then
-        w_try_unzip "$W_TMP" "${W_CACHE}/${W_PACKAGE}/${_W_package_archive}"
+        w_try_unzip "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${_W_package_archive}"
     else
         w_try_cd "${W_TMP}"
         w_try tar -zxf "${W_CACHE}/${W_PACKAGE}/${_W_package_archive}"
@@ -7100,18 +7100,18 @@ w_metadata d9vk010 dlls \
     year="2019" \
     media="download" \
     file1="d9vk-0.10.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_d9vk010()
 {
     # https://github.com/Joshua-Ashton/d9vk
     w_download "https://github.com/Joshua-Ashton/d9vk/releases/download/0.10/d9vk-0.10.tar.gz" 9e50f2609aafaa7dd24c327f6af83c821c2259ca4967656029782faa71398ae2
-    helper_dxvk_d9vk "$file1" "4.5" "1.1.104" "dxgi,d3d9,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.5" "1.1.104" "dxgi,d3d9,d3d10core,d3d10,d3d11"
 }
 
 w_metadata d9vk011 dlls \
@@ -7120,18 +7120,18 @@ w_metadata d9vk011 dlls \
     year="2019" \
     media="download" \
     file1="d9vk-0.11.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_d9vk011()
 {
     # https://github.com/Joshua-Ashton/d9vk
     w_download "https://github.com/Joshua-Ashton/d9vk/releases/download/0.11/d9vk-0.11.tar.gz" fac8eab2a7de7af2404d4bac13ed24ff60c1cf36ba6b8ab7fc5f0d405f284e08
-    helper_dxvk_d9vk "$file1" "4.5" "1.1.104" "dxgi,d3d9,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.5" "1.1.104" "dxgi,d3d9,d3d10core,d3d10,d3d11"
 }
 
 w_metadata d9vk012 dlls \
@@ -7140,18 +7140,18 @@ w_metadata d9vk012 dlls \
     year="2019" \
     media="download" \
     file1="d9vk-0.12.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_d9vk012()
 {
     # https://github.com/Joshua-Ashton/d9vk
     w_download "https://github.com/Joshua-Ashton/d9vk/releases/download/0.12/d9vk-0.12.tar.gz" 13a657cce7d7a03aace794ab52f0d09cb5aaf1c59a9c9971eae294fc50f39f41
-    helper_dxvk_d9vk "$file1" "4.5" "1.1.104" "dxgi,d3d9,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.5" "1.1.104" "dxgi,d3d9,d3d10core,d3d10,d3d11"
 }
 
 w_metadata d9vk013 dlls \
@@ -7160,18 +7160,18 @@ w_metadata d9vk013 dlls \
     year="2019" \
     media="download" \
     file1="d9vk-0.13.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_d9vk013()
 {
     # https://github.com/Joshua-Ashton/d9vk
     w_download "https://github.com/Joshua-Ashton/d9vk/releases/download/0.13/d9vk-0.13.tar.gz" 53eeca60e94d3bbe5dbf57eaaf3d15746d4bca48a15968cf841ffdf68d999e59
-    helper_dxvk_d9vk "$file1" "4.5" "1.1.104" "dxgi,d3d9,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.5" "1.1.104" "dxgi,d3d9,d3d10core,d3d10,d3d11"
 }
 
 w_metadata d9vk013f dlls \
@@ -7180,18 +7180,18 @@ w_metadata d9vk013f dlls \
     year="2019" \
     media="download" \
     file1="d9vk-0.13f.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_d9vk013f()
 {
     # https://github.com/Joshua-Ashton/d9vk
     w_download "https://github.com/Joshua-Ashton/d9vk/releases/download/0.13f/d9vk-0.13f.tar.gz" 7408ba54c4104b2a18ab4a4a575665f66e1517b46282724111d129bf127bfb8a
-    helper_dxvk_d9vk "$file1" "4.5" "1.1.104" "dxgi,d3d9,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.5" "1.1.104" "dxgi,d3d9,d3d10core,d3d10,d3d11"
 }
 
 w_metadata d9vk020 dlls \
@@ -7200,18 +7200,18 @@ w_metadata d9vk020 dlls \
     year="2019" \
     media="download" \
     file1="d9vk-0.20.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_d9vk020()
 {
     # https://github.com/Joshua-Ashton/d9vk
     w_download "https://github.com/Joshua-Ashton/d9vk/releases/download/0.20/d9vk-0.20.tar.gz" bd53c17eafeffcf2251d3911b7814b92c8f7e4c6b7364217da38645093a1db35
-    helper_dxvk_d9vk "$file1" "4.5" "1.1.104" "dxgi,d3d9,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.5" "1.1.104" "dxgi,d3d9,d3d10core,d3d10,d3d11"
 }
 
 w_metadata d9vk021 dlls \
@@ -7220,18 +7220,18 @@ w_metadata d9vk021 dlls \
     year="2019" \
     media="download" \
     file1="d9vk-0.21.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_d9vk021()
 {
     # https://github.com/Joshua-Ashton/d9vk
     w_download "https://github.com/Joshua-Ashton/d9vk/releases/download/0.21/d9vk-0.21.tar.gz" e58d11733b6471718b4652e5be66bfd1a4d908d0ddf96be0ecb9efb2fb748055
-    helper_dxvk_d9vk "$file1" "4.5" "1.1.104" "dxgi,d3d9,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.5" "1.1.104" "dxgi,d3d9,d3d10core,d3d10,d3d11"
 }
 
 w_metadata d9vk022 dlls \
@@ -7240,18 +7240,18 @@ w_metadata d9vk022 dlls \
     year="2019" \
     media="download" \
     file1="d9vk-0.22.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_d9vk022()
 {
     # https://github.com/Joshua-Ashton/d9vk
     w_download "https://github.com/Joshua-Ashton/d9vk/releases/download/0.22/d9vk-0.22.tar.gz" 45d2b5d20cd6d96a43673b999814d3d9d3e64360a514757df3ef49b9a28ae65a
-    helper_dxvk_d9vk "$file1" "4.5" "1.1.104" "dxgi,d3d9,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.5" "1.1.104" "dxgi,d3d9,d3d10core,d3d10,d3d11"
 }
 
 w_metadata d9vk030 dlls \
@@ -7260,18 +7260,18 @@ w_metadata d9vk030 dlls \
     year="2019" \
     media="download" \
     file1="d9vk-0.30.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_d9vk030()
 {
     # https://github.com/Joshua-Ashton/d9vk
     w_download "https://github.com/Joshua-Ashton/d9vk/releases/download/0.30/d9vk-0.30.tar.gz" 9654b888665184bf795aa33a0c7287d04666ebe21e56e53df0f6c331fde24927
-    helper_dxvk_d9vk "$file1" "4.5" "1.1.104" "dxgi,d3d9,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.5" "1.1.104" "dxgi,d3d9,d3d10core,d3d10,d3d11"
 }
 
 w_metadata d9vk040 dlls \
@@ -7280,18 +7280,18 @@ w_metadata d9vk040 dlls \
     year="2019" \
     media="download" \
     file1="d9vk-0.40.1.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_d9vk040()
 {
     # https://github.com/Joshua-Ashton/d9vk
     w_download "https://github.com/Joshua-Ashton/d9vk/releases/download/0.40.1/d9vk-0.40.1.tar.gz" 6bfcf05d68207b140dbfaa938f8e3807d938466682b531d6daa36b22fa0a6d03
-    helper_dxvk_d9vk "$file1" "4.5" "1.1.104" "dxgi,d3d9,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.5" "1.1.104" "dxgi,d3d9,d3d10core,d3d10,d3d11"
 }
 
 #----------------------------------------------------------------
@@ -7301,12 +7301,12 @@ w_metadata d9vk dlls \
     publisher="Joshua Ashton" \
     year="2019" \
     media="download" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_d9vk()
 {
@@ -7327,14 +7327,14 @@ w_metadata dxvk054 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-0.54.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk054()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v0.54/dxvk-0.54.tar.gz" 1c2f186baaa01d2de7b832f6f05021bdd29eccb65fc197c8b15adfd4e08f9640
-    helper_dxvk_d9vk "$file1" "3.10" "1.1.72" "dxgi,d3d11"
+    helper_dxvk_d9vk "${file1}" "3.10" "1.1.72" "dxgi,d3d11"
 }
 
 w_metadata dxvk060 dlls \
@@ -7343,14 +7343,14 @@ w_metadata dxvk060 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-0.60.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk060()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v0.60/dxvk-0.60.tar.gz" 27d6f700241d3ec3b6c002c3d739bb0e3f210ec916ecb5a62d9204e9e50f2c4a
-    helper_dxvk_d9vk "$file1" "3.10" "1.1.72" "dxgi,d3d11"
+    helper_dxvk_d9vk "${file1}" "3.10" "1.1.72" "dxgi,d3d11"
 }
 
 w_metadata dxvk061 dlls \
@@ -7359,14 +7359,14 @@ w_metadata dxvk061 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-0.61.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk061()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v0.61/dxvk-0.61.tar.gz" d04388f026dc0d8b276b08f7db74fb3556cbbc8f762401eb5ef52629ee39ded1
-    helper_dxvk_d9vk "$file1"  "3.10" "1.1.72" "dxgi,d3d11"
+    helper_dxvk_d9vk "${file1}"  "3.10" "1.1.72" "dxgi,d3d11"
 }
 
 w_metadata dxvk062 dlls \
@@ -7375,14 +7375,14 @@ w_metadata dxvk062 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-0.62.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk062()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v0.62/dxvk-0.62.tar.gz" b9dbb57908e24b094b68f665ad729b6ee277eecc8ba04a6e6e4f8a4d2dfd94e3
-    helper_dxvk_d9vk "$file1"  "3.10" "1.1.72" "dxgi,d3d11"
+    helper_dxvk_d9vk "${file1}"  "3.10" "1.1.72" "dxgi,d3d11"
 }
 
 w_metadata dxvk063 dlls \
@@ -7391,14 +7391,14 @@ w_metadata dxvk063 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-0.63.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk063()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v0.63/dxvk-0.63.tar.gz" 696df816bd9640770dee14f932bc641a16261fccf76be7c28d812a64ca6040fa
-    helper_dxvk_d9vk "$file1"  "3.18" "1.1.80" "dxgi,d3d11"
+    helper_dxvk_d9vk "${file1}"  "3.18" "1.1.80" "dxgi,d3d11"
 }
 
 w_metadata dxvk064 dlls \
@@ -7407,14 +7407,14 @@ w_metadata dxvk064 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-0.64.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk064()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v0.64/dxvk-0.64.tar.gz" 2e03e40ff0a9d36f96a06137f3fa9110ebaea230d0bf6c22cf6399e16e97fb9c
-    helper_dxvk_d9vk "$file1" "3.18" "1.1.80" "dxgi,d3d11"
+    helper_dxvk_d9vk "${file1}" "3.18" "1.1.80" "dxgi,d3d11"
 }
 
 w_metadata dxvk065 dlls \
@@ -7423,14 +7423,14 @@ w_metadata dxvk065 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-0.65.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk065()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v0.65/dxvk-0.65.tar.gz" 7b4eb42e693f925d0aff90bae261b20c50428602382ee94a3e3860b2ad1ebad0
-    helper_dxvk_d9vk "$file1" "3.18" "1.1.80" "dxgi,d3d11"
+    helper_dxvk_d9vk "${file1}" "3.18" "1.1.80" "dxgi,d3d11"
 }
 
 w_metadata dxvk070 dlls \
@@ -7439,17 +7439,17 @@ w_metadata dxvk070 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-0.70.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk070()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v0.70/dxvk-0.70.tar.gz" 310546d530be494a35cae49b707fef4b073269d811aac25bdf72899ed1df4e9f
-    helper_dxvk_d9vk "$file1" "3.18" "1.1.80" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "3.18" "1.1.80" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk071 dlls \
@@ -7458,17 +7458,17 @@ w_metadata dxvk071 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-0.71.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk071()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v0.71/dxvk-0.71.tar.gz" fbe66337d1450f366961a7699253cd7a96c12a88c2fcda64b79be1cbb13d37d5
-    helper_dxvk_d9vk "$file1" "3.18" "1.1.80" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "3.18" "1.1.80" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk072 dlls \
@@ -7477,17 +7477,17 @@ w_metadata dxvk072 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-0.72.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk072()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v0.72/dxvk-0.72.tar.gz" bc84f48f99cf5add3c8919a43d7a9c0bf208c994dc58326a636b56b8db650c52
-    helper_dxvk_d9vk "$file1" "3.18" "1.1.84" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "3.18" "1.1.84" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk080 dlls \
@@ -7496,11 +7496,11 @@ w_metadata dxvk080 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-0.80.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk080()
 {
@@ -7509,7 +7509,7 @@ load_dxvk080()
     # 2017/11/17: 7058a834bb006cad5462933110449b434df561e67d83f68d3965ecc74e2e1cbc
     # See: https://github.com/doitsujin/dxvk/issues/773
     w_download "https://github.com/doitsujin/dxvk/releases/download/v0.80/dxvk-0.80.tar.gz" 7058a834bb006cad5462933110449b434df561e67d83f68d3965ecc74e2e1cbc
-    helper_dxvk_d9vk "$file1" "3.18" "1.1.84" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "3.18" "1.1.84" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk081 dlls \
@@ -7518,17 +7518,17 @@ w_metadata dxvk081 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-0.81.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk081()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v0.81/dxvk-0.81.tar.gz" 9bf6eda9ae4ee74b509e07dfe9cc003dfa4bba192b519dacdd542a57f6a43869
-    helper_dxvk_d9vk "$file1" "3.18" "1.1.84" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "3.18" "1.1.84" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk090 dlls \
@@ -7537,17 +7537,17 @@ w_metadata dxvk090 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-0.90.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk090()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v0.90/dxvk-0.90.tar.gz" 15bce7b282065054ff9233b33738bf1d2c74b16829361cbd6843bc2f5dfe4509
-    helper_dxvk_d9vk "$file1" "3.19" "1.1.87" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "3.19" "1.1.87" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk091 dlls \
@@ -7556,17 +7556,17 @@ w_metadata dxvk091 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-0.91.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk091()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v0.91/dxvk-0.91.tar.gz" 5296106ac3a8c631d7f26fa46dbff4be1332cda14fa493fd89ccf97e050c4855
-    helper_dxvk_d9vk "$file1" "3.19" "1.1.87" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "3.19" "1.1.87" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk092 dlls \
@@ -7575,17 +7575,17 @@ w_metadata dxvk092 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-0.92.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk092()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v0.92/dxvk-0.92.tar.gz" e22c0ae4693aac88562c7a9a97b3316e086b9048c9f8f9e128923ac1611a5c49
-    helper_dxvk_d9vk "$file1" "3.19" "1.1.87" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "3.19" "1.1.87" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk093 dlls \
@@ -7594,17 +7594,17 @@ w_metadata dxvk093 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-0.93.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk093()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v0.93/dxvk-0.93.tar.gz" 4d964e4e10e67ba7705312496e472ae9859520a78d8742d6d377886318c95e53
-    helper_dxvk_d9vk "$file1" "4.0" "1.1.93" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.0" "1.1.93" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk094 dlls \
@@ -7613,17 +7613,17 @@ w_metadata dxvk094 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-0.94.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk094()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v0.94/dxvk-0.94.tar.gz" 1f06bfac5b435b62b972806fb3bbd86f7ccae2399b4451e85ae414e03d3712a3
-    helper_dxvk_d9vk "$file1" "4.0" "1.1.93" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.0" "1.1.93" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk095 dlls \
@@ -7632,17 +7632,17 @@ w_metadata dxvk095 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-0.95.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk095()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v0.95/dxvk-0.95.tar.gz" 1eea48149f6e94c3c74ecddd92df4f9daa67ab28d0fca548bde5cd40f0e486bf
-    helper_dxvk_d9vk "$file1" "4.0" "1.1.93" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.0" "1.1.93" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk096 dlls \
@@ -7651,17 +7651,17 @@ w_metadata dxvk096 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-0.96.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk096()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v0.96/dxvk-0.96.tar.gz" 9d054c1e7a4f59825c651b14d3cfbf0d8c724763f485b3d59c89f1d7194b2206
-    helper_dxvk_d9vk "$file1" "4.0" "1.1.93" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.0" "1.1.93" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk100 dlls \
@@ -7670,17 +7670,17 @@ w_metadata dxvk100 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.0.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk100()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.0/dxvk-1.0.tar.gz" 8c8d26544609532201c10e6f5309bf5e913b5ca5b985932928ef9ab238de6dc2
-    helper_dxvk_d9vk "$file1" "4.5" "1.1.101" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.5" "1.1.101" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk101 dlls \
@@ -7689,17 +7689,17 @@ w_metadata dxvk101 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.0.1.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk101()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.0.1/dxvk-1.0.1.tar.gz" 739847cdd14b302dac600c66bc6617d7814945df6d4d7b6c91fecfa910e3b1b1
-    helper_dxvk_d9vk "$file1" "4.5" "1.1.101" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.5" "1.1.101" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk102 dlls \
@@ -7708,17 +7708,17 @@ w_metadata dxvk102 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.0.2.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk102()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.0.2/dxvk-1.0.2.tar.gz" f9504b188488d1102cba7e82c28681708f39e151af1c1ef7ebeac82d729c01ac
-    helper_dxvk_d9vk "$file1" "4.5" "1.1.101" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.5" "1.1.101" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk103 dlls \
@@ -7727,17 +7727,17 @@ w_metadata dxvk103 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.0.3.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk103()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.0.3/dxvk-1.0.3.tar.gz" 984d28ab3a112be207d6339da19113d1117e56731ed413d0e202e6fd1391a6ae
-    helper_dxvk_d9vk "$file1" "4.5" "1.1.101" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.5" "1.1.101" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk111 dlls \
@@ -7746,17 +7746,17 @@ w_metadata dxvk111 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.1.1.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk111()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.1.1/dxvk-1.1.1.tar.gz" 346c523953f72ac5885071c4384039faf01f6f43a88d5b0c12d94bfaa9598c1d
-    helper_dxvk_d9vk "$file1" "4.5" "1.1.104" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.5" "1.1.104" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk120 dlls \
@@ -7765,17 +7765,17 @@ w_metadata dxvk120 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.2.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk120()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.2/dxvk-1.2.tar.gz" 414751a810143ced34d1f4f0eb2a40e79b4c9726318994b244b70d1b3a6f8b32
-    helper_dxvk_d9vk "$file1" "4.5" "1.1.104" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.5" "1.1.104" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk121 dlls \
@@ -7784,17 +7784,17 @@ w_metadata dxvk121 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.2.1.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk121()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.2.1/dxvk-1.2.1.tar.gz" 192beca0a34d13f101e9c2545d9533cf84830a23b566bed185c022ed754c3daa
-    helper_dxvk_d9vk "$file1" "4.5" "1.1.104" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.5" "1.1.104" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk122 dlls \
@@ -7803,17 +7803,17 @@ w_metadata dxvk122 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.2.2.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk122()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.2.2/dxvk-1.2.2.tar.gz" dfe620a387222dc117a6722171e0bca400755a3e1c6459350c710dfda40b6701
-    helper_dxvk_d9vk "$file1" "4.5" "1.1.104" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.5" "1.1.104" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk123 dlls \
@@ -7822,17 +7822,17 @@ w_metadata dxvk123 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.2.3.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk123()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.2.3/dxvk-1.2.3.tar.gz" 29ce345b3d962dbd8ec8bfda190635a21f62124e3e46f06e89aa2f3b1e230321
-    helper_dxvk_d9vk "$file1" "4.5" "1.1.104" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.5" "1.1.104" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk130 dlls \
@@ -7841,17 +7841,17 @@ w_metadata dxvk130 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.3.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk130()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.3/dxvk-1.3.tar.gz" d15fac6503ea614986237052d554d7cbd2dbf5f3486feb6217e64bae83cfc2cf
-    helper_dxvk_d9vk "$file1" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk131 dlls \
@@ -7860,17 +7860,17 @@ w_metadata dxvk131 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.3.1.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk131()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.3.1/dxvk-1.3.1.tar.gz" 2f6636dbd591ea9de20b30a33c9c8c0985a4939f6503f90ca5c7edafd01524a3
-    helper_dxvk_d9vk "$file1" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk132 dlls \
@@ -7879,17 +7879,17 @@ w_metadata dxvk132 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.3.2.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk132()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.3.2/dxvk-1.3.2.tar.gz" aa70890a17b48be27648d15cb837b5167c99f75ee32ae0c94a85ec1f1fdc4675
-    helper_dxvk_d9vk "$file1" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk133 dlls \
@@ -7898,17 +7898,17 @@ w_metadata dxvk133 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.3.3.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk133()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.3.3/dxvk-1.3.3.tar.gz" 828171ad1dbb6b51f367fa46cf33f8db4a0b1b990cd2e95654d6a65500d230b7
-    helper_dxvk_d9vk "$file1" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk134 dlls \
@@ -7917,17 +7917,17 @@ w_metadata dxvk134 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.3.4.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk134()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.3.4/dxvk-1.3.4.tar.gz" 4683e2ad4221b16572b0d939da5a05ab9a16b2b62c2f4e0c8bf3b2cdb27918ff
-    helper_dxvk_d9vk "$file1" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk140 dlls \
@@ -7936,17 +7936,17 @@ w_metadata dxvk140 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.4.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk140()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.4/dxvk-1.4.tar.gz" bf22785de1ce728bbdcfb4615035924112b4718049ca2cade5861b03735181de
-    helper_dxvk_d9vk "$file1" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk141 dlls \
@@ -7955,17 +7955,17 @@ w_metadata dxvk141 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.4.1.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk141()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.4.1/dxvk-1.4.1.tar.gz" 574ec4dc5201e45d70472228f0c6695426f0392503ec7a47d6092600aac53a07
-    helper_dxvk_d9vk "$file1" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk142 dlls \
@@ -7974,17 +7974,17 @@ w_metadata dxvk142 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.4.2.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk142()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.4.2/dxvk-1.4.2.tar.gz" 5adfd71ee0299798af4402f09f113f88929af429b6889af334cff5b84b84dbe6
-    helper_dxvk_d9vk "$file1" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk143 dlls \
@@ -7993,17 +7993,17 @@ w_metadata dxvk143 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.4.3.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk143()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.4.3/dxvk-1.4.3.tar.gz" e4b9e7fc8faf2dd1ddf5206e14939a822034a85778d54a6950767d68909726f7
-    helper_dxvk_d9vk "$file1" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk144 dlls \
@@ -8012,17 +8012,17 @@ w_metadata dxvk144 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.4.4.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk144()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.4.4/dxvk-1.4.4.tar.gz" a845285c8dfc63c7d00c14520b58fc6048796fef69fea49617edb46662a0ba31
-    helper_dxvk_d9vk "$file1" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk145 dlls \
@@ -8031,17 +8031,17 @@ w_metadata dxvk145 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.4.5.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk145()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.4.5/dxvk-1.4.5.tar.gz" 566c93dce84c3c2f39938428ddcca27a5bb2f5068eb4f868ff2126389b965cd1
-    helper_dxvk_d9vk "$file1" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk146 dlls \
@@ -8050,11 +8050,11 @@ w_metadata dxvk146 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.4.6.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk146()
 {
@@ -8062,7 +8062,7 @@ load_dxvk146()
     # Original sha256sum: 1aa069f5ea7d3d6e374bda332d12f9207f1a21e9811c4d4d82487416420ee73e
     # Upstream later rebuilt with commit 1ae7d4b30283d2eb06b467c581aafdbbd9d36cdf: c9e3a96d8c5e693e20f69f27ac3f8b55198449fddd24205195476d6af7e8a339
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.4.6/dxvk-1.4.6.tar.gz" c9e3a96d8c5e693e20f69f27ac3f8b55198449fddd24205195476d6af7e8a339
-    helper_dxvk_d9vk "$file1" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.20" "1.1.113" "dxgi,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk150 dlls \
@@ -8071,18 +8071,18 @@ w_metadata dxvk150 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.5.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk150()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.5/dxvk-1.5.tar.gz" 90cfae0bb43fed1e46442d20e2ab3bf448ebdff1e9f4f59841dc922aa3a36d3b
-    helper_dxvk_d9vk "$file1" "4.20" "1.1.113" "dxgi,d3d9,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.20" "1.1.113" "dxgi,d3d9,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk151 dlls \
@@ -8091,18 +8091,18 @@ w_metadata dxvk151 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.5.1.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk151()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.5.1/dxvk-1.5.1.tar.gz" 474ce9995edd47a3bd347a8f3263f35cf8df2676f5b16668bf38efa298d75c01
-    helper_dxvk_d9vk "$file1" "4.20" "1.1.113" "dxgi,d3d9,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.20" "1.1.113" "dxgi,d3d9,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk152 dlls \
@@ -8111,18 +8111,18 @@ w_metadata dxvk152 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.5.2.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk152()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.5.2/dxvk-1.5.2.tar.gz" 684ba886b5ed922c2417753d8178f923c695258c69cc8f778bb59b99bbf62477
-    helper_dxvk_d9vk "$file1" "4.20" "1.1.113" "dxgi,d3d9,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.20" "1.1.113" "dxgi,d3d9,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk153 dlls \
@@ -8131,18 +8131,18 @@ w_metadata dxvk153 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.5.3.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk153()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.5.3/dxvk-1.5.3.tar.gz" b845c9c492e32648dee44d058c189eff8534e5490a80a3b2a921248bc72e33bd
-    helper_dxvk_d9vk "$file1" "4.20" "1.1.113" "dxgi,d3d9,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.20" "1.1.113" "dxgi,d3d9,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk154 dlls \
@@ -8151,18 +8151,18 @@ w_metadata dxvk154 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.5.4.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk154()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.5.4/dxvk-1.5.4.tar.gz" 8e4fd15525def9bcaa9cc1b4496f76a2664ba4806b02a5ac0eddd703d7bbdea7
-    helper_dxvk_d9vk "$file1" "4.20" "1.1.113" "dxgi,d3d9,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.20" "1.1.113" "dxgi,d3d9,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk155 dlls \
@@ -8171,18 +8171,18 @@ w_metadata dxvk155 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.5.5.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d10.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10_1.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file5="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file5="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk155()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.5.5/dxvk-1.5.5.tar.gz" f4c57274ac85d71b192e2a0ac095f285e26cc054c87c6c34c081f919147539eb
-    helper_dxvk_d9vk "$file1" "4.20" "1.1.113" "dxgi,d3d9,d3d10core,d3d10,d3d11"
+    helper_dxvk_d9vk "${file1}" "4.20" "1.1.113" "dxgi,d3d9,d3d10core,d3d10,d3d11"
 }
 
 w_metadata dxvk160 dlls \
@@ -8191,16 +8191,16 @@ w_metadata dxvk160 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.6.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk160()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.6/dxvk-1.6.tar.gz" a493e0802e02629244672c44ad92c40fa0813b38908677ae14ee07feefcf7227
-    helper_dxvk_d9vk "$file1" "5.3" "1.1.113" "dxgi,d3d9,d3d10core,d3d11"
+    helper_dxvk_d9vk "${file1}" "5.3" "1.1.113" "dxgi,d3d9,d3d10core,d3d11"
 }
 
 w_metadata dxvk161 dlls \
@@ -8209,16 +8209,16 @@ w_metadata dxvk161 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.6.1.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk161()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.6.1/dxvk-1.6.1.tar.gz" cdef8735313ed9ccb7af23b37bcceaad54553e29505c269246d5e347f1359136
-    helper_dxvk_d9vk "$file1" "5.3" "1.1.113" "dxgi,d3d9,d3d10core,d3d11"
+    helper_dxvk_d9vk "${file1}" "5.3" "1.1.113" "dxgi,d3d9,d3d10core,d3d11"
 }
 
 w_metadata dxvk170 dlls \
@@ -8227,16 +8227,16 @@ w_metadata dxvk170 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.7.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk170()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.7/dxvk-1.7.tar.gz" 67d78239906c24bd50a5ecbc2fd792c1721e274a7a60dd22f74b21b08ca4c7a1
-    helper_dxvk_d9vk "$file1" "5.8" "1.2.140" "dxgi,d3d9,d3d10core,d3d11"
+    helper_dxvk_d9vk "${file1}" "5.8" "1.2.140" "dxgi,d3d9,d3d10core,d3d11"
 }
 
 w_metadata dxvk171 dlls \
@@ -8245,16 +8245,16 @@ w_metadata dxvk171 dlls \
     year="2017" \
     media="download" \
     file1="dxvk-1.7.1.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk171()
 {
     # https://github.com/doitsujin/dxvk
     w_download "https://github.com/doitsujin/dxvk/releases/download/v1.7.1/dxvk-1.7.1.tar.gz" 6ce66c4e01196ed022604e90383593aea02c9016bde92c6840aa58805d5fc588
-    helper_dxvk_d9vk "$file1" "5.8" "1.2.140" "dxgi,d3d9,d3d10core,d3d11"
+    helper_dxvk_d9vk "${file1}" "5.8" "1.2.140" "dxgi,d3d9,d3d10core,d3d11"
 }
 
 #----------------------------------------------------------------
@@ -8264,10 +8264,10 @@ w_metadata dxvk dlls \
     publisher="Philip Rebohle" \
     year="2017" \
     media="download" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk()
 {
@@ -8287,20 +8287,20 @@ w_metadata dxvk_master dlls \
     year="2017" \
     media="download" \
     file1="dxvk_master.zip" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/d3d10core.dll" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/d3d11.dll" \
-    installed_file4="$W_SYSTEM32_DLLS_WIN/dxgi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk_master()
 {
     # https://git.froggi.es/doitsujin/dxvk
     # FIXME: Delete cached file, when verb is forced. Gitlab artifacts do not supply any version/commit hash information.
-    if test "$WINETRICKS_FORCE" = 1 && test -f "${W_CACHE}/${W_PACKAGE}/${file1}"; then
+    if test "${WINETRICKS_FORCE}" = 1 && test -f "${W_CACHE}/${W_PACKAGE}/${file1}"; then
         w_try rm -f "${W_CACHE}/${W_PACKAGE}/${file1}"
     fi
     w_linkcheck_ignore=1 w_download_to "${W_CACHE}/${W_PACKAGE}" "https://git.froggi.es/doitsujin/dxvk/-/jobs/artifacts/master/download?job=dxvk" "" "dxvk_master.zip"
-    helper_dxvk_d9vk "$file1" "5.8" "1.2.140" "dxgi,d3d9,d3d10core,d3d11"
+    helper_dxvk_d9vk "${file1}" "5.8" "1.2.140" "dxgi,d3d9,d3d10core,d3d11"
 }
 
 #----------------------------------------------------------------
@@ -8311,14 +8311,14 @@ w_metadata dmusic32 dlls \
     year="2006" \
     media="download" \
     file1="../directx9/directx_apr2006_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dmusic32.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dmusic32.dll"
 
 load_dmusic32()
 {
     w_download_to directx9 https://download.microsoft.com/download/3/9/7/3972f80c-5711-4e14-9483-959d48a2d03b/directx_apr2006_redist.exe dd8c3d401efe4561b67bd88475201b2f62f43cd23e4acc947bb34a659fa74952
 
-    w_try_cabextract -d "$W_TMP" -F DirectX.cab "$W_CACHE"/directx9/directx_apr2006_redist.exe
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F dmusic32.dll "$W_TMP"/DirectX.cab
+    w_try_cabextract -d "${W_TMP}" -F DirectX.cab "${W_CACHE}"/directx9/directx_apr2006_redist.exe
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F dmusic32.dll "${W_TMP}"/DirectX.cab
 
     w_override_dlls native dmusic32
 }
@@ -8331,14 +8331,14 @@ w_metadata dmband dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dmband.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dmband.dll"
 
 load_dmband()
 {
     helper_directx_dl
 
-    w_try_cabextract -d "$W_TMP" -L -F dxnt.cab "$W_CACHE"/directx9/$DIRECTX_NAME
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dmband.dll' "$W_TMP/dxnt.cab"
+    w_try_cabextract -d "${W_TMP}" -L -F dxnt.cab "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dmband.dll' "${W_TMP}/dxnt.cab"
 
     w_override_dlls native dmband
     w_try_regsvr dmband.dll
@@ -8352,14 +8352,14 @@ w_metadata dmcompos dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dmcompos.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dmcompos.dll"
 
 load_dmcompos()
 {
     helper_directx_dl
 
-    w_try_cabextract -d "$W_TMP" -L -F dxnt.cab "$W_CACHE"/directx9/$DIRECTX_NAME
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dmcompos.dll' "$W_TMP/dxnt.cab"
+    w_try_cabextract -d "${W_TMP}" -L -F dxnt.cab "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dmcompos.dll' "${W_TMP}/dxnt.cab"
 
     w_override_dlls native dmcompos
     w_try_regsvr dmcompos.dll
@@ -8373,14 +8373,14 @@ w_metadata dmime dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dmime.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dmime.dll"
 
 load_dmime()
 {
     helper_directx_dl
 
-    w_try_cabextract -d "$W_TMP" -L -F dxnt.cab "$W_CACHE"/directx9/$DIRECTX_NAME
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dmime.dll' "$W_TMP/dxnt.cab"
+    w_try_cabextract -d "${W_TMP}" -L -F dxnt.cab "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dmime.dll' "${W_TMP}/dxnt.cab"
 
     w_override_dlls native dmime
     w_try_regsvr dmime.dll
@@ -8394,14 +8394,14 @@ w_metadata dmloader dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dmloader.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dmloader.dll"
 
 load_dmloader()
 {
     helper_directx_dl
 
-    w_try_cabextract -d "$W_TMP" -L -F dxnt.cab "$W_CACHE"/directx9/$DIRECTX_NAME
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dmloader.dll' "$W_TMP/dxnt.cab"
+    w_try_cabextract -d "${W_TMP}" -L -F dxnt.cab "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dmloader.dll' "${W_TMP}/dxnt.cab"
 
     w_override_dlls native dmloader
     w_try_regsvr dmloader.dll
@@ -8415,14 +8415,14 @@ w_metadata dmscript dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dmscript.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dmscript.dll"
 
 load_dmscript()
 {
     helper_directx_dl
 
-    w_try_cabextract -d "$W_TMP" -L -F dxnt.cab "$W_CACHE"/directx9/$DIRECTX_NAME
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dmscript.dll' "$W_TMP/dxnt.cab"
+    w_try_cabextract -d "${W_TMP}" -L -F dxnt.cab "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dmscript.dll' "${W_TMP}/dxnt.cab"
 
     w_override_dlls native dmscript
     w_try_regsvr dmscript.dll
@@ -8436,14 +8436,14 @@ w_metadata dmstyle dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dmstyle.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dmstyle.dll"
 
 load_dmstyle()
 {
     helper_directx_dl
 
-    w_try_cabextract -d "$W_TMP" -L -F dxnt.cab "$W_CACHE"/directx9/$DIRECTX_NAME
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dmstyle.dll' "$W_TMP/dxnt.cab"
+    w_try_cabextract -d "${W_TMP}" -L -F dxnt.cab "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dmstyle.dll' "${W_TMP}/dxnt.cab"
 
     w_override_dlls native dmstyle
     w_try_regsvr dmstyle.dll
@@ -8457,14 +8457,14 @@ w_metadata dmsynth dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dmsynth.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dmsynth.dll"
 
 load_dmsynth()
 {
     helper_directx_dl
 
-    w_try_cabextract -d "$W_TMP" -L -F dxnt.cab "$W_CACHE"/directx9/$DIRECTX_NAME
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dmsynth.dll' "$W_TMP/dxnt.cab"
+    w_try_cabextract -d "${W_TMP}" -L -F dxnt.cab "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dmsynth.dll' "${W_TMP}/dxnt.cab"
 
     w_override_dlls native dmsynth
     w_try_regsvr dmsynth.dll
@@ -8478,14 +8478,14 @@ w_metadata dmusic dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dmusic.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dmusic.dll"
 
 load_dmusic()
 {
     helper_directx_dl
 
-    w_try_cabextract -d "$W_TMP" -L -F dxnt.cab "$W_CACHE"/directx9/$DIRECTX_NAME
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dmusic.dll' "$W_TMP/dxnt.cab"
+    w_try_cabextract -d "${W_TMP}" -L -F dxnt.cab "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dmusic.dll' "${W_TMP}/dxnt.cab"
 
     w_override_dlls native dmusic
     w_try_regsvr dmusic.dll
@@ -8499,14 +8499,14 @@ w_metadata dswave dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dswave.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dswave.dll"
 
 load_dswave()
 {
     helper_directx_dl
 
-    w_try_cabextract -d "$W_TMP" -L -F dxnt.cab "$W_CACHE"/directx9/$DIRECTX_NAME
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dswave.dll' "$W_TMP/dxnt.cab"
+    w_try_cabextract -d "${W_TMP}" -L -F dxnt.cab "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dswave.dll' "${W_TMP}/dxnt.cab"
 
     w_override_dlls native dswave
     w_try_regsvr dswave.dll
@@ -8535,9 +8535,9 @@ load_dotnet11()
     w_call corefonts
     w_call fontfix
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     # Use builtin regsvcs.exe to work around https://bugs.winehq.org/show_bug.cgi?id=25120
-    if [ -n "$W_OPT_UNATTENDED" ]; then
+    if [ -n "${W_OPT_UNATTENDED}" ]; then
         WINEDLLOVERRIDES="regsvcs.exe=b" w_ahk_do "
             SetTitleMatchMode, 2
             run, dotnetfx.exe /q /C:\"install /q\"
@@ -8559,12 +8559,12 @@ load_dotnet11()
             }
         "
     else
-        WINEDLLOVERRIDES="regsvcs.exe=b" w_try "$WINE" dotnetfx.exe
+        WINEDLLOVERRIDES="regsvcs.exe=b" w_try "${WINE}" dotnetfx.exe
     fi
 
     w_override_dlls native mscorwks
 
-    W_NGEN_CMD="w_try $WINE $W_DRIVE_C/windows/Microsoft.NET/Framework/v1.1.4322/ngen.exe executequeueditems"
+    W_NGEN_CMD="w_try ${WINE} ${W_DRIVE_C}/windows/Microsoft.NET/Framework/v1.1.4322/ngen.exe executequeueditems"
 }
 
 verify_dotnet11()
@@ -8592,9 +8592,9 @@ load_dotnet11sp1()
     w_call remove_mono
     w_call dotnet11
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     # Use builtin regsvcs.exe to work around https://bugs.winehq.org/show_bug.cgi?id=25120
-    if [ -n "$W_OPT_UNATTENDED" ]; then
+    if [ -n "${W_OPT_UNATTENDED}" ]; then
         WINEDLLOVERRIDES="regsvcs.exe=b" w_ahk_do "
             SetTitleMatchMode, 2
             run, NDP1.1sp1-KB867460-X86.exe /q /C:"install /q"
@@ -8616,12 +8616,12 @@ load_dotnet11sp1()
             }
         "
     else
-        WINEDLLOVERRIDES="regsvcs.exe=b" w_try "$WINE" "$W_CACHE"/dotnet11sp1/NDP1.1sp1-KB867460-X86.exe
+        WINEDLLOVERRIDES="regsvcs.exe=b" w_try "${WINE}" "${W_CACHE}"/dotnet11sp1/NDP1.1sp1-KB867460-X86.exe
     fi
 
     w_override_dlls native mscorwks
 
-    W_NGEN_CMD="w_try $WINE $W_DRIVE_C/windows/Microsoft.NET/Framework/v1.1.4322/ngen.exe executequeueditems"
+    W_NGEN_CMD="w_try ${WINE} ${W_DRIVE_C}/windows/Microsoft.NET/Framework/v1.1.4322/ngen.exe executequeueditems"
 }
 
 verify_dotnet11sp1()
@@ -8645,7 +8645,7 @@ load_dotnet20()
     w_call remove_mono
     w_call fontfix
 
-    if [ "$W_ARCH" = "win32" ]; then
+    if [ "${W_ARCH}" = "win32" ]; then
         # https://www.microsoft.com/en-us/download/details.aspx?id=19
         w_download https://download.lenovo.com/ibmdl/pub/pc/pccbbs/thinkvantage_en/dotnetfx.exe 46693d9b74d12454d117cc61ff2e9481cabb100b4d74eb5367d3cf88b89a0e71
 
@@ -8654,7 +8654,7 @@ load_dotnet20()
 
         # if dotnet11 if installed there is a warning dialog, but it still verifies
         # dotnet11 doesn't work on 64-bit, so no need to run there
-        w_try_cd "$W_CACHE/$W_PACKAGE"
+        w_try_cd "${W_CACHE}/${W_PACKAGE}"
         if [ -n "${W_OPT_UNATTENDED}" ]; then
             w_ahk_do "
                 SetTitleMatchMode, 2
@@ -8679,7 +8679,7 @@ load_dotnet20()
                 }
             "
         else
-            w_try_ms_installer "$WINE" dotnetfx.exe ${W_OPT_UNATTENDED:+/q /c:"install.exe /q"}
+            w_try_ms_installer "${WINE}" dotnetfx.exe ${W_OPT_UNATTENDED:+/q /c:"install.exe /q"}
         fi
 
         w_set_winver 'default'
@@ -8690,18 +8690,18 @@ load_dotnet20()
         # so for now just remove the bogus msvc*80.dll files it installs.
         # See also https://bugs.winehq.org/show_bug.cgi?id=16577
         # This affects Victoria 2 demo, see https://forum.paradoxplaza.com/forum/showthread.php?p=11523967
-        rm -f "$W_SYSTEM32_DLLS"/msvc?80.dll
-    elif [ "$W_ARCH" = "win64" ]; then
+        rm -f "${W_SYSTEM32_DLLS}"/msvc?80.dll
+    elif [ "${W_ARCH}" = "win64" ]; then
         w_download https://download.microsoft.com/download/a/3/f/a3f1bf98-18f3-4036-9b68-8e6de530ce0a/NetFx64.exe 7ea86dca8eeaedcaa4a17370547ca2cea9e9b6774972b8e03d2cb1fb0e798669
 
         # validates successfully in win7 mode wine-3.19, so not setting winversion
-        w_try_cd "$W_CACHE"/"$W_PACKAGE"
-        w_try "$WINE" NetFx64.exe ${W_OPT_UNATTENDED:+/q /c:"install.exe /q"}
+        w_try_cd "${W_CACHE}"/"${W_PACKAGE}"
+        w_try "${WINE}" NetFx64.exe ${W_OPT_UNATTENDED:+/q /c:"install.exe /q"}
     fi
 
     w_override_dlls native mscorwks
 
-    W_NGEN_CMD="w_try $WINE $W_DRIVE_C/windows/Microsoft.NET/Framework/v2.0.50727/ngen.exe executequeueditems"
+    W_NGEN_CMD="w_try ${WINE} ${W_DRIVE_C}/windows/Microsoft.NET/Framework/v2.0.50727/ngen.exe executequeueditems"
 }
 
 verify_dotnet20()
@@ -8718,7 +8718,7 @@ w_metadata dotnet20sdk apps \
     media="download" \
     conflicts="dotnet11 dotnet20sp1 dotnet20sp2 dotnet30 dotnet40" \
     file1="setup.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/Microsoft.NET/SDK/v2.0/Bin/cordbg.exe"
+    installed_file1="${W_PROGRAMS_X86_WIN}/Microsoft.NET/SDK/v2.0/Bin/cordbg.exe"
 
 load_dotnet20sdk()
 {
@@ -8731,7 +8731,7 @@ load_dotnet20sdk()
 
     w_call dotnet20
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetTitleMatchMode, 2
         run, setup.exe ${W_OPT_UNATTENDED:+/q /c:"install.exe /q"}
@@ -8800,21 +8800,21 @@ load_dotnet20sp1()
     # See https://github.com/Winetricks/winetricks/pull/1271
     # https://bugs.winehq.org/show_bug.cgi?id=47484, et al
     if w_wine_version_in ,4.0 ; then
-        WINEDLLOVERRIDES="regsvcs.exe,mscorsvw.exe=b;$WINEDLLOVERRIDES"
+        WINEDLLOVERRIDES="regsvcs.exe,mscorsvw.exe=b;${WINEDLLOVERRIDES}"
         export WINEDLLOVERRIDES
     else
-        WINEDLLOVERRIDES="ngen.exe,regsvcs.exe,mscorsvw.exe=b;$WINEDLLOVERRIDES"
+        WINEDLLOVERRIDES="ngen.exe,regsvcs.exe,mscorsvw.exe=b;${WINEDLLOVERRIDES}"
         export WINEDLLOVERRIDES
     fi
 
-    if [ "$W_ARCH" = "win32" ]; then
+    if [ "${W_ARCH}" = "win32" ]; then
         # https://www.microsoft.com/en-us/download/details.aspx?id=16614
         w_download https://download.microsoft.com/download/0/8/c/08c19fa4-4c4f-4ffb-9d6c-150906578c9e/NetFx20SP1_x86.exe c36c3a1d074de32d53f371c665243196a7608652a2fc6be9520312d5ce560871
         exe="NetFx20SP1_x86.exe"
 
         w_warn "Setting Windows version so installer works"
         w_set_winver win2k
-    elif [ "$W_ARCH" = "win64" ]; then
+    elif [ "${W_ARCH}" = "win64" ]; then
         # https://www.microsoft.com/en-us/download/details.aspx?id=6041
         w_download https://download.microsoft.com/download/9/8/6/98610406-c2b7-45a4-bdc3-9db1b1c5f7e2/NetFx20SP1_x64.exe 1731e53de5f48baae0963677257660df1329549e81c48b4d7db7f7f3f2329aab
         exe="NetFx20SP1_x64.exe"
@@ -8823,23 +8823,23 @@ load_dotnet20sp1()
         w_set_winver winxp
     fi
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try_ms_installer "$WINE" "$exe" ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try_ms_installer "${WINE}" "${exe}" ${W_OPT_UNATTENDED:+/q}
 
-    if [ "$W_ARCH" = "win32" ]; then
+    if [ "${W_ARCH}" = "win32" ]; then
         # We can't stop installing dotnet20sp1 in win2k mode until Wine supports
         # reparse/junction points
         # (see https://bugs.winehq.org/show_bug.cgi?id=10467#c57 )
         # so for now just remove the bogus msvc*80.dll files it installs.
         # See also https://bugs.winehq.org/show_bug.cgi?id=16577
         # This affects Victoria 2 demo, see https://forum.paradoxplaza.com/forum/showthread.php?p=11523967
-        rm -f "$W_SYSTEM32_DLLS"/msvc?80.dll
+        rm -f "${W_SYSTEM32_DLLS}"/msvc?80.dll
 
     fi
 
     w_set_winver 'default'
 
-    W_NGEN_CMD="w_try $WINE $W_DRIVE_C/windows/Microsoft.NET/Framework/v2.0.50727/ngen.exe executequeueditems"
+    W_NGEN_CMD="w_try ${WINE} ${W_DRIVE_C}/windows/Microsoft.NET/Framework/v2.0.50727/ngen.exe executequeueditems"
 
     w_override_dlls native mscorwks
 
@@ -8872,42 +8872,42 @@ load_dotnet20sp2()
     # See https://github.com/Winetricks/winetricks/pull/1271
     # https://bugs.winehq.org/show_bug.cgi?id=47484, et al
     if w_wine_version_in ,4.0 ; then
-        WINEDLLOVERRIDES="regsvcs.exe,mscorsvw.exe=b;$WINEDLLOVERRIDES"
+        WINEDLLOVERRIDES="regsvcs.exe,mscorsvw.exe=b;${WINEDLLOVERRIDES}"
         export WINEDLLOVERRIDES
     else
-        WINEDLLOVERRIDES="ngen.exe,regsvcs.exe,mscorsvw.exe=b;$WINEDLLOVERRIDES"
+        WINEDLLOVERRIDES="ngen.exe,regsvcs.exe,mscorsvw.exe=b;${WINEDLLOVERRIDES}"
         export WINEDLLOVERRIDES
     fi
     w_warn "Setting Windows version so installer works"
     w_set_winver winxp
 
-    if [ "$W_ARCH" = "win32" ]; then
+    if [ "${W_ARCH}" = "win32" ]; then
         # https://www.microsoft.com/en-us/download/details.aspx?id=1639
         w_download https://download.microsoft.com/download/c/6/e/c6e88215-0178-4c6c-b5f3-158ff77b1f38/NetFx20SP2_x86.exe 6e3f363366e7d0219b7cb269625a75d410a5c80d763cc3d73cf20841084e851f
         exe="NetFx20SP2_x86.exe"
-    elif [ "$W_ARCH" = "win64" ]; then
+    elif [ "${W_ARCH}" = "win64" ]; then
         # https://www.microsoft.com/en-us/download/details.aspx?id=1639
         w_download https://download.microsoft.com/download/c/6/e/c6e88215-0178-4c6c-b5f3-158ff77b1f38/NetFx20SP2_x64.exe
         exe="NetFx20SP2_x64.exe"
     fi
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try_ms_installer "$WINE" "$exe" ${W_OPT_UNATTENDED:+ /q /c:"install.exe /q"}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try_ms_installer "${WINE}" "${exe}" ${W_OPT_UNATTENDED:+ /q /c:"install.exe /q"}
 
-    if [ "$W_ARCH" = "win32" ]; then
+    if [ "${W_ARCH}" = "win32" ]; then
         # We can't stop installing dotnet20sp1 in win2k mode until Wine supports
         # reparse/junction points
         # (see https://bugs.winehq.org/show_bug.cgi?id=10467#c57 )
         # so for now just remove the bogus msvc*80.dll files it installs.
         # See also https://bugs.winehq.org/show_bug.cgi?id=16577
         # This affects Victoria 2 demo, see https://forum.paradoxplaza.com/forum/showthread.php?p=11523967
-        rm -f "$W_SYSTEM32_DLLS"/msvc?80.dll
+        rm -f "${W_SYSTEM32_DLLS}"/msvc?80.dll
     fi
 
     w_set_winver 'default'
     w_override_dlls native mscorwks
 
-    W_NGEN_CMD="w_try $WINE $W_DRIVE_C/windows/Microsoft.NET/Framework/v2.0.50727/ngen.exe executequeueditems"
+    W_NGEN_CMD="w_try ${WINE} ${W_DRIVE_C}/windows/Microsoft.NET/Framework/v2.0.50727/ngen.exe executequeueditems"
 }
 
 verify_dotnet20sp2()
@@ -8949,10 +8949,10 @@ load_dotnet30()
         esac
     fi
 
-    case "$W_PLATFORM" in
+    case "${W_PLATFORM}" in
         windows_cmd)
             osver=$(cmd /c ver)
-            case "$osver" in
+            case "${osver}" in
                 *Version?6*) w_die "Vista and up bundle .NET 3.0, so you can't install it like this" ;;
             esac
             ;;
@@ -8970,23 +8970,23 @@ load_dotnet30()
 
     # Delete FontCache 3.0 service, it's in Wine for Mono, breaks native .NET
     # OK if this fails, that just means you have an older Wine.
-    "$WINE" sc delete "FontCache3.0.0.0"
+    "${WINE}" sc delete "FontCache3.0.0.0"
 
     # Not sure when exactly it was fixed, but it works with 4.0+, and doesn't in 3.0
     # Given that 3.x is deprecated, not worth looking into.
     # See https://github.com/Winetricks/winetricks/pull/1271
     # https://bugs.winehq.org/show_bug.cgi?id=47484, et al
     if w_wine_version_in ,4.0 ; then
-        WINEDLLOVERRIDES="mscorsvw.exe=b;$WINEDLLOVERRIDES"
+        WINEDLLOVERRIDES="mscorsvw.exe=b;${WINEDLLOVERRIDES}"
         export WINEDLLOVERRIDES
     else
-        WINEDLLOVERRIDES="ngen.exe,mscorsvw.exe=b;$WINEDLLOVERRIDES"
+        WINEDLLOVERRIDES="ngen.exe,mscorsvw.exe=b;${WINEDLLOVERRIDES}"
         export WINEDLLOVERRIDES
     fi
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_warn "Installing .NET 3.0 runtime silently, as otherwise it gets hidden behind taskbar. Installation usually takes about 3 minutes."
-    w_try "$WINE" "$file1" /q /c:"install.exe /q"
+    w_try "${WINE}" "${file1}" /q /c:"install.exe /q"
 
     w_override_dlls native mscorwks
 
@@ -9036,17 +9036,17 @@ load_dotnet30sp1()
         w_call prntvpt
     fi
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
-    "$WINE" reg add "HKLM\\Software\\Microsoft\\Net Framework Setup\\NDP\\v3.0" /v Version /t REG_SZ /d "3.0" /f
-    "$WINE" reg add "HKLM\\Software\\Microsoft-\\Net Framework Setup\\NDP\\v3.0" /v SP /t REG_DWORD /d 0001 /f
+    "${WINE}" reg add "HKLM\\Software\\Microsoft\\Net Framework Setup\\NDP\\v3.0" /v Version /t REG_SZ /d "3.0" /f
+    "${WINE}" reg add "HKLM\\Software\\Microsoft-\\Net Framework Setup\\NDP\\v3.0" /v SP /t REG_DWORD /d 0001 /f
 
     w_set_winver winxp
 
-    w_try "$WINE" msiexec /i "XPSEP XP and Server 2003 32 bit.msi" ${W_OPT_UNATTENDED:+/qb}
-    "$WINE" sc delete FontCache3.0.0.0
+    w_try "${WINE}" msiexec /i "XPSEP XP and Server 2003 32 bit.msi" ${W_OPT_UNATTENDED:+/qb}
+    "${WINE}" sc delete FontCache3.0.0.0
 
-    w_try_ms_installer "$WINE" "$file1" ${W_OPT_UNATTENDED:+/q}
+    w_try_ms_installer "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+/q}
 
     w_override_dlls native mscorwks
     w_set_winver 'default'
@@ -9087,8 +9087,8 @@ load_dotnet35()
     w_override_dlls native mscoree mscorwks
     w_wineserver -w
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try_ms_installer "$WINE" "${file1}" /lang:ENU ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try_ms_installer "${WINE}" "${file1}" /lang:ENU ${W_OPT_UNATTENDED:+/q}
 
     # Doesn't install any ngen.exe
     # W_NGEN_CMD=""
@@ -9123,8 +9123,8 @@ load_dotnet35sp1()
 
     w_set_winver winxp
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try_ms_installer "$WINE" dotnetfx35.exe /lang:ENU ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try_ms_installer "${WINE}" dotnetfx35.exe /lang:ENU ${W_OPT_UNATTENDED:+/q}
 
     # Doesn't install any ngen.exe
     # W_NGEN_CMD=""
@@ -9152,12 +9152,12 @@ load_dotnet40()
 
     w_package_warn_win64
 
-    case "$W_PLATFORM" in
+    case "${W_PLATFORM}" in
         windows_cmd) ;;
         *) w_warn "dotnet40 does not yet fully work or install on wine.  Caveat emptor." ;;
     esac
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         w_workaround_wine_bug 42701 "On 64-bit, you'll run into https://bugs.winehq.org/show_bug.cgi?id=42701 (missing api-ms-win-core-winrt-roparameterizediid-l1-1-0.dll.RoGetParameterizedTypeInstanceIID", 2.22
     fi
 
@@ -9168,19 +9168,19 @@ load_dotnet40()
 
     w_call winxp
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
-    WINEDLLOVERRIDES=fusion=b w_try_ms_installer "$WINE" dotNetFx40_Full_x86_x64.exe ${W_OPT_UNATTENDED:+/q /c:"install.exe /q"}
+    WINEDLLOVERRIDES=fusion=b w_try_ms_installer "${WINE}" dotNetFx40_Full_x86_x64.exe ${W_OPT_UNATTENDED:+/q /c:"install.exe /q"}
 
     w_override_dlls native mscoree
 
-    "$WINE" reg add "HKLM\\Software\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full" /v Install /t REG_DWORD /d 0001 /f
-    "$WINE" reg add "HKLM\\Software\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full" /v Version /t REG_SZ /d "4.0.30319" /f
+    "${WINE}" reg add "HKLM\\Software\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full" /v Install /t REG_DWORD /d 0001 /f
+    "${WINE}" reg add "HKLM\\Software\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full" /v Version /t REG_SZ /d "4.0.30319" /f
 
-    W_NGEN_CMD="$WINE $WINEPREFIX/drive_c/windows/Microsoft.NET/Framework/v4.0.30319/ngen.exe executequeueditems"
+    W_NGEN_CMD="${WINE} ${WINEPREFIX}/drive_c/windows/Microsoft.NET/Framework/v4.0.30319/ngen.exe executequeueditems"
 
     # Avoid a popup on WINEPREFIX updates, see https://bugs.winehq.org/show_bug.cgi?id=41727#c5
-    "$WINE" reg add "HKLM\\Software\\Microsoft\\.NETFramework" /v OnlyUseLatestCLR /t REG_DWORD /d 0001 /f
+    "${WINE}" reg add "HKLM\\Software\\Microsoft\\.NETFramework" /v OnlyUseLatestCLR /t REG_DWORD /d 0001 /f
 
     w_set_winver 'default'
 }
@@ -9207,16 +9207,16 @@ load_dotnet40_kb2468871()
     w_call dotnet40
 
     # Install KB2468871:
-    if [ "$W_ARCH" = "win32" ]; then
+    if [ "${W_ARCH}" = "win32" ]; then
         w_download https://download.microsoft.com/download/2/B/F/2BF4D7D1-E781-4EE0-9E4F-FDD44A2F8934/NDP40-KB2468871-v2-x86.exe 8822672fc864544e0766c80b635973bd9459d719b1af75f51483ff36cfb26f03
-        w_try_7z "$W_TMP" "${W_CACHE}/${W_PACKAGE}/NDP40-KB2468871-v2-x86.exe" NDP40-KB2468871.msp
-    elif [ "$W_ARCH" = "win64" ]; then
+        w_try_7z "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/NDP40-KB2468871-v2-x86.exe" NDP40-KB2468871.msp
+    elif [ "${W_ARCH}" = "win64" ]; then
         w_download https://download.microsoft.com/download/2/B/F/2BF4D7D1-E781-4EE0-9E4F-FDD44A2F8934/NDP40-KB2468871-v2-x64.exe b1b53c3953377b111fe394dd57592d342cfc8a3261a5575253b211c1c2e48ff8
-        w_try_7z "$W_TMP" "${W_CACHE}/${W_PACKAGE}/NDP40-KB2468871-v2-x64.exe" NDP40-KB2468871.msp
+        w_try_7z "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/NDP40-KB2468871-v2-x64.exe" NDP40-KB2468871.msp
     fi
 
-    w_try_cd "$W_TMP"
-    w_try "$WINE" msiexec /p NDP40-KB2468871.msp
+    w_try_cd "${W_TMP}"
+    w_try "${WINE}" msiexec /p NDP40-KB2468871.msp
 
     w_set_winver 'default'
 }
@@ -9257,14 +9257,14 @@ load_dotnet45()
     w_call dotnet40
     w_set_winver win7
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
-    WINEDLLOVERRIDES=fusion=b w_try_ms_installer "$WINE" dotnetfx45_full_x86_x64.exe ${W_OPT_UNATTENDED:+/q /c:"install.exe /q"}
+    WINEDLLOVERRIDES=fusion=b w_try_ms_installer "${WINE}" dotnetfx45_full_x86_x64.exe ${W_OPT_UNATTENDED:+/q /c:"install.exe /q"}
 
     w_override_dlls native mscoree
 
     # Avoid a popup on WINEPREFIX updates, see https://bugs.winehq.org/show_bug.cgi?id=41727#c5
-    "$WINE" reg add "HKLM\\Software\\Microsoft\\.NETFramework" /v OnlyUseLatestCLR /t REG_DWORD /d 0001 /f
+    "${WINE}" reg add "HKLM\\Software\\Microsoft\\.NETFramework" /v OnlyUseLatestCLR /t REG_DWORD /d 0001 /f
 
     w_warn "Setting Windows version to 2003, otherwise applications using .NET 4.5 will subtly fail"
     w_set_winver win2k3
@@ -9306,9 +9306,9 @@ load_dotnet452()
     w_call dotnet40
     w_set_winver win7
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
-    WINEDLLOVERRIDES=fusion=b w_try_ms_installer "$WINE" NDP452-KB2901907-x86-x64-AllOS-ENU.exe ${W_OPT_UNATTENDED:+/q /c:"install.exe /q"}
+    WINEDLLOVERRIDES=fusion=b w_try_ms_installer "${WINE}" NDP452-KB2901907-x86-x64-AllOS-ENU.exe ${W_OPT_UNATTENDED:+/q /c:"install.exe /q"}
 
     w_override_dlls native mscoree
 
@@ -9346,16 +9346,16 @@ load_dotnet46()
     w_call dotnet45
     w_set_winver win7
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
-    if w_workaround_wine_bug 42470 "$W_PACKAGE may experience heap timeouts" ,3.14; then
+    if w_workaround_wine_bug 42470 "${W_PACKAGE} may experience heap timeouts" ,3.14; then
         w_warn "If you see heap timeouts like: 'err:ntdll:RtlpWaitForCriticalSection section 0x110060 \"heap.c: main process heap section\" wait timed out in thread 0064, blocked by 0000, retrying (60 sec)', try the patch from https://bugs.winehq.org/show_bug.cgi?id=42470"
     fi
 
     if w_workaround_wine_bug 38959 "This installer will fail unless run in quiet mode. See: https://bugs.winehq.org/show_bug.cgi?id=38959" ,3.6; then
-        WINEDLLOVERRIDES=fusion=b w_try_ms_installer "$WINE" "$file1" /q /c:"install.exe /q"
+        WINEDLLOVERRIDES=fusion=b w_try_ms_installer "${WINE}" "${file1}" /q /c:"install.exe /q"
     else
-        WINEDLLOVERRIDES=fusion=b w_try_ms_installer "$WINE" "$file1" ${W_OPT_UNATTENDED:+/q /c:"install.exe /q"}
+        WINEDLLOVERRIDES=fusion=b w_try_ms_installer "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+/q /c:"install.exe /q"}
     fi
 
     w_override_dlls native mscoree
@@ -9391,9 +9391,9 @@ load_dotnet461()
     w_call dotnet46
     w_set_winver win7
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
-    WINEDLLOVERRIDES=fusion=b w_try_ms_installer "$WINE" "$file1" /sfxlang:1027 ${W_OPT_UNATTENDED:+/q /norestart}
+    WINEDLLOVERRIDES=fusion=b w_try_ms_installer "${WINE}" "${file1}" /sfxlang:1027 ${W_OPT_UNATTENDED:+/q /norestart}
 
     w_override_dlls native mscoree
 
@@ -9431,9 +9431,9 @@ load_dotnet462()
     w_call dotnet461
     w_set_winver win7
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
-    WINEDLLOVERRIDES=fusion=b w_try_ms_installer "$WINE" "$file_package" ${W_OPT_UNATTENDED:+/sfxlang:1027 /q /norestart}
+    WINEDLLOVERRIDES=fusion=b w_try_ms_installer "${WINE}" "${file_package}" ${W_OPT_UNATTENDED:+/sfxlang:1027 /q /norestart}
 
     w_override_dlls native mscoree
 
@@ -9472,9 +9472,9 @@ load_dotnet471()
     w_call dotnet462
     w_set_winver win7
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
-    WINEDLLOVERRIDES=fusion=b w_try_ms_installer "$WINE" "$file1" ${W_OPT_UNATTENDED:+/sfxlang:1027 /q /norestart}
+    WINEDLLOVERRIDES=fusion=b w_try_ms_installer "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+/sfxlang:1027 /q /norestart}
 
     w_override_dlls native mscoree
 
@@ -9511,9 +9511,9 @@ load_dotnet472()
     w_call dotnet462
     w_set_winver win7
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
-    WINEDLLOVERRIDES=fusion=b w_try_ms_installer "$WINE" NDP472-KB4054530-x86-x64-AllOS-ENU.exe ${W_OPT_UNATTENDED:+/sfxlang:1027 /q /norestart}
+    WINEDLLOVERRIDES=fusion=b w_try_ms_installer "${WINE}" NDP472-KB4054530-x86-x64-AllOS-ENU.exe ${W_OPT_UNATTENDED:+/sfxlang:1027 /q /norestart}
 
     w_override_dlls native mscoree
 
@@ -9551,9 +9551,9 @@ load_dotnet48()
     w_call dotnet40
     w_set_winver win7
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
-    WINEDLLOVERRIDES=fusion=b w_try_ms_installer "$WINE" "$file1" ${W_OPT_UNATTENDED:+/sfxlang:1027 /q /norestart}
+    WINEDLLOVERRIDES=fusion=b w_try_ms_installer "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+/sfxlang:1027 /q /norestart}
 
     w_override_dlls native mscoree
 
@@ -9574,20 +9574,20 @@ w_metadata dotnetcore2 dlls \
     year="2020" \
     media="download" \
     file1="dotnet-runtime-2.1.17-win-x86.exe" \
-    installed_file1="$W_PROGRAMS_WIN/dotnet/dotnet.exe"
+    installed_file1="${W_PROGRAMS_WIN}/dotnet/dotnet.exe"
 
 load_dotnetcore2()
 {
     # Official version, see https://dotnet.microsoft.com/download/dotnet-core/2.1
     w_download https://download.visualstudio.microsoft.com/download/pr/73a0ea97-57d6-4263-ac36-ea3a9b373bcf/cd5f7e08e749c1d3468cdae89e4518de/dotnet-runtime-2.1.17-win-x86.exe 706a7f0ad998c3c1b321e89e4bcd6304bef31c95c83eda119e8d4adccccbc915
 
-    w_try_cd "$W_CACHE"/"$W_PACKAGE"
-    w_try "$WINE" "$file1" ${W_OPT_UNATTENDED:+/quiet}
+    w_try_cd "${W_CACHE}"/"${W_PACKAGE}"
+    w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+/quiet}
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         # Also install the 64-bit version
         w_download https://download.visualstudio.microsoft.com/download/pr/cd223083-8c0e-4963-9fcd-fcf01a55e56c/15500e764899442ed6e014687caa34e9/dotnet-runtime-2.1.17-win-x64.exe 5a065ae6f9e031399cb7084c6315ce977342dec069cd6386caed1c5b69d49260
-        w_try "$WINE" "dotnet-runtime-2.1.17-win-x64.exe" ${W_OPT_UNATTENDED:+/quiet}
+        w_try "${WINE}" "dotnet-runtime-2.1.17-win-x64.exe" ${W_OPT_UNATTENDED:+/quiet}
     fi
 }
 
@@ -9599,7 +9599,7 @@ w_metadata dotnet_verifier dlls \
     year="2016" \
     media="download" \
     file1="netfx_setupverifier_new.zip" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/netfx_setupverifier.exe"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/netfx_setupverifier.exe"
 
 load_dotnet_verifier()
 {
@@ -9610,8 +9610,8 @@ load_dotnet_verifier()
 
     w_download https://msdnshared.blob.core.windows.net/media/2018/05/netfx_setupverifier_new.zip 13fd683fd604f9de09a9e649df303100b81e6797f868024d55e5c2f3c14aa9a6
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try_unzip "$W_SYSTEM32_DLLS" netfx_setupverifier_new.zip netfx_setupverifier.exe
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try_unzip "${W_SYSTEM32_DLLS}" netfx_setupverifier_new.zip netfx_setupverifier.exe
 
     w_warn "You can run the .NET Verifier with \"${WINE} netfx_setupverifier.exe\""
 }
@@ -9624,14 +9624,14 @@ w_metadata dx8vb dlls \
     year="2001" \
     media="download" \
     file1="DX81NTger.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dx8vb.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dx8vb.dll"
 
 load_dx8vb()
 {
     # https://www.microsoft.com/de-de/download/details.aspx?id=10968
     w_download https://download.microsoft.com/download/win2000pro/dx/8.1/NT5/DE/DX81NTger.exe 31513966a29dc100165072891d21b5c5e0dd2632abf3409a843cefb3a9886f13
 
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -F dx8vb.dll "$W_CACHE/$W_PACKAGE"/DX81NTger.exe
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -F dx8vb.dll "${W_CACHE}/${W_PACKAGE}"/DX81NTger.exe
 
     w_override_dlls native dx8vb
 }
@@ -9645,18 +9645,18 @@ w_metadata dxdiagn dlls \
     media="download" \
     conflicts="dxdiagn_feb2010" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dxdiagn.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dxdiagn.dll"
 
 load_dxdiagn()
 {
     helper_win7sp1 x86_microsoft-windows-d..x-directxdiagnostic_31bf3856ad364e35_6.1.7601.17514_none_25cb021dbc0611db/dxdiagn.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-d..x-directxdiagnostic_31bf3856ad364e35_6.1.7601.17514_none_25cb021dbc0611db/dxdiagn.dll" "$W_SYSTEM32_DLLS/dxdiagn.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-d..x-directxdiagnostic_31bf3856ad364e35_6.1.7601.17514_none_25cb021dbc0611db/dxdiagn.dll" "${W_SYSTEM32_DLLS}/dxdiagn.dll"
     w_override_dlls native,builtin dxdiagn
     w_try_regsvr dxdiagn.dll
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-d..x-directxdiagnostic_31bf3856ad364e35_6.1.7601.17514_none_81e99da174638311/dxdiagn.dll
-        w_try cp "$W_TMP/amd64_microsoft-windows-d..x-directxdiagnostic_31bf3856ad364e35_6.1.7601.17514_none_81e99da174638311/dxdiagn.dll" "$W_SYSTEM64_DLLS/dxdiagn.dll"
+        w_try cp "${W_TMP}/amd64_microsoft-windows-d..x-directxdiagnostic_31bf3856ad364e35_6.1.7601.17514_none_81e99da174638311/dxdiagn.dll" "${W_SYSTEM64_DLLS}/dxdiagn.dll"
         w_try_regsvr64 dxdiagn.dll
     fi
 }
@@ -9670,14 +9670,14 @@ w_metadata dxdiagn_feb2010 dlls \
     media="download" \
     conflicts="dxdiagn" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dxdiagn.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dxdiagn.dll"
 
 load_dxdiagn_feb2010()
 {
     helper_directx_dl
 
-    w_try_cabextract -d "$W_TMP" -L -F dxnt.cab "$W_CACHE"/directx9/$DIRECTX_NAME
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dxdiagn.dll' "$W_TMP/dxnt.cab"
+    w_try_cabextract -d "${W_TMP}" -L -F dxnt.cab "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dxdiagn.dll' "${W_TMP}/dxnt.cab"
     w_override_dlls native dxdiagn
     w_try_regsvr dxdiagn.dll
 }
@@ -9690,14 +9690,14 @@ w_metadata dsound dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dsound.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dsound.dll"
 
 load_dsound()
 {
     helper_directx_dl
 
-    w_try_cabextract -d "$W_TMP" -L -F dxnt.cab "$W_CACHE"/directx9/$DIRECTX_NAME
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'dsound.dll' "$W_TMP/dxnt.cab"
+    w_try_cabextract -d "${W_TMP}" -L -F dxnt.cab "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dsound.dll' "${W_TMP}/dxnt.cab"
 
     # Don't try to register native dsound; it doesn't export DllRegisterServer().
     w_try_regsvr dsound.dll
@@ -9712,16 +9712,16 @@ w_metadata esent dlls \
     year="2011" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/esent.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/esent.dll"
 
 load_esent()
 {
     helper_win7sp1 x86_microsoft-windows-e..estorageengine-isam_31bf3856ad364e35_6.1.7601.17514_none_f3ebb0cc8a4dd814/esent.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-e..estorageengine-isam_31bf3856ad364e35_6.1.7601.17514_none_f3ebb0cc8a4dd814/esent.dll" "$W_SYSTEM32_DLLS/esent.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-e..estorageengine-isam_31bf3856ad364e35_6.1.7601.17514_none_f3ebb0cc8a4dd814/esent.dll" "${W_SYSTEM32_DLLS}/esent.dll"
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-e..estorageengine-isam_31bf3856ad364e35_6.1.7601.17514_none_500a4c5042ab494a/esent.dll
-        w_try cp "$W_TMP/amd64_microsoft-windows-e..estorageengine-isam_31bf3856ad364e35_6.1.7601.17514_none_500a4c5042ab494a/esent.dll" "$W_SYSTEM64_DLLS/esent.dll"
+        w_try cp "${W_TMP}/amd64_microsoft-windows-e..estorageengine-isam_31bf3856ad364e35_6.1.7601.17514_none_500a4c5042ab494a/esent.dll" "${W_SYSTEM64_DLLS}/esent.dll"
     fi
 
     w_override_dlls native,builtin esent
@@ -9735,7 +9735,7 @@ helper_faudio()
     faudio_archive="$1"
     faudio_version="$(basename "${faudio_archive}" .tar.xz)"
 
-    w_try_cd "$W_TMP"
+    w_try_cd "${W_TMP}"
     w_try tar -Jxf "${W_CACHE}/${W_PACKAGE}/${faudio_archive}"
 
     if [ -d "${faudio_version}/x32" ]; then
@@ -9745,17 +9745,17 @@ helper_faudio()
         # Unless they add something more complex, this should suffice:
         for dll in "${faudio_version}/x32/"*.dll; do
             shortdll="$(basename "${dll}" .dll)"
-            w_try cp "${dll}" "$W_SYSTEM32_DLLS"
-            w_override_dlls native "$shortdll"
+            w_try cp "${dll}" "${W_SYSTEM32_DLLS}"
+            w_override_dlls native "${shortdll}"
         done
     fi
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         for dll in "${faudio_version}/x64/"*.dll; do
             # Note: 'libgcc_s_sjlj-1.dll' is not included in the 64-bit build
             shortdll="$(basename "${dll}" .dll)"
-            w_try cp "${dll}" "$W_SYSTEM64_DLLS"
-            w_override_dlls native "$shortdll"
+            w_try cp "${dll}" "${W_SYSTEM64_DLLS}"
+            w_override_dlls native "${shortdll}"
         done
     fi
 }
@@ -9768,12 +9768,12 @@ w_metadata faudio1901 dlls \
     year="2019" \
     media="download" \
     file1="faudio-19.01.tar.xz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/FAudio.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/FAudio.dll"
 
 load_faudio1901()
 {
     w_download https://github.com/Kron4ek/FAudio-Builds/releases/download/19.01/faudio-19.01.tar.xz f3439090ba36061ee47ebda93e409ae4b2d8886c780c86a197c66ff08b9b573f
-    helper_faudio "$file1"
+    helper_faudio "${file1}"
 }
 
 #----------------------------------------------------------------
@@ -9784,12 +9784,12 @@ w_metadata faudio1902 dlls \
     year="2019" \
     media="download" \
     file1="faudio-19.02.tar.xz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/FAudio.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/FAudio.dll"
 
 load_faudio1902()
 {
     w_download https://github.com/Kron4ek/FAudio-Builds/releases/download/19.02/faudio-19.02.tar.xz 849fec35482748a2b441d8dd7e9a171c7c5c2207d1037c7ffd0265e65f2a4b2b
-    helper_faudio "$file1"
+    helper_faudio "${file1}"
 }
 
 #----------------------------------------------------------------
@@ -9800,12 +9800,12 @@ w_metadata faudio1903 dlls \
     year="2019" \
     media="download" \
     file1="faudio-19.03.tar.xz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/FAudio.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/FAudio.dll"
 
 load_faudio1903()
 {
     w_download https://github.com/Kron4ek/FAudio-Builds/releases/download/19.03/faudio-19.03.tar.xz d5c62437fd5b185e82f464f6a82334af5d666cb506aba218358ea7a3697fdf63
-    helper_faudio "$file1"
+    helper_faudio "${file1}"
 }
 
 #----------------------------------------------------------------
@@ -9816,12 +9816,12 @@ w_metadata faudio1904 dlls \
     year="2019" \
     media="download" \
     file1="faudio-19.04.tar.xz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/FAudio.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/FAudio.dll"
 
 load_faudio1904()
 {
     w_download https://github.com/Kron4ek/FAudio-Builds/releases/download/19.04/faudio-19.04.tar.xz c364db1a18bfb6f6c0f375c641672ca40140b8e5db69dc2c8c9b41d79d0fc56f
-    helper_faudio "$file1"
+    helper_faudio "${file1}"
 }
 
 #----------------------------------------------------------------
@@ -9832,12 +9832,12 @@ w_metadata faudio1905 dlls \
     year="2019" \
     media="download" \
     file1="faudio-19.05.tar.xz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/FAudio.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/FAudio.dll"
 
 load_faudio1905()
 {
     w_download https://github.com/Kron4ek/FAudio-Builds/releases/download/19.05/faudio-19.05.tar.xz 94b44c43c0b2260f8061dd699292c8d58ce56fae330a53314417804df4f5f723
-    helper_faudio "$file1"
+    helper_faudio "${file1}"
 }
 
 #----------------------------------------------------------------
@@ -9848,12 +9848,12 @@ w_metadata faudio1906 dlls \
     year="2019" \
     media="download" \
     file1="faudio-19.06.tar.xz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/FAudio.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/FAudio.dll"
 
 load_faudio1906()
 {
     w_download https://github.com/Kron4ek/FAudio-Builds/releases/download/19.06/faudio-19.06.tar.xz 87639e30f9e913685829e05b925809598409e54c4c51e3d74b977cedd658aaf3
-    helper_faudio "$file1"
+    helper_faudio "${file1}"
 }
 
 #----------------------------------------------------------------
@@ -9864,7 +9864,7 @@ w_metadata faudio190607 dlls \
     year="2019" \
     media="download" \
     file1="faudio-19.06.07.tar.xz" \
-    installed_file1="$W_SYSTEM64_DLLS_WIN64/FAudio.dll"
+    installed_file1="${W_SYSTEM64_DLLS_WIN64}/FAudio.dll"
 
 load_faudio190607()
 {
@@ -9872,7 +9872,7 @@ load_faudio190607()
     w_package_unsupported_win32
 
     w_download https://github.com/Kron4ek/FAudio-Builds/releases/download/19.06.07/faudio-19.06.07.tar.xz e17e3a9dadeb1017dc369fe0d46c3d1945ebceadb7ad2f94a3a1448435ab3f6c
-    helper_faudio "$file1"
+    helper_faudio "${file1}"
 }
 #----------------------------------------------------------------
 
@@ -9881,7 +9881,7 @@ w_metadata faudio dlls \
     publisher="Kron4ek" \
     year="2019" \
     media="download" \
-    installed_file1="$W_SYSTEM64_DLLS_WIN64/FAudio.dll"
+    installed_file1="${W_SYSTEM64_DLLS_WIN64}/FAudio.dll"
 
 load_faudio()
 {
@@ -9901,12 +9901,12 @@ w_metadata filever dlls \
     publisher="Microsoft" \
     year="20??" \
     media="download" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/filever.exe"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/filever.exe"
 
 load_filever()
 {
     helper_winxpsp2_support_tools filever.exe
-    w_try cp "$W_TMP/filever.exe" "$W_SYSTEM32_DLLS/filever.exe"
+    w_try cp "${W_TMP}/filever.exe" "${W_SYSTEM32_DLLS}/filever.exe"
 }
 
 #----------------------------------------------------------------
@@ -9919,9 +9919,9 @@ w_metadata flash dlls \
     year="2020" \
     media="download" \
     file1="fp_32.0.0.363_archive.zip" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/Macromed/Flash/FlashUtil32_32_0_0_363_Plugin.exe" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/Macromed/Flash/FlashUtil32_32_0_0_363_ActiveX.exe" \
-    installed_file3="$W_SYSTEM32_DLLS_WIN/Macromed/Flash/flashplayer32_0r0_363_win_sa.exe" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/Macromed/Flash/FlashUtil32_32_0_0_363_Plugin.exe" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/Macromed/Flash/FlashUtil32_32_0_0_363_ActiveX.exe" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/Macromed/Flash/flashplayer32_0r0_363_win_sa.exe" \
     homepage="https://www.adobe.com/products/flashplayer/"
 
 load_flash()
@@ -9944,7 +9944,7 @@ load_flash()
 
     # 2018/06/24: d4b6f9a5e42cc9f2c7cbd1fd72059d4c1bead91b076afa2ca042d28f0fd7bedb
     # 2020/05/24  a64230033de485f9454a07cdb1b366e1307d005223657086ab8a0b8b91610ed4
-    w_linkcheck_ignore=1 w_download "https://fpdownload.macromedia.com/pub/flashplayer/installers/archive/$_W_archive" a64230033de485f9454a07cdb1b366e1307d005223657086ab8a0b8b91610ed4
+    w_linkcheck_ignore=1 w_download "https://fpdownload.macromedia.com/pub/flashplayer/installers/archive/${_W_archive}" a64230033de485f9454a07cdb1b366e1307d005223657086ab8a0b8b91610ed4
 
     # If OS version is Vista or newer:
     #   1. NPAPI plugin doesn't work
@@ -9954,19 +9954,19 @@ load_flash()
 
     # ActiveX plugin
     # 2014/10/02: 3958827058648cfe05fc6ee510685e8d93f995d3428c3eedbd6814704765672a
-    w_try_unzip "$W_TMP" "$W_CACHE/flash/$_W_archive" "$_W_dirname/${_W_fileprefix}_winax.exe"
-    w_try_cd "$W_TMP/$_W_dirname"
-    w_try "$WINE" "${_W_fileprefix}_winax.exe" ${W_OPT_UNATTENDED:+ /install}
+    w_try_unzip "${W_TMP}" "${W_CACHE}/flash/${_W_archive}" "${_W_dirname}/${_W_fileprefix}_winax.exe"
+    w_try_cd "${W_TMP}/${_W_dirname}"
+    w_try "${WINE}" "${_W_fileprefix}_winax.exe" ${W_OPT_UNATTENDED:+ /install}
 
     # Mozilla / Firefox (NPAPI) plugin
     # 2014/10/02: 17496fd3c863c180aead953d7d4499dd36f997a9570abc2b92f55e4ea1d55d73
-    w_try_unzip "$W_TMP" "$W_CACHE/flash/$_W_archive" "$_W_dirname/${_W_fileprefix}_win.exe"
-    w_try "$WINE" "${_W_fileprefix}_win.exe" ${W_OPT_UNATTENDED:+ /install}
+    w_try_unzip "${W_TMP}" "${W_CACHE}/flash/${_W_archive}" "${_W_dirname}/${_W_fileprefix}_win.exe"
+    w_try "${WINE}" "${_W_fileprefix}_win.exe" ${W_OPT_UNATTENDED:+ /install}
 
     # Projector (standalone player)
     # 2015/07/06: 8640c42e73dc44125045e17abd32412c48f3808a8393c94fc8281cf4b0d87bdc
-    w_try_unzip "$W_TMP" "$W_CACHE/flash/$_W_archive" "$_W_dirname/${_W_fileprefix}_win_sa.exe"
-    w_try mv "${_W_fileprefix}_win_sa.exe" "$W_SYSTEM32_DLLS/Macromed/Flash"
+    w_try_unzip "${W_TMP}" "${W_CACHE}/flash/${_W_archive}" "${_W_dirname}/${_W_fileprefix}_win_sa.exe"
+    w_try mv "${_W_fileprefix}_win_sa.exe" "${W_SYSTEM32_DLLS}/Macromed/Flash"
 
     # After updating the above, you should carry the following steps out by
     # hand to verify that plugin works.
@@ -9997,20 +9997,20 @@ load_flash()
 helper_galliumnine()
 {
     _W_galliumnine_archive="${1}"
-    _W_galliumnine_tmp="$W_TMP/galliumnine"
+    _W_galliumnine_tmp="${W_TMP}/galliumnine"
 
-    w_try rm -rf "$_W_galliumnine_tmp"
-    w_try mkdir -p "$_W_galliumnine_tmp"
-    w_try tar -C "$_W_galliumnine_tmp" --strip-components=1 -zxf "$W_CACHE/$W_PACKAGE/$_W_galliumnine_archive"
-    w_try mv "$_W_galliumnine_tmp/lib32/d3d9-nine.dll.so" "$W_SYSTEM32_DLLS/d3d9-nine.dll"
-    w_try mv "$_W_galliumnine_tmp/bin32/ninewinecfg.exe.so" "$W_SYSTEM32_DLLS/ninewinecfg.exe"
-    if test "$W_ARCH" = "win64"; then
-        w_try mv "$_W_galliumnine_tmp/lib64/d3d9-nine.dll.so" "$W_SYSTEM64_DLLS/d3d9-nine.dll"
-        w_try mv "$_W_galliumnine_tmp/bin64/ninewinecfg.exe.so" "$W_SYSTEM64_DLLS/ninewinecfg.exe"
+    w_try rm -rf "${_W_galliumnine_tmp}"
+    w_try mkdir -p "${_W_galliumnine_tmp}"
+    w_try tar -C "${_W_galliumnine_tmp}" --strip-components=1 -zxf "${W_CACHE}/${W_PACKAGE}/${_W_galliumnine_archive}"
+    w_try mv "${_W_galliumnine_tmp}/lib32/d3d9-nine.dll.so" "${W_SYSTEM32_DLLS}/d3d9-nine.dll"
+    w_try mv "${_W_galliumnine_tmp}/bin32/ninewinecfg.exe.so" "${W_SYSTEM32_DLLS}/ninewinecfg.exe"
+    if test "${W_ARCH}" = "win64"; then
+        w_try mv "${_W_galliumnine_tmp}/lib64/d3d9-nine.dll.so" "${W_SYSTEM64_DLLS}/d3d9-nine.dll"
+        w_try mv "${_W_galliumnine_tmp}/bin64/ninewinecfg.exe.so" "${W_SYSTEM64_DLLS}/ninewinecfg.exe"
     fi
-    w_try rm -rf "$_W_galliumnine_tmp"
+    w_try rm -rf "${_W_galliumnine_tmp}"
     # use ninewinecfg to enable gallium nine
-    WINEDEBUG=-all w_try "$WINE_MULTI" ninewinecfg -e
+    WINEDEBUG=-all w_try "${WINE_MULTI}" ninewinecfg -e
 
     unset _W_galliumnine_tmp _W_galliumnine_archive
 }
@@ -10021,8 +10021,8 @@ w_metadata galliumnine02 dlls \
     year="2019" \
     media="download" \
     file1="gallium-nine-standalone-v0.2.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9-nine.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/ninewinecfg.exe" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9-nine.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/ninewinecfg.exe" \
     homepage="https://github.com/iXit/wine-nine-standalone"
 
 load_galliumnine02()
@@ -10030,7 +10030,7 @@ load_galliumnine02()
     w_package_broken "https://bugs.winehq.org/show_bug.cgi?id=49676" 5.13
 
     w_download "https://github.com/iXit/wine-nine-standalone/releases/download/v0.2/gallium-nine-standalone-v0.2.tar.gz" 6818fe890e343aa32d3d53179bfeb63df40977797bd7b6263e85e2bb57559313
-    helper_galliumnine "$file1"
+    helper_galliumnine "${file1}"
 }
 
 w_metadata galliumnine03 dlls \
@@ -10039,8 +10039,8 @@ w_metadata galliumnine03 dlls \
     year="2019" \
     media="download" \
     file1="gallium-nine-standalone-v0.3.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9-nine.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/ninewinecfg.exe" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9-nine.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/ninewinecfg.exe" \
     homepage="https://github.com/iXit/wine-nine-standalone"
 
 load_galliumnine03()
@@ -10048,7 +10048,7 @@ load_galliumnine03()
     w_package_broken "https://bugs.winehq.org/show_bug.cgi?id=49676" 5.13
 
     w_download "https://github.com/iXit/wine-nine-standalone/releases/download/v0.3/gallium-nine-standalone-v0.3.tar.gz" 8bb564073ab2198e5b9b870f7b8cac8d9bc20bc6accf66c4c798e4b450ec0c91
-    helper_galliumnine "$file1"
+    helper_galliumnine "${file1}"
 }
 
 w_metadata galliumnine04 dlls \
@@ -10057,8 +10057,8 @@ w_metadata galliumnine04 dlls \
     year="2019" \
     media="download" \
     file1="gallium-nine-standalone-v0.4.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9-nine.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/ninewinecfg.exe" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9-nine.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/ninewinecfg.exe" \
     homepage="https://github.com/iXit/wine-nine-standalone"
 
 load_galliumnine04()
@@ -10066,7 +10066,7 @@ load_galliumnine04()
     w_package_broken "https://bugs.winehq.org/show_bug.cgi?id=49676" 5.13
 
     w_download "https://github.com/iXit/wine-nine-standalone/releases/download/v0.4/gallium-nine-standalone-v0.4.tar.gz" 4423c32d46419830c8e68fea86d28e740f17f182c365250c379b5493176e19ab
-    helper_galliumnine "$file1"
+    helper_galliumnine "${file1}"
 }
 
 w_metadata galliumnine05 dlls \
@@ -10075,14 +10075,14 @@ w_metadata galliumnine05 dlls \
     year="2019" \
     media="download" \
     file1="gallium-nine-standalone-v0.5.tar.gz" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9-nine.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/ninewinecfg.exe" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9-nine.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/ninewinecfg.exe" \
     homepage="https://github.com/iXit/wine-nine-standalone"
 
 load_galliumnine05()
 {
     w_download "https://github.com/iXit/wine-nine-standalone/releases/download/v0.5/gallium-nine-standalone-v0.5.tar.gz" c46e06b13a3ba0adee75b27a8b54e9d772f83ed29dee5e203364460771fb1bcd
-    helper_galliumnine "$file1"
+    helper_galliumnine "${file1}"
 }
 
 w_metadata galliumnine dlls \
@@ -10090,8 +10090,8 @@ w_metadata galliumnine dlls \
     publisher="Gallium Nine Team" \
     year="2019" \
     media="download" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/d3d9-nine.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/ninewinecfg.exe" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9-nine.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/ninewinecfg.exe" \
     homepage="https://github.com/iXit/wine-nine-standalone"
 
 load_galliumnine()
@@ -10110,17 +10110,17 @@ w_metadata gdiplus dlls \
     year="2011" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/gdiplus.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/gdiplus.dll"
 
 load_gdiplus()
 {
     # gdiplus has changed in win7. See https://bugs.winehq.org/show_bug.cgi?id=32163#c3
     helper_win7sp1 x86_microsoft.windows.gdiplus_6595b64144ccf1df_1.1.7601.17514_none_72d18a4386696c80/gdiplus.dll
-    w_try cp "$W_TMP/x86_microsoft.windows.gdiplus_6595b64144ccf1df_1.1.7601.17514_none_72d18a4386696c80/gdiplus.dll" "$W_SYSTEM32_DLLS/gdiplus.dll"
+    w_try cp "${W_TMP}/x86_microsoft.windows.gdiplus_6595b64144ccf1df_1.1.7601.17514_none_72d18a4386696c80/gdiplus.dll" "${W_SYSTEM32_DLLS}/gdiplus.dll"
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft.windows.gdiplus_6595b64144ccf1df_1.1.7601.17514_none_2b24536c71ed437a/gdiplus.dll
-        w_try cp "$W_TMP/amd64_microsoft.windows.gdiplus_6595b64144ccf1df_1.1.7601.17514_none_2b24536c71ed437a/gdiplus.dll" "$W_SYSTEM64_DLLS/gdiplus.dll"
+        w_try cp "${W_TMP}/amd64_microsoft.windows.gdiplus_6595b64144ccf1df_1.1.7601.17514_none_2b24536c71ed437a/gdiplus.dll" "${W_SYSTEM64_DLLS}/gdiplus.dll"
     fi
 
     # For some reason, native, builtin isn't good enough...?
@@ -10135,15 +10135,15 @@ w_metadata gdiplus_winxp dlls \
     year="2009" \
     media="manual_download" \
     file1="WindowsXP-KB975337-x86-ENU.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/gdiplus.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/gdiplus.dll"
 
 load_gdiplus_winxp()
 {
     # https://www.microsoft.com/en-us/download/details.aspx?id=5339
     w_download https://web.archive.org/web/20140615000000/http://download.microsoft.com/download/a/b/c/abc45517-97a0-4cee-a362-1957be2f24e1/WindowsXP-KB975337-x86-ENU.exe 699e76e9f100db3d50da8762c484a369df4698d4b84f7821d4df0e37ce68bcbe
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" "$W_CACHE/${W_PACKAGE}/$file1" /x:. /q
-    w_try cp "$W_CACHE/$W_PACKAGE/asms/10/msft/windows/gdiplus/gdiplus.dll" "$W_SYSTEM32_DLLS/gdiplus.dll"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" "${W_CACHE}/${W_PACKAGE}/${file1}" /x:. /q
+    w_try cp "${W_CACHE}/${W_PACKAGE}/asms/10/msft/windows/gdiplus/gdiplus.dll" "${W_SYSTEM32_DLLS}/gdiplus.dll"
 
     # For some reason, native, builtin isn't good enough...?
     w_override_dlls native gdiplus
@@ -10162,27 +10162,27 @@ w_metadata glidewrapper dlls \
 load_glidewrapper()
 {
     w_download http://www.zeckensack.de/glide/archive/GlideWrapper084c.exe 3c4185bd7eac9bd50e0727a7b5165ec8273230455480cf94358e1bbd35921b69
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
     # The installer opens its README in a web browser, really annoying when doing make check/test:
     # FIXME: maybe we should back up this key first?
     if [ -n "${W_OPT_UNATTENDED}" ]; then
-        cat > "$W_TMP"/disable-browser.reg <<_EOF_
+        cat > "${W_TMP}"/disable-browser.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\WineBrowser]
 "Browsers"=""
 
 _EOF_
-        w_try_regedit "$W_TMP_WIN"\\disable-browser.reg
+        w_try_regedit "${W_TMP_WIN}"\\disable-browser.reg
 
     fi
 
     # NSIS installer
-    w_try "$WINE" "$file1" ${W_OPT_UNATTENDED:+ /S}
+    w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+ /S}
 
     if [ -n "${W_OPT_UNATTENDED}" ]; then
-        "$WINE" reg delete "HKEY_CURRENT_USER\\Software\\Wine\\WineBrowser" /v Browsers /f || true
+        "${WINE}" reg delete "HKEY_CURRENT_USER\\Software\\Wine\\WineBrowser" /v Browsers /f || true
     fi
 }
 
@@ -10194,7 +10194,7 @@ w_metadata gfw dlls \
     year="2008" \
     media="download" \
     file1="gfwlivesetupmin.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/xlive.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/xlive.dll"
 
 load_gfw()
 {
@@ -10203,8 +10203,8 @@ load_gfw()
     w_download https://download.microsoft.com/download/5/5/8/55846E20-4A46-4EF8-B272-7F988BC9090A/gfwlivesetupmin.exe b14609508e2f8dba0886ded84e2817ad532ebfa31f8a6d4be2e6a5a03a9d7c23
 
     # FIXME: Depends on .NET 20, but is it really needed? For now, skip it.
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" gfwlivesetupmin.exe /nodotnet ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" gfwlivesetupmin.exe /nodotnet ${W_OPT_UNATTENDED:+/q}
 
     w_call msasn1
 }
@@ -10223,9 +10223,9 @@ load_glut()
 {
     w_download https://press.liacs.nl/researchdownloads/glut.win32/glut-3.7.6-bin.zip 788e97653bfd527afbdc69e1b7c6bcf9cb45f33d13ddf9d676dc070da92f80d4
     # FreeBSD unzip rm -rf's inside the target directory before extracting:
-    w_try_unzip "$W_TMP" "$W_CACHE"/glut/glut-3.7.6-bin.zip
-    w_try mv "$W_TMP/glut-3.7.6-bin" "$W_DRIVE_C"
-    w_try cp "$W_DRIVE_C"/glut-3.7.6-bin/glut32.dll "$W_SYSTEM32_DLLS"
+    w_try_unzip "${W_TMP}" "${W_CACHE}"/glut/glut-3.7.6-bin.zip
+    w_try mv "${W_TMP}/glut-3.7.6-bin" "${W_DRIVE_C}"
+    w_try cp "${W_DRIVE_C}"/glut-3.7.6-bin/glut32.dll "${W_SYSTEM32_DLLS}"
     w_warn "If you want to compile glut programs, add c:/glut-3.7.6-bin to LIB and INCLUDE"
 }
 
@@ -10237,17 +10237,17 @@ w_metadata gmdls dlls \
     year="1999" \
     media="download" \
     file1="../directx9/directx_apr2006_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/drivers/gm.dls"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/drivers/gm.dls"
 
 load_gmdls()
 {
     w_download_to directx9 https://download.microsoft.com/download/3/9/7/3972f80c-5711-4e14-9483-959d48a2d03b/directx_apr2006_redist.exe dd8c3d401efe4561b67bd88475201b2f62f43cd23e4acc947bb34a659fa74952
 
-    w_try_cabextract -d "$W_TMP" -F DirectX.cab "$W_CACHE"/directx9/directx_apr2006_redist.exe
-    w_try_cabextract -d "$W_TMP" -F gm16.dls "$W_TMP"/DirectX.cab
-    w_try mv "$W_TMP"/gm16.dls "$W_SYSTEM32_DLLS"/drivers/gm.dls
-    if test "$W_ARCH" = "win64"; then
-        w_try_cd "$W_SYSTEM64_DLLS"/drivers
+    w_try_cabextract -d "${W_TMP}" -F DirectX.cab "${W_CACHE}"/directx9/directx_apr2006_redist.exe
+    w_try_cabextract -d "${W_TMP}" -F gm16.dls "${W_TMP}"/DirectX.cab
+    w_try mv "${W_TMP}"/gm16.dls "${W_SYSTEM32_DLLS}"/drivers/gm.dls
+    if test "${W_ARCH}" = "win64"; then
+        w_try_cd "${W_SYSTEM64_DLLS}"/drivers
         w_try ln -s ../../syswow64/drivers/gm.dls
     fi
 }
@@ -10279,7 +10279,7 @@ w_metadata dirac dlls \
     year="2009" \
     media="download" \
     file1="DiracDirectShowFilter-1.0.2.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/Dirac/DiracDecoder.dll"
+    installed_file1="${W_PROGRAMS_X86_WIN}/Dirac/DiracDecoder.dll"
 
 load_dirac()
 {
@@ -10288,7 +10288,7 @@ load_dirac()
     # Avoid mfc90 not found error.  (DiracSplitter-libschroedinger.ax needs mfc90 to register itself, I think.)
     w_call vcrun2008
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetTitleMatchMode, 2
         run DiracDirectShowFilter-1.0.2.exe
@@ -10323,14 +10323,14 @@ w_metadata ffdshow dlls \
     year="2010" \
     media="download" \
     file1="ffdshow_beta7_rev3154_20091209.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/ffdshow/ff_liba52.dll" \
+    installed_file1="${W_PROGRAMS_X86_WIN}/ffdshow/ff_liba52.dll" \
     homepage="https://ffdshow-tryout.sourceforge.io/"
 
 load_ffdshow()
 {
     w_download https://downloads.sourceforge.net/ffdshow-tryout/ffdshow_beta7_rev3154_20091209.exe 86fb22e9a79a1c83340a99fd5722974a4d03948109d404a383c4334fab8f8860
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" ffdshow_beta7_rev3154_20091209.exe ${W_OPT_UNATTENDED:+/silent}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" ffdshow_beta7_rev3154_20091209.exe ${W_OPT_UNATTENDED:+/silent}
 }
 
 #----------------------------------------------------------------
@@ -10341,12 +10341,12 @@ w_metadata hid dlls \
     year="2003" \
     media="download" \
     file1="../win2ksp4/W2KSP4_EN.EXE" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/hid.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/hid.dll"
 
 load_hid()
 {
     helper_win2ksp4 i386/hid.dl_
-    w_try_cabextract --directory="$W_SYSTEM32_DLLS" "$W_TMP"/i386/hid.dl_
+    w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_TMP}"/i386/hid.dl_
 
     w_override_dlls native hid
 }
@@ -10359,7 +10359,7 @@ w_metadata icodecs dlls \
     year="1998" \
     media="download" \
     file1="codinstl.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/ir50_32.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/ir50_32.dll"
 
 load_icodecs()
 {
@@ -10372,9 +10372,9 @@ load_icodecs()
 
     # Extract the installer so that we can use the included Install Shield
     # response file for unattended installations
-    w_try_cabextract -d "$W_TMP/codinstl/" "$W_CACHE/$W_PACKAGE/codinstl.exe"
-    w_try_cd "$W_TMP/codinstl/"
-    w_try "$WINE" "setup.exe" ${W_OPT_UNATTENDED:+/s}
+    w_try_cabextract -d "${W_TMP}/codinstl/" "${W_CACHE}/${W_PACKAGE}/codinstl.exe"
+    w_try_cd "${W_TMP}/codinstl/"
+    w_try "${WINE}" "setup.exe" ${W_OPT_UNATTENDED:+/s}
 
     # Work around bug in codec's installer?
     # https://support.britannica.com/other/touchthesky/win/issues/TSTUw_150.htm
@@ -10387,13 +10387,13 @@ load_icodecs()
 
     # Extract the installer so that we can create and use a pre-recorded
     # Install Shield response file for unattended installations
-    w_try_cabextract -d "$W_TMP/iv5setup/" "$W_CACHE/$W_PACKAGE/iv5setup.exe"
+    w_try_cabextract -d "${W_TMP}/iv5setup/" "${W_CACHE}/${W_PACKAGE}/iv5setup.exe"
 
     # Create the response file with the following excluded components
     # - IV5 Directshow plugin (gives error about missing Ivfsrc.ax)
     # - Web browser (Netscape) plugin
     # http://www.silentinstall.org/InstallShield
-    cat > "$W_TMP/iv5setup/setup.iss" <<_EOF_
+    cat > "${W_TMP}/iv5setup/setup.iss" <<_EOF_
 [InstallShield Silent]
 Version=v5.00.000
 File=Response File
@@ -10452,15 +10452,15 @@ bOpt1=0
 bOpt2=0
 _EOF_
 
-    w_try_cd "$W_TMP/iv5setup/"
-    w_try "$WINE" "setup.exe" ${W_OPT_UNATTENDED:+/s}
+    w_try_cd "${W_TMP}/iv5setup/"
+    w_try "${WINE}" "setup.exe" ${W_OPT_UNATTENDED:+/s}
 
     # Note, this leaves a dangling explorer window.
     # Wait for it to appear and kill it
     while ! inode_pid=$(pgrep -f "explorer.exe.*Indeo"); do
         sleep 1
     done
-    kill -HUP "$inode_pid"
+    kill -HUP "${inode_pid}"
 }
 
 #----------------------------------------------------------------
@@ -10471,16 +10471,16 @@ w_metadata iertutil dlls \
     year="2011" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/iertutil.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/iertutil.dll"
 
 load_iertutil()
 {
     helper_win7sp1 x86_microsoft-windows-ie-runtimeutilities_31bf3856ad364e35_8.0.7601.17514_none_64655b7c61c841cb/iertutil.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-ie-runtimeutilities_31bf3856ad364e35_8.0.7601.17514_none_64655b7c61c841cb/iertutil.dll" "$W_SYSTEM32_DLLS/iertutil.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-ie-runtimeutilities_31bf3856ad364e35_8.0.7601.17514_none_64655b7c61c841cb/iertutil.dll" "${W_SYSTEM32_DLLS}/iertutil.dll"
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-ie-runtimeutilities_31bf3856ad364e35_8.0.7601.17514_none_c083f7001a25b301/iertutil.dll
-        w_try cp "$W_TMP/amd64_microsoft-windows-ie-runtimeutilities_31bf3856ad364e35_8.0.7601.17514_none_c083f7001a25b301/iertutil.dll" "$W_SYSTEM64_DLLS/iertutil.dll"
+        w_try cp "${W_TMP}/amd64_microsoft-windows-ie-runtimeutilities_31bf3856ad364e35_8.0.7601.17514_none_c083f7001a25b301/iertutil.dll" "${W_SYSTEM64_DLLS}/iertutil.dll"
     fi
 
     w_override_dlls native,builtin iertutil
@@ -10494,15 +10494,15 @@ w_metadata itircl dlls \
     year="1999" \
     media="download" \
     file1="../hhw/htmlhelp.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/itircl.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/itircl.dll"
 
 load_itircl()
 {
     # https://msdn.microsoft.com/en-us/library/windows/desktop/ms669985(v=vs.85).aspx
     w_download_to hhw https://download.microsoft.com/download/0/A/9/0A939EF6-E31C-430F-A3DF-DFAE7960D564/htmlhelp.exe b2b3140d42a818870c1ab13c1c7b8d4536f22bd994fa90aade89729a6009a3ae
 
-    w_try_cabextract -d "$W_TMP" -F hhupd.exe "$W_CACHE"/hhw/htmlhelp.exe
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -F itircl.dll "$W_TMP"/hhupd.exe
+    w_try_cabextract -d "${W_TMP}" -F hhupd.exe "${W_CACHE}"/hhw/htmlhelp.exe
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -F itircl.dll "${W_TMP}"/hhupd.exe
     w_override_dlls native itircl
     w_try_regsvr itircl.dll
 }
@@ -10515,15 +10515,15 @@ w_metadata itss dlls \
     year="1999" \
     media="download" \
     file1="../hhw/htmlhelp.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/itss.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/itss.dll"
 
 load_itss()
 {
     # https://msdn.microsoft.com/en-us/library/windows/desktop/ms669985(v=vs.85).aspx
     w_download_to hhw https://download.microsoft.com/download/0/A/9/0A939EF6-E31C-430F-A3DF-DFAE7960D564/htmlhelp.exe b2b3140d42a818870c1ab13c1c7b8d4536f22bd994fa90aade89729a6009a3ae
 
-    w_try_cabextract -d "$W_TMP" -F hhupd.exe "$W_CACHE"/hhw/htmlhelp.exe
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -F itss.dll "$W_TMP"/hhupd.exe
+    w_try_cabextract -d "${W_TMP}" -F hhupd.exe "${W_CACHE}"/hhw/htmlhelp.exe
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -F itss.dll "${W_TMP}"/hhupd.exe
     w_override_dlls native itss
     w_try_regsvr itss.dll
 }
@@ -10536,20 +10536,20 @@ w_metadata cinepak dlls \
     year="1995" \
     media="download" \
     file1="cvid32.zip" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/iccvid.dll" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/iccvid.dll" \
     homepage="http://www.probo.com/cinepak.php"
 
 load_cinepak()
 {
     w_download "http://www.probo.com/pub/cinepak/cvid32.zip" a41984a954fe77557f228fa8a95cdc05db22bf9ff5429fe4307fd6fc51e11969
 
-    if [ -f "$W_SYSTEM32_DLLS/iccvid.dll" ]; then
-        w_try rm -f "$W_SYSTEM32_DLLS/iccvid.dll"
+    if [ -f "${W_SYSTEM32_DLLS}/iccvid.dll" ]; then
+        w_try rm -f "${W_SYSTEM32_DLLS}/iccvid.dll"
     fi
 
-    w_try_unzip "$W_SYSTEM32_DLLS" "${W_CACHE}/${W_PACKAGE}/${file1}" ICCVID.DLL
+    w_try_unzip "${W_SYSTEM32_DLLS}" "${W_CACHE}/${W_PACKAGE}/${file1}" ICCVID.DLL
 
-    w_try mv -f "$W_SYSTEM32_DLLS/ICCVID.DLL" "$W_SYSTEM32_DLLS/iccvid.dll"
+    w_try mv -f "${W_SYSTEM32_DLLS}/ICCVID.DLL" "${W_SYSTEM32_DLLS}/iccvid.dll"
 
     w_override_dlls native iccvid
 }
@@ -10562,12 +10562,12 @@ w_metadata jet40 dlls \
     year="2003" \
     media="download" \
     file1="jet40sp8_9xnt.exe" \
-    installed_file1="$W_COMMONFILES_WIN/Microsoft Shared/dao/dao360.dll"
+    installed_file1="${W_COMMONFILES_WIN}/Microsoft Shared/dao/dao360.dll"
 
 load_jet40()
 {
     # mdac27 is 32-bit only, so use mdac28 for win64:
-    if [ "$W_ARCH" = "win64" ] ; then
+    if [ "${W_ARCH}" = "win64" ] ; then
         w_call mdac28
     else
         w_call mdac27
@@ -10579,8 +10579,8 @@ load_jet40()
     # FIXME: "failed with error 2"
     w_download https://download.microsoft.com/download/4/3/9/4393c9ac-e69e-458d-9f6d-2fe191c51469/jet40sp8_9xnt.exe b060246cd499085a31f15873689d5fa7df817e407c8261a5c71fa6b9f7042560
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" jet40sp8_9xnt.exe ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" jet40sp8_9xnt.exe ${W_OPT_UNATTENDED:+/q}
 }
 
 # FIXME: verify_jet40()
@@ -10609,8 +10609,8 @@ load_ie8_kb2936068()
 
     w_set_winver winxp
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try_ms_installer "$WINE" IE8-WindowsXP-KB2936068-x86-ENU.exe ${W_OPT_UNATTENDED:+/quiet /forcerestart}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try_ms_installer "${WINE}" IE8-WindowsXP-KB2936068-x86-ENU.exe ${W_OPT_UNATTENDED:+/quiet /forcerestart}
 
     w_set_winver 'default'
 }
@@ -10623,14 +10623,14 @@ w_metadata l3codecx dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/l3codecx.ax"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/l3codecx.ax"
 
 load_l3codecx()
 {
     helper_directx_dl
 
-    w_try_cabextract -d "$W_TMP" -L -F dxnt.cab "$W_CACHE"/directx9/$DIRECTX_NAME
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'l3codecx.ax' "$W_TMP/dxnt.cab"
+    w_try_cabextract -d "${W_TMP}" -L -F dxnt.cab "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'l3codecx.ax' "${W_TMP}/dxnt.cab"
 
     w_try_regsvr l3codecx.ax
 }
@@ -10638,7 +10638,7 @@ load_l3codecx()
 #----------------------------------------------------------------
 
 # FIXME: installed location is
-# $W_PROGRAMS_X86_WIN/Gemeinsame Dateien/System/ADO/msado26.tlb
+# ${W_PROGRAMS_X86_WIN}/Gemeinsame Dateien/System/ADO/msado26.tlb
 # in German... need a variable W_COMMONFILES or something like that
 
 w_metadata mdac27 dlls \
@@ -10647,7 +10647,7 @@ w_metadata mdac27 dlls \
     year="2006" \
     media="download" \
     file1="MDAC_TYP.EXE" \
-    installed_file1="$W_COMMONFILES_X86_WIN/System/ADO/msado26.tlb"
+    installed_file1="${W_COMMONFILES_X86_WIN}/System/ADO/msado26.tlb"
 
 load_mdac27()
 {
@@ -10662,7 +10662,7 @@ load_mdac27()
     load_native_mdac
     w_set_winver nt40
     w_try_cd "${W_CACHE}/${W_PACKAGE}"
-    w_try "$WINE" "${file1}" ${W_OPT_UNATTENDED:+/q /C:"setup /qnt"}
+    w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+/q /C:"setup /qnt"}
     w_set_winver 'default'
 }
 
@@ -10674,7 +10674,7 @@ w_metadata mdac28 dlls \
     year="2005" \
     media="download" \
     file1="MDAC_TYP.EXE" \
-    installed_file1="$W_COMMONFILES_X86_WIN/System/ADO/msado27.tlb"
+    installed_file1="${W_COMMONFILES_X86_WIN}/System/ADO/msado27.tlb"
 
 load_mdac28()
 {
@@ -10682,8 +10682,8 @@ load_mdac28()
     w_download https://download.microsoft.com/download/4/a/a/4aafff19-9d21-4d35-ae81-02c48dcbbbff/MDAC_TYP.EXE 157ebae46932cb9047b58aa849ac1885e8cbd2f218810cb83e57613b49c679d6
     load_native_mdac
     w_set_winver nt40
-    w_try_cd "$W_CACHE"/"$W_PACKAGE"
-    w_try "$WINE" mdac_typ.exe ${W_OPT_UNATTENDED:+/q /C:"setup /qnt"}
+    w_try_cd "${W_CACHE}"/"${W_PACKAGE}"
+    w_try "${WINE}" mdac_typ.exe ${W_OPT_UNATTENDED:+/q /C:"setup /qnt"}
     w_set_winver 'default'
 }
 
@@ -10701,35 +10701,35 @@ load_mdx()
 {
     helper_directx_Jun2010
 
-    w_try_cd "$W_TMP"
+    w_try_cd "${W_TMP}"
 
-    w_try_cabextract -F "*MDX*" "$W_CACHE"/directx9/$DIRECTX_NAME
+    w_try_cabextract -F "*MDX*" "${W_CACHE}"/directx9/${DIRECTX_NAME}
     w_try_cabextract -F "*.cab" ./*Archive.cab
 
     # Install assemblies
-    w_try_cabextract -d "$W_WINDIR_UNIX/Microsoft.NET/DirectX for Managed Code/1.0.2902.0" -F "microsoft.directx*" ./*MDX1_x86.cab
+    w_try_cabextract -d "${W_WINDIR_UNIX}/Microsoft.NET/DirectX for Managed Code/1.0.2902.0" -F "microsoft.directx*" ./*MDX1_x86.cab
     for file in mdx_*.cab; do
         ver="${file%%_x86.cab}"
         ver="${ver##mdx_}"
-        w_try_cabextract -d "$W_WINDIR_UNIX/Microsoft.NET/DirectX for Managed Code/$ver" -F "microsoft.directx*" "$file"
+        w_try_cabextract -d "${W_WINDIR_UNIX}/Microsoft.NET/DirectX for Managed Code/${ver}" -F "microsoft.directx*" "${file}"
     done
-    w_try_cabextract -d "$W_WINDIR_UNIX/Microsoft.NET/DirectX for Managed Code/1.0.2911.0" -F "microsoft.directx.direct3dx*" ./*MDX1_x86.cab
+    w_try_cabextract -d "${W_WINDIR_UNIX}/Microsoft.NET/DirectX for Managed Code/1.0.2911.0" -F "microsoft.directx.direct3dx*" ./*MDX1_x86.cab
 
     # Add them to GAC
-    w_try_cd "$W_WINDIR_UNIX/Microsoft.NET/DirectX for Managed Code"
+    w_try_cd "${W_WINDIR_UNIX}/Microsoft.NET/DirectX for Managed Code"
     for ver in *; do
         (
-            w_try_cd "$ver"
+            w_try_cd "${ver}"
             for asm in *.dll; do
                 name="${asm%%.dll}"
-                w_try mkdir -p "$W_WINDIR_UNIX/assembly/GAC/$name/${ver}__31bf3856ad364e35"
-                w_try cp "$asm" "$W_WINDIR_UNIX/assembly/GAC/$name/${ver}__31bf3856ad364e35"
+                w_try mkdir -p "${W_WINDIR_UNIX}/assembly/GAC/${name}/${ver}__31bf3856ad364e35"
+                w_try cp "${asm}" "${W_WINDIR_UNIX}/assembly/GAC/${name}/${ver}__31bf3856ad364e35"
             done
         )
     done
 
     # AssemblyFolders
-    cat > "$W_TMP"/asmfolders.reg <<_EOF_
+    cat > "${W_TMP}"/asmfolders.reg <<_EOF_
 REGEDIT4
 
 [HKEY_LOCAL_MACHINE\\Software\\Microsoft\\.NETFramework\\AssemblyFolders\\DX_1.0.2902.0]
@@ -10762,7 +10762,7 @@ REGEDIT4
 [HKEY_LOCAL_MACHINE\\Software\\Microsoft\\.NETFramework\\AssemblyFolders\\DX_1.0.2911.0]
 @="C:\\\\windows\\\\Microsoft.NET\\\\DirectX for Managed Code\\\\1.0.2911.0\\\\"
 _EOF_
-    w_try_regedit "$W_TMP_WIN"\\asmfolders.reg
+    w_try_regedit "${W_TMP_WIN}"\\asmfolders.reg
 }
 
 #----------------------------------------------------------------
@@ -10773,16 +10773,16 @@ w_metadata mf dlls \
     year="2011" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/mf.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/mf.dll"
 
 load_mf()
 {
     helper_win7sp1 x86_microsoft-windows-mediafoundation_31bf3856ad364e35_6.1.7601.17514_none_9e6699276b03c38e/mf.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-mediafoundation_31bf3856ad364e35_6.1.7601.17514_none_9e6699276b03c38e/mf.dll" "$W_SYSTEM32_DLLS/mf.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-mediafoundation_31bf3856ad364e35_6.1.7601.17514_none_9e6699276b03c38e/mf.dll" "${W_SYSTEM32_DLLS}/mf.dll"
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-mediafoundation_31bf3856ad364e35_6.1.7601.17514_none_fa8534ab236134c4/mf.dll
-        w_try cp "$W_TMP/amd64_microsoft-windows-mediafoundation_31bf3856ad364e35_6.1.7601.17514_none_fa8534ab236134c4/mf.dll" "$W_SYSTEM64_DLLS/mf.dll"
+        w_try cp "${W_TMP}/amd64_microsoft-windows-mediafoundation_31bf3856ad364e35_6.1.7601.17514_none_fa8534ab236134c4/mf.dll" "${W_SYSTEM64_DLLS}/mf.dll"
     fi
 
     w_override_dlls native,builtin mf
@@ -10796,15 +10796,15 @@ w_metadata mfc40 dlls \
     year="1999" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc40.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/mfc40.dll"
 
 load_mfc40()
 {
     helper_win7sp1 x86_microsoft-windows-mfc40_31bf3856ad364e35_6.1.7601.17514_none_5c06580240091047/mfc40.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-mfc40_31bf3856ad364e35_6.1.7601.17514_none_5c06580240091047/mfc40.dll" "$W_SYSTEM32_DLLS/mfc40.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-mfc40_31bf3856ad364e35_6.1.7601.17514_none_5c06580240091047/mfc40.dll" "${W_SYSTEM32_DLLS}/mfc40.dll"
 
     helper_win7sp1 x86_microsoft-windows-mfc40u_31bf3856ad364e35_6.1.7601.17514_none_f51a7bf0b3d25294/mfc40u.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-mfc40u_31bf3856ad364e35_6.1.7601.17514_none_f51a7bf0b3d25294/mfc40u.dll" "$W_SYSTEM32_DLLS/mfc40u.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-mfc40u_31bf3856ad364e35_6.1.7601.17514_none_f51a7bf0b3d25294/mfc40u.dll" "${W_SYSTEM32_DLLS}/mfc40u.dll"
 
     w_call msvcrt40
 }
@@ -10817,12 +10817,12 @@ w_metadata msacm32 dlls \
     year="2003" \
     media="download" \
     file1="../winxpsp3/WindowsXP-KB936929-SP3-x86-ENU.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/msacm32.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/msacm32.dll"
 
 load_msacm32()
 {
     helper_winxpsp3 i386/msacm32.dl_
-    w_try_cabextract --directory="$W_SYSTEM32_DLLS" "$W_TMP"/i386/msacm32.dl_
+    w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_TMP}"/i386/msacm32.dl_
     w_override_dlls native,builtin msacm32
 }
 
@@ -10834,12 +10834,12 @@ w_metadata msasn1 dlls \
     year="2003" \
     media="download" \
     file1="../win2ksp4/W2KSP4_EN.EXE" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/msasn1.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/msasn1.dll"
 
 load_msasn1()
 {
     helper_win2ksp4 i386/msasn1.dl_
-    w_try_cabextract --directory="$W_SYSTEM32_DLLS" "$W_TMP"/i386/msasn1.dl_
+    w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_TMP}"/i386/msasn1.dl_
 }
 
 #----------------------------------------------------------------
@@ -10850,12 +10850,12 @@ w_metadata msctf dlls \
     year="2003" \
     media="download" \
     file1="../winxpsp3/WindowsXP-KB936929-SP3-x86-ENU.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/msctf.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/msctf.dll"
 
 load_msctf()
 {
     helper_winxpsp3 i386/msctf.dl_
-    w_try_cabextract --directory="$W_SYSTEM32_DLLS" "$W_TMP"/i386/msctf.dl_
+    w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_TMP}"/i386/msctf.dl_
     w_override_dlls native,builtin msctf
 }
 
@@ -10867,16 +10867,16 @@ w_metadata msdelta dlls \
     year="2011" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/msdelta.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/msdelta.dll"
 
 load_msdelta()
 {
     helper_win7sp1 x86_microsoft-windows-servicingstack_31bf3856ad364e35_6.1.7601.17514_none_0b66cb34258c936f/msdelta.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-servicingstack_31bf3856ad364e35_6.1.7601.17514_none_0b66cb34258c936f/msdelta.dll" "$W_SYSTEM32_DLLS/msdelta.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-servicingstack_31bf3856ad364e35_6.1.7601.17514_none_0b66cb34258c936f/msdelta.dll" "${W_SYSTEM32_DLLS}/msdelta.dll"
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-servicingstack_31bf3856ad364e35_6.1.7601.17514_none_678566b7ddea04a5/msdelta.dll
-        w_try cp "$W_TMP/amd64_microsoft-windows-servicingstack_31bf3856ad364e35_6.1.7601.17514_none_678566b7ddea04a5/msdelta.dll" "$W_SYSTEM64_DLLS/msdelta.dll"
+        w_try cp "${W_TMP}/amd64_microsoft-windows-servicingstack_31bf3856ad364e35_6.1.7601.17514_none_678566b7ddea04a5/msdelta.dll" "${W_SYSTEM64_DLLS}/msdelta.dll"
     fi
 
     w_override_dlls native,builtin msdelta
@@ -10890,7 +10890,7 @@ w_metadata msdxmocx dlls \
     year="1999" \
     media="download" \
     file1="mpfull.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/msdxm.ocx"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/msdxm.ocx"
 
 load_msdxmocx()
 {
@@ -10908,7 +10908,7 @@ load_msdxmocx()
 
     w_download http://hell.pl/agnus/windows95/mpfull.exe a39b2b9735cedd513fcb78f8634695d35073e9d7e865e536a0da6db38c7225e4
 
-    w_try_cabextract --directory="$W_SYSTEM32_DLLS" "$W_CACHE/$W_PACKAGE/${file1}"
+    w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_CACHE}/${W_PACKAGE}/${file1}"
     w_try_regsvr msdxm.ocx
 }
 
@@ -10920,12 +10920,12 @@ w_metadata msflxgrd dlls \
     year="2012" \
     media="download" \
     file1="../vb6sp6/VB60SP6-KB2708437-x86-ENU.msi" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/msflxgrd.ocx"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/msflxgrd.ocx"
 
 load_msflxgrd()
 {
-    helper_vb6sp6 "$W_TMP" MSFlxGrd.ocx
-    w_try mv "${W_TMP}/MSFlxGrd.ocx" "$W_SYSTEM32_DLLS/msflxgrd.ocx"
+    helper_vb6sp6 "${W_TMP}" MSFlxGrd.ocx
+    w_try mv "${W_TMP}/MSFlxGrd.ocx" "${W_SYSTEM32_DLLS}/msflxgrd.ocx"
     w_try_regsvr msflxgrd.ocx
 }
 
@@ -10937,12 +10937,12 @@ w_metadata mshflxgd dlls \
     year="2012" \
     media="download" \
     file1="../vb6sp6/VB60SP6-KB2708437-x86-ENU.msi" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/mshflxgd.ocx"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/mshflxgd.ocx"
 
 load_mshflxgd()
 {
-    helper_vb6sp6 "$W_TMP" MShflxgd.ocx
-    w_try mv "${W_TMP}/MShflxgd.ocx" "$W_SYSTEM32_DLLS/mshflxgd.ocx"
+    helper_vb6sp6 "${W_TMP}" MShflxgd.ocx
+    w_try mv "${W_TMP}/MShflxgd.ocx" "${W_SYSTEM32_DLLS}/mshflxgd.ocx"
     w_try_regsvr mshflxgd.ocx
 }
 
@@ -10954,12 +10954,12 @@ w_metadata mspatcha dlls \
     year="2004" \
     media="download" \
     file1="../win2ksp4/W2KSP4_EN.EXE" \
-    installed_exe1="$W_SYSTEM32_DLLS_WIN/mspatcha.dll"
+    installed_exe1="${W_SYSTEM32_DLLS_WIN}/mspatcha.dll"
 
 load_mspatcha()
 {
     helper_win2ksp4 i386/mspatcha.dl_
-    w_try_cabextract --directory="$W_SYSTEM32_DLLS" "$W_TMP"/i386/mspatcha.dl_
+    w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_TMP}"/i386/mspatcha.dl_
 
     w_override_dlls native,builtin mspatcha
 }
@@ -10972,12 +10972,12 @@ w_metadata msscript dlls \
     year="2004" \
     media="download" \
     file1="../winxpsp3/WindowsXP-KB936929-SP3-x86-ENU.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/msscript.ocx"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/msscript.ocx"
 
 load_msscript()
 {
     helper_winxpsp3 i386/msscript.oc_
-    w_try_cabextract --directory="$W_SYSTEM32_DLLS" "$W_TMP"/i386/msscript.oc_
+    w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_TMP}"/i386/msscript.oc_
     w_override_dlls native,builtin i386/msscript.ocx
 }
 
@@ -10989,7 +10989,7 @@ w_metadata msls31 dlls \
     year="2001" \
     media="download" \
     file1="InstMsiW.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/msls31.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/msls31.dll"
 
 load_msls31()
 {
@@ -10998,8 +10998,8 @@ load_msls31()
     # Mirror list at http://www.filewatcher.com/m/InstMsiW.exe.1822848-0.html
     w_download https://ftp.hp.com/pub/softlib/software/msi/InstMsiW.exe 4c3516c0b5c2b76b88209b22e3bf1cb82d8e2de7116125e97e128952372eed6b InstMsiW.exe
 
-    w_try_cabextract --directory="$W_TMP" "$W_CACHE"/msls31/InstMsiW.exe
-    w_try cp -f "$W_TMP"/msls31.dll "$W_SYSTEM32_DLLS"
+    w_try_cabextract --directory="${W_TMP}" "${W_CACHE}"/msls31/InstMsiW.exe
+    w_try cp -f "${W_TMP}"/msls31.dll "${W_SYSTEM32_DLLS}"
 }
 
 #----------------------------------------------------------------
@@ -11010,12 +11010,12 @@ w_metadata msmask dlls \
     year="2009" \
     media="download" \
     file1="../vb6sp6/VB60SP6-KB2708437-x86-ENU.msi" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/msmask32.ocx"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/msmask32.ocx"
 
 load_msmask()
 {
-    helper_vb6sp6 "$W_TMP" msmask32.ocx
-    w_try mv "${W_TMP}/msmask32.ocx" "$W_SYSTEM32_DLLS/msmask32.ocx"
+    helper_vb6sp6 "${W_TMP}" msmask32.ocx
+    w_try mv "${W_TMP}/msmask32.ocx" "${W_SYSTEM32_DLLS}/msmask32.ocx"
     w_try_regsvr msmask32.ocx
 }
 
@@ -11027,16 +11027,16 @@ w_metadata msftedit dlls \
     year="2011" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/msftedit.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/msftedit.dll"
 
 load_msftedit()
 {
     helper_win7sp1 x86_microsoft-windows-msftedit_31bf3856ad364e35_6.1.7601.17514_none_d7d862f19573a5ff/msftedit.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-msftedit_31bf3856ad364e35_6.1.7601.17514_none_d7d862f19573a5ff/msftedit.dll" "$W_SYSTEM32_DLLS/msftedit.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-msftedit_31bf3856ad364e35_6.1.7601.17514_none_d7d862f19573a5ff/msftedit.dll" "${W_SYSTEM32_DLLS}/msftedit.dll"
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-msftedit_31bf3856ad364e35_6.1.7601.17514_none_33f6fe754dd11735/msftedit.dll
-        w_try cp "$W_TMP/amd64_microsoft-windows-msftedit_31bf3856ad364e35_6.1.7601.17514_none_33f6fe754dd11735/msftedit.dll" "$W_SYSTEM64_DLLS/msftedit.dll"
+        w_try cp "${W_TMP}/amd64_microsoft-windows-msftedit_31bf3856ad364e35_6.1.7601.17514_none_33f6fe754dd11735/msftedit.dll" "${W_SYSTEM64_DLLS}/msftedit.dll"
     fi
 
     w_override_dlls native,builtin msftedit
@@ -11050,12 +11050,12 @@ w_metadata msvcrt40 dlls \
     year="2011" \
     media="download" \
     file1="../winxpsp3/WindowsXP-KB936929-SP3-x86-ENU.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/msvcrt40.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/msvcrt40.dll"
 
 load_msvcrt40()
 {
     helper_winxpsp3 i386/msvcrt40.dl_
-    w_try_cabextract --directory="$W_SYSTEM32_DLLS" "$W_TMP"/i386/msvcrt40.dl_
+    w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_TMP}"/i386/msvcrt40.dl_
 
     w_override_dlls native,builtin msvcrt40
 }
@@ -11068,7 +11068,7 @@ w_metadata msxml3 dlls \
     year="2005" \
     media="download" \
     file1="msxml3.msi" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/msxml3.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/msxml3.dll"
 
 load_msxml3()
 {
@@ -11081,16 +11081,16 @@ load_msxml3()
     w_download https://media.codeweavers.com/pub/other/msxml3.msi f9c678f8217e9d4f9647e8a1f6d89a7c26a57b9e9e00d39f7487493dd7b4e36c
 
     # It won't install on top of Wine's msxml3, which has a pretty high version number, so delete Wine's fake DLL
-    rm "$W_SYSTEM32_DLLS"/msxml3.dll
+    rm "${W_SYSTEM32_DLLS}"/msxml3.dll
     w_override_dlls native msxml3
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
     # See https://github.com/Winetricks/winetricks/issues/1086
     # and https://bugs.winehq.org/show_bug.cgi?id=26925
     if w_workaround_wine_bug 26925 "Forcing quiet install"; then
-        w_try "$WINE" msiexec /i msxml3.msi /q
+        w_try "${WINE}" msiexec /i msxml3.msi /q
     else
-        w_try "$WINE" msiexec /i msxml3.msi ${W_OPT_UNATTENDED:+/q}
+        w_try "${WINE}" msiexec /i msxml3.msi ${W_OPT_UNATTENDED:+/q}
     fi
 }
 
@@ -11102,7 +11102,7 @@ w_metadata msxml4 dlls \
     year="2009" \
     media="download" \
     file1="msxml.msi" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/msxml4.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/msxml4.dll"
 
 load_msxml4()
 {
@@ -11113,8 +11113,8 @@ load_msxml4()
     # SP3 (2009): https://www.microsoft.com/en-us/download/details.aspx?id=15697
     w_download https://download.microsoft.com/download/A/2/D/A2D8587D-0027-4217-9DAD-38AFDB0A177E/msxml.msi 47c2ae679c37815da9267c81fc3777de900ad2551c11c19c2840938b346d70bb
     w_override_dlls native,builtin msxml4
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" msiexec /i msxml.msi ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" msiexec /i msxml.msi ${W_OPT_UNATTENDED:+/q}
 }
 
 #----------------------------------------------------------------
@@ -11125,7 +11125,7 @@ w_metadata msxml6 dlls \
     year="2009" \
     media="download" \
     file1="msxml6-KB973686-enu-amd64.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/msxml6.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/msxml6.dll"
 
 load_msxml6()
 {
@@ -11138,12 +11138,12 @@ load_msxml6()
 
     w_try_cabextract --directory="${W_TMP}" "${W_CACHE}"/msxml6/msxml6-KB973686-enu-amd64.exe
     w_try_cabextract --directory="${W_TMP}" "${W_TMP}"/msxml6.msi
-    w_try cp -f "${W_TMP}"/msxml6.dll.86F857F6_A743_463D_B2FE_98CB5F727E09 "$W_SYSTEM32_DLLS"/msxml6.dll
-    w_try cp -f "${W_TMP}"/msxml6r.dll.86F857F6_A743_463D_B2FE_98CB5F727E09 "$W_SYSTEM32_DLLS"/msxml6r.dll
+    w_try cp -f "${W_TMP}"/msxml6.dll.86F857F6_A743_463D_B2FE_98CB5F727E09 "${W_SYSTEM32_DLLS}"/msxml6.dll
+    w_try cp -f "${W_TMP}"/msxml6r.dll.86F857F6_A743_463D_B2FE_98CB5F727E09 "${W_SYSTEM32_DLLS}"/msxml6r.dll
 
-    if [ "$W_ARCH" = "win64" ]; then
-        w_try cp -f "${W_TMP}"/msxml6.dll.1ECC0691_D2EB_4A33_9CBF_5487E5CB17DB "$W_SYSTEM64_DLLS"/msxml6.dll
-        w_try cp -f "${W_TMP}"/msxml6r.dll.1ECC0691_D2EB_4A33_9CBF_5487E5CB17DB "$W_SYSTEM64_DLLS"/msxml6r.dll
+    if [ "${W_ARCH}" = "win64" ]; then
+        w_try cp -f "${W_TMP}"/msxml6.dll.1ECC0691_D2EB_4A33_9CBF_5487E5CB17DB "${W_SYSTEM64_DLLS}"/msxml6.dll
+        w_try cp -f "${W_TMP}"/msxml6r.dll.1ECC0691_D2EB_4A33_9CBF_5487E5CB17DB "${W_SYSTEM64_DLLS}"/msxml6r.dll
     fi
 
     w_override_dlls native,builtin msxml6
@@ -11157,7 +11157,7 @@ w_metadata nuget dlls \
     year="2013" \
     media="download" \
     file1="nuget.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/nuget.exe" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/nuget.exe" \
     homepage="https://nuget.org"
 
 load_nuget()
@@ -11165,8 +11165,8 @@ load_nuget()
     w_call dotnet40
     # Changes too rapidly to check shasum
     w_download https://nuget.org/nuget.exe
-    w_try cp "$W_CACHE/$W_PACKAGE"/nuget.exe "$W_SYSTEM32_DLLS"
-    w_warn "To run NuGet, use the command line \"$WINE nuget\"."
+    w_try cp "${W_CACHE}/${W_PACKAGE}"/nuget.exe "${W_SYSTEM32_DLLS}"
+    w_warn "To run NuGet, use the command line \"${WINE} nuget\"."
 }
 
 #----------------------------------------------------------------
@@ -11177,14 +11177,14 @@ w_metadata ogg dlls \
     year="2011" \
     media="download" \
     file1="opencodecs_0.85.17777.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/Xiph.Org/Open Codecs/AxPlayer.dll" \
+    installed_file1="${W_PROGRAMS_X86_WIN}/Xiph.Org/Open Codecs/AxPlayer.dll" \
     homepage="https://xiph.org/dshow"
 
 load_ogg()
 {
     w_download https://downloads.xiph.org/releases/oggdsf/opencodecs_0.85.17777.exe fcec3cea637e806501aff447d902de3b5bfef226b629e43ab67e46dbb23f13e7
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" "$file1" ${W_OPT_UNATTENDED:+/S}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+/S}
 }
 
 
@@ -11196,13 +11196,13 @@ w_metadata ole32 dlls \
     year="2004" \
     media="download" \
     file1="../winxpsp3/WindowsXP-KB936929-SP3-x86-ENU.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/ole32.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/ole32.dll"
 
 load_ole32()
 {
     # Some applications need this, for example Wechat.
     helper_winxpsp3 i386/ole32.dl_
-    w_try_cabextract --directory="$W_SYSTEM32_DLLS" "$W_TMP"/i386/ole32.dl_
+    w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_TMP}"/i386/ole32.dl_
     w_override_dlls native,builtin ole32
 }
 
@@ -11214,16 +11214,16 @@ w_metadata oleaut32 dlls \
     year="2011" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/oleaut32.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/oleaut32.dll"
 
 load_oleaut32()
 {
     helper_win7sp1 x86_microsoft-windows-ole-automation_31bf3856ad364e35_6.1.7601.17514_none_bf07947959bc4c33/oleaut32.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-ole-automation_31bf3856ad364e35_6.1.7601.17514_none_bf07947959bc4c33/oleaut32.dll" "$W_SYSTEM32_DLLS/oleaut32.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-ole-automation_31bf3856ad364e35_6.1.7601.17514_none_bf07947959bc4c33/oleaut32.dll" "${W_SYSTEM32_DLLS}/oleaut32.dll"
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-ole-automation_31bf3856ad364e35_6.1.7601.17514_none_1b262ffd1219bd69/oleaut32.dll
-        w_try cp "$W_TMP/amd64_microsoft-windows-ole-automation_31bf3856ad364e35_6.1.7601.17514_none_1b262ffd1219bd69/oleaut32.dll" "$W_SYSTEM64_DLLS/oleaut32.dll"
+        w_try cp "${W_TMP}/amd64_microsoft-windows-ole-automation_31bf3856ad364e35_6.1.7601.17514_none_1b262ffd1219bd69/oleaut32.dll" "${W_SYSTEM64_DLLS}/oleaut32.dll"
     fi
 
     w_override_dlls native,builtin oleaut32
@@ -11237,16 +11237,16 @@ w_metadata pdh dlls \
     year="2011" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/pdh.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/pdh.dll"
 
 load_pdh()
 {
     helper_win7sp1 x86_microsoft-windows-p..rastructureconsumer_31bf3856ad364e35_6.1.7601.17514_none_b5e3f88a8eb425e8/pdh.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-p..rastructureconsumer_31bf3856ad364e35_6.1.7601.17514_none_b5e3f88a8eb425e8/pdh.dll" "$W_SYSTEM32_DLLS/pdh.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-p..rastructureconsumer_31bf3856ad364e35_6.1.7601.17514_none_b5e3f88a8eb425e8/pdh.dll" "${W_SYSTEM32_DLLS}/pdh.dll"
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-p..rastructureconsumer_31bf3856ad364e35_6.1.7601.17514_none_1202940e4711971e/pdh.dll
-        w_try cp "$W_TMP/amd64_microsoft-windows-p..rastructureconsumer_31bf3856ad364e35_6.1.7601.17514_none_1202940e4711971e/pdh.dll" "$W_SYSTEM64_DLLS/pdh.dll"
+        w_try cp "${W_TMP}/amd64_microsoft-windows-p..rastructureconsumer_31bf3856ad364e35_6.1.7601.17514_none_1202940e4711971e/pdh.dll" "${W_SYSTEM64_DLLS}/pdh.dll"
     fi
 
     w_override_dlls native,builtin pdh
@@ -11260,7 +11260,7 @@ w_metadata peverify dlls \
     year="2006" \
     media="download" \
     file1="../dotnet20sdk/setup.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/peverify.exe"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/peverify.exe"
 
 load_peverify()
 {
@@ -11282,13 +11282,13 @@ w_metadata physx dlls \
     year="2014" \
     media="download" \
     file1="PhysX-9.14.0702-SystemSoftware.msi" \
-    installed_file1="$W_PROGRAMS_X86_WIN/NVIDIA Corporation/PhysX/Engine/v2.8.3/PhysXCore.dll"
+    installed_file1="${W_PROGRAMS_X86_WIN}/NVIDIA Corporation/PhysX/Engine/v2.8.3/PhysXCore.dll"
 
 load_physx()
 {
     w_download https://uk.download.nvidia.com/Windows/9.14.0702/PhysX-9.14.0702-SystemSoftware.msi 0a022e28accf5851be9d6577487cdcd3d3a3e2a8a21a64456b72b415c217f03c
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" msiexec /i PhysX-9.14.0702-SystemSoftware.msi ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" msiexec /i PhysX-9.14.0702-SystemSoftware.msi ${W_OPT_UNATTENDED:+/q}
 }
 
 #----------------------------------------------------------------
@@ -11299,7 +11299,7 @@ w_metadata pngfilt dlls \
     year="2004" \
     media="download" \
     file1="../winxpsp3/WindowsXP-KB936929-SP3-x86-ENU.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/pngfilt.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/pngfilt.dll"
 
 load_pngfilt()
 {
@@ -11307,7 +11307,7 @@ load_pngfilt()
     # Now using winxp's dll
 
     helper_winxpsp3 i386/pngfilt.dl_
-    w_try_cabextract --directory="$W_SYSTEM32_DLLS" "$W_TMP"/i386/pngfilt.dl_
+    w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_TMP}"/i386/pngfilt.dl_
     w_try_regsvr pngfilt.dll
 }
 
@@ -11319,20 +11319,20 @@ w_metadata prntvpt dlls \
     year="2011" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/prntvpt.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/prntvpt.dll"
 
 load_prntvpt()
 {
 
     helper_win7sp1 x86_microsoft-windows-p..g-printticket-win32_31bf3856ad364e35_6.1.7601.17514_none_1562129afd710f2c/prntvpt.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-p..g-printticket-win32_31bf3856ad364e35_6.1.7601.17514_none_1562129afd710f2c/prntvpt.dll" "$W_SYSTEM32_DLLS/prntvpt.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-p..g-printticket-win32_31bf3856ad364e35_6.1.7601.17514_none_1562129afd710f2c/prntvpt.dll" "${W_SYSTEM32_DLLS}/prntvpt.dll"
 
     w_override_dlls native,builtin prntvpt
     w_try_regsvr prntvpt.dll
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-p..g-printticket-win32_31bf3856ad364e35_6.1.7601.17514_none_7180ae1eb5ce8062/prntvpt.dll
-        w_try cp "$W_TMP/amd64_microsoft-windows-p..g-printticket-win32_31bf3856ad364e35_6.1.7601.17514_none_7180ae1eb5ce8062/prntvpt.dll" "$W_SYSTEM64_DLLS/prntvpt.dll"
+        w_try cp "${W_TMP}/amd64_microsoft-windows-p..g-printticket-win32_31bf3856ad364e35_6.1.7601.17514_none_7180ae1eb5ce8062/prntvpt.dll" "${W_SYSTEM64_DLLS}/prntvpt.dll"
         w_try_regsvr64 prntvpt.dll
     fi
 }
@@ -11352,8 +11352,8 @@ load_python26()
     w_download https://www.python.org/ftp/python/2.6.2/python-2.6.2.msi c2276b398864b822c25a7c240cb12ddb178962afd2e12d602f1a961e31ad52ff
     w_download https://downloads.sourceforge.net/project/pywin32/pywin32/Build%20214/pywin32-214.win32-py2.6.exe dc311bbdc5868e3dd139dfc46136221b7f55c5613a98a5a48fa725a6c681cd40
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" msiexec /i python-2.6.2.msi ALLUSERS=1 ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" msiexec /i python-2.6.2.msi ALLUSERS=1 ${W_OPT_UNATTENDED:+/q}
 
     w_ahk_do "
         SetTitleMatchMode, 2
@@ -11387,8 +11387,8 @@ load_python27()
     w_download https://www.python.org/ftp/python/2.7.16/python-2.7.16.msi d57dc3e1ba490aee856c28b4915d09e3f49442461e46e481bc6b2d18207831d7
     w_download https://github.com/mhammond/pywin32/releases/download/b224/pywin32-224.win32-py2.7.exe 03bb02aff0ec604d1d5fefc699581ab599fff618eaddc8a721f2fa22e5572dd4
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" msiexec /i python-2.7.16.msi ALLUSERS=1 ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" msiexec /i python-2.7.16.msi ALLUSERS=1 ${W_OPT_UNATTENDED:+/q}
 
     w_ahk_do "
         SetTitleMatchMode, 2
@@ -11415,19 +11415,19 @@ w_metadata qasf dlls \
     year="2011" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/qasf.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/qasf.dll"
 
 load_qasf()
 {
     helper_win7sp1 x86_microsoft-windows-directshow-asf_31bf3856ad364e35_6.1.7601.17514_none_1cc4e9c15ccc8ae8/qasf.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-directshow-asf_31bf3856ad364e35_6.1.7601.17514_none_1cc4e9c15ccc8ae8/qasf.dll" "$W_SYSTEM32_DLLS/qasf.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-directshow-asf_31bf3856ad364e35_6.1.7601.17514_none_1cc4e9c15ccc8ae8/qasf.dll" "${W_SYSTEM32_DLLS}/qasf.dll"
 
     w_override_dlls native,builtin qasf
     w_try_regsvr qasf.dll
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-directshow-asf_31bf3856ad364e35_6.1.7601.17514_none_78e385451529fc1e/qasf.dll
-        w_try cp "$W_TMP/amd64_microsoft-windows-directshow-asf_31bf3856ad364e35_6.1.7601.17514_none_78e385451529fc1e/qasf.dll" "$W_SYSTEM64_DLLS/qasf.dll"
+        w_try cp "${W_TMP}/amd64_microsoft-windows-directshow-asf_31bf3856ad364e35_6.1.7601.17514_none_78e385451529fc1e/qasf.dll" "${W_SYSTEM64_DLLS}/qasf.dll"
         w_try_regsvr64 qasf.dll
     fi
 }
@@ -11440,18 +11440,18 @@ w_metadata qcap dlls \
     year="2011" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/qcap.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/qcap.dll"
 
 load_qcap()
 {
     helper_win7sp1 x86_microsoft-windows-directshow-capture_31bf3856ad364e35_6.1.7601.17514_none_bae08d1e7dcccf2a/qcap.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-directshow-capture_31bf3856ad364e35_6.1.7601.17514_none_bae08d1e7dcccf2a/qcap.dll" "$W_SYSTEM32_DLLS/qcap.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-directshow-capture_31bf3856ad364e35_6.1.7601.17514_none_bae08d1e7dcccf2a/qcap.dll" "${W_SYSTEM32_DLLS}/qcap.dll"
     w_override_dlls native,builtin qcap
     w_try_regsvr qcap.dll
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-directshow-capture_31bf3856ad364e35_6.1.7601.17514_none_16ff28a2362a4060/qcap.dll
-        w_try cp "$W_TMP/amd64_microsoft-windows-directshow-capture_31bf3856ad364e35_6.1.7601.17514_none_16ff28a2362a4060/qcap.dll" "$W_SYSTEM64_DLLS/qcap.dll"
+        w_try cp "${W_TMP}/amd64_microsoft-windows-directshow-capture_31bf3856ad364e35_6.1.7601.17514_none_16ff28a2362a4060/qcap.dll" "${W_SYSTEM64_DLLS}/qcap.dll"
         w_try_regsvr64 qcap.dll
     fi
 }
@@ -11464,18 +11464,18 @@ w_metadata qdvd dlls \
     year="2011" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/qdvd.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/qdvd.dll"
 
 load_qdvd()
 {
     helper_win7sp1 x86_microsoft-windows-directshow-dvdsupport_31bf3856ad364e35_6.1.7601.17514_none_562994bd321aac67/qdvd.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-directshow-dvdsupport_31bf3856ad364e35_6.1.7601.17514_none_562994bd321aac67/qdvd.dll" "$W_SYSTEM32_DLLS/qdvd.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-directshow-dvdsupport_31bf3856ad364e35_6.1.7601.17514_none_562994bd321aac67/qdvd.dll" "${W_SYSTEM32_DLLS}/qdvd.dll"
     w_override_dlls native,builtin qdvd
     w_try_regsvr qdvd.dll
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-directshow-dvdsupport_31bf3856ad364e35_6.1.7601.17514_none_b2483040ea781d9d/qdvd.dll
-        w_try cp "$W_TMP/amd64_microsoft-windows-directshow-dvdsupport_31bf3856ad364e35_6.1.7601.17514_none_b2483040ea781d9d/qdvd.dll" "$W_SYSTEM64_DLLS/qdvd.dll"
+        w_try cp "${W_TMP}/amd64_microsoft-windows-directshow-dvdsupport_31bf3856ad364e35_6.1.7601.17514_none_b2483040ea781d9d/qdvd.dll" "${W_SYSTEM64_DLLS}/qdvd.dll"
         w_try_regsvr64 qdvd.dll
     fi
 }
@@ -11488,18 +11488,18 @@ w_metadata qedit dlls \
     year="2011" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/qedit.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/qedit.dll"
 
 load_qedit()
 {
     helper_win7sp1 x86_microsoft-windows-qedit_31bf3856ad364e35_6.1.7601.17514_none_5ca34698a5a970d2/qedit.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-qedit_31bf3856ad364e35_6.1.7601.17514_none_5ca34698a5a970d2/qedit.dll" "$W_SYSTEM32_DLLS/qedit.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-qedit_31bf3856ad364e35_6.1.7601.17514_none_5ca34698a5a970d2/qedit.dll" "${W_SYSTEM32_DLLS}/qedit.dll"
     w_override_dlls native,builtin qedit
     w_try_regsvr qedit.dll
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-qedit_31bf3856ad364e35_6.1.7601.17514_none_b8c1e21c5e06e208/qedit.dll
-        w_try cp "$W_TMP/amd64_microsoft-windows-qedit_31bf3856ad364e35_6.1.7601.17514_none_b8c1e21c5e06e208/qedit.dll" "$W_SYSTEM64_DLLS/qedit.dll"
+        w_try cp "${W_TMP}/amd64_microsoft-windows-qedit_31bf3856ad364e35_6.1.7601.17514_none_b8c1e21c5e06e208/qedit.dll" "${W_SYSTEM64_DLLS}/qedit.dll"
         w_try_regsvr64 qedit.dll
     fi
 }
@@ -11512,18 +11512,18 @@ w_metadata quartz dlls \
     year="2011" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/quartz.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/quartz.dll"
 
 load_quartz()
 {
     helper_win7sp1 x86_microsoft-windows-directshow-core_31bf3856ad364e35_6.1.7601.17514_none_a877a1cc4c284497/quartz.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-directshow-core_31bf3856ad364e35_6.1.7601.17514_none_a877a1cc4c284497/quartz.dll" "$W_SYSTEM32_DLLS/quartz.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-directshow-core_31bf3856ad364e35_6.1.7601.17514_none_a877a1cc4c284497/quartz.dll" "${W_SYSTEM32_DLLS}/quartz.dll"
     w_override_dlls native,builtin quartz
     w_try_regsvr quartz.dll
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-directshow-core_31bf3856ad364e35_6.1.7601.17514_none_04963d500485b5cd/quartz.dll
-        w_try cp "$W_TMP/amd64_microsoft-windows-directshow-core_31bf3856ad364e35_6.1.7601.17514_none_04963d500485b5cd/quartz.dll" "$W_SYSTEM64_DLLS/quartz.dll"
+        w_try cp "${W_TMP}/amd64_microsoft-windows-directshow-core_31bf3856ad364e35_6.1.7601.17514_none_04963d500485b5cd/quartz.dll" "${W_SYSTEM64_DLLS}/quartz.dll"
         w_try_regsvr64 quartz.dll
     fi
 }
@@ -11543,20 +11543,20 @@ load_quicktime72()
     # https://support.apple.com/kb/DL837
     w_download http://appldnld.apple.com.edgesuite.net/content.info.apple.com/QuickTime/061-2915.20070710.pO94c/QuickTimeInstaller.exe a42b93531910bdf1539cc5ae3199ade5a1ca63fd4ac971df74c345d8e1ee6593
 
-    w_try_cd "$W_CACHE"/"$W_PACKAGE"
-    w_try "$WINE" "$file1" ALLUSERS=1 DESKTOP_SHORTCUTS=0 QTTaskRunFlags=0 QTINFO.BISQTPRO=1 SCHEDULE_ASUW=0 REBOOT_REQUIRED=No ${W_OPT_UNATTENDED:+/qn} > /dev/null 2>&1
+    w_try_cd "${W_CACHE}"/"${W_PACKAGE}"
+    w_try "${WINE}" "${file1}" ALLUSERS=1 DESKTOP_SHORTCUTS=0 QTTaskRunFlags=0 QTINFO.BISQTPRO=1 SCHEDULE_ASUW=0 REBOOT_REQUIRED=No ${W_OPT_UNATTENDED:+/qn} > /dev/null 2>&1
 
     if w_workaround_wine_bug 11681; then
         # Following advice verified with test movies from
         # https://support.apple.com/kb/HT1425
         # in QuickTimePlayer.
 
-        case $LANG in
+        case ${LANG} in
             ru*) w_warn "В настройках Quicktime включите Дополнительно / Безопасный режим (только gdi), иначе видеофайлы не будут воспроизводиться." ;;
             *) w_warn "In Quicktime preferences, check Advanced / Safe Mode (gdi), or movies won't play." ;;
         esac
         if [ -z "${W_OPT_UNATTENDED}" ]; then
-            w_try "$WINE" control "$W_PROGRAMS_WIN\\QuickTime\\QTSystem\\QuickTime.cpl"
+            w_try "${WINE}" control "${W_PROGRAMS_WIN}\\QuickTime\\QTSystem\\QuickTime.cpl"
         else
             # FIXME: script the control panel with AutoHotKey?
             # We could probably also overwrite QuickTime.qtp but
@@ -11581,20 +11581,20 @@ load_quicktime76()
     # https://support.apple.com/kb/DL837
     w_download http://appldnld.apple.com/QuickTime/041-0025.20101207.Ptrqt/QuickTimeInstaller.exe c2dcda76ed55428e406ad7e6acdc84e804d30752a1380c313394c09bb3e27f56
 
-    w_try_cd "$W_CACHE"/"$W_PACKAGE"
-    w_try "$WINE" QuickTimeInstaller.exe ALLUSERS=1 DESKTOP_SHORTCUTS=0 QTTaskRunFlags=0 QTINFO.BISQTPRO=1 SCHEDULE_ASUW=0 REBOOT_REQUIRED=No ${W_OPT_UNATTENDED:+/qn} > /dev/null 2>&1
+    w_try_cd "${W_CACHE}"/"${W_PACKAGE}"
+    w_try "${WINE}" QuickTimeInstaller.exe ALLUSERS=1 DESKTOP_SHORTCUTS=0 QTTaskRunFlags=0 QTINFO.BISQTPRO=1 SCHEDULE_ASUW=0 REBOOT_REQUIRED=No ${W_OPT_UNATTENDED:+/qn} > /dev/null 2>&1
 
     if w_workaround_wine_bug 11681; then
         # Following advice verified with test movies from
         # https://support.apple.com/kb/HT1425
         # in QuickTimePlayer.
 
-        case $LANG in
+        case ${LANG} in
             ru*) w_warn "В настройках Quicktime включите Дополнительно / Безопасный режим (только gdi), иначе видеофайлы не будут воспроизводиться." ;;
             *) w_warn "In Quicktime preferences, check Advanced / Safe Mode (gdi), or movies won't play." ;;
         esac
         if [ -z "${W_OPT_UNATTENDED}" ]; then
-            w_try "$WINE" control "$W_PROGRAMS_WIN\\QuickTime\\QTSystem\\QuickTime.cpl"
+            w_try "${WINE}" control "${W_PROGRAMS_WIN}\\QuickTime\\QTSystem\\QuickTime.cpl"
         else
             # FIXME: script the control panel with AutoHotKey?
             # We could probably also overwrite QuickTime.qtp but
@@ -11612,13 +11612,13 @@ w_metadata riched20 dlls \
     year="2004" \
     media="download" \
     file1="../win2ksp4/W2KSP4_EN.EXE" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/riched20.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/riched20.dll"
 
 load_riched20()
 {
     # FIXME: this verb used to also install riched32.  Does anyone need that?
     helper_win2ksp4 i386/riched20.dl_
-    w_try_cabextract --directory="$W_SYSTEM32_DLLS" "$W_TMP"/i386/riched20.dl_
+    w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_TMP}"/i386/riched20.dl_
     w_override_dlls native,builtin riched20
 
     # https://github.com/Winetricks/winetricks/issues/292
@@ -11636,8 +11636,8 @@ w_metadata riched30 dlls \
     year="2001" \
     media="download" \
     file1="InstMsiA.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/riched20.dll" \
-    installed_file2="$W_SYSTEM32_DLLS_WIN/msls31.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/riched20.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/msls31.dll"
 
 load_riched30()
 {
@@ -11655,9 +11655,9 @@ load_riched30()
     # Since mirrors are dead, going back to the microsoft.com version, via archive.org
     w_download https://web.archive.org/web/20060720160141/https://download.microsoft.com/download/WindowsInstaller/Install/2.0/W9XMe/EN-US/InstMsiA.exe 536e4c8385d7d250fd5702a6868d1ed004692136eefad22252d0dac15f02563a
 
-    w_try_cabextract --directory="$W_TMP" "$W_CACHE"/riched30/InstMsiA.exe
-    w_try cp -f "$W_TMP"/riched20.dll "$W_SYSTEM32_DLLS"
-    w_try cp -f "$W_TMP"/msls31.dll "$W_SYSTEM32_DLLS"
+    w_try_cabextract --directory="${W_TMP}" "${W_CACHE}"/riched30/InstMsiA.exe
+    w_try cp -f "${W_TMP}"/riched20.dll "${W_SYSTEM32_DLLS}"
+    w_try cp -f "${W_TMP}"/msls31.dll "${W_SYSTEM32_DLLS}"
     w_override_dlls native,builtin riched20
 }
 
@@ -11669,11 +11669,11 @@ w_metadata richtx32 dlls \
     year="2012" \
     media="download" \
     file1="../vb6sp6/VB60SP6-KB2708437-x86-ENU.msi" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/richtx32.ocx"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/richtx32.ocx"
 
 load_richtx32()
 {
-    helper_vb6sp6 "$W_SYSTEM32_DLLS" richtx32.ocx
+    helper_vb6sp6 "${W_SYSTEM32_DLLS}" richtx32.ocx
     w_try_regsvr richtx32.ocx
 }
 
@@ -11685,13 +11685,13 @@ w_metadata sdl dlls \
     year="2012" \
     media="download" \
     file1="SDL-1.2.15-win32.zip" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/SDL.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/SDL.dll"
 
 load_sdl()
 {
     # https://www.libsdl.org/download-1.2.php
     w_download https://www.libsdl.org/release/SDL-1.2.15-win32.zip a28bbe38714ef7817b1c1e8082a48f391f15e4043402444b783952fca939edc1
-    w_try_unzip "$W_SYSTEM32_DLLS" "$W_CACHE"/sdl/SDL-1.2.15-win32.zip SDL.dll
+    w_try_unzip "${W_SYSTEM32_DLLS}" "${W_CACHE}"/sdl/SDL-1.2.15-win32.zip SDL.dll
 }
 
 #----------------------------------------------------------------
@@ -11702,18 +11702,18 @@ w_metadata secur32 dlls \
     year="2011" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/secur32.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/secur32.dll"
 
 load_secur32()
 {
     w_warn "Installing native secur32 may lead to stack overflow crashes, see https://bugs.winehq.org/show_bug.cgi?id=45344"
 
     helper_win7sp1 x86_microsoft-windows-lsa_31bf3856ad364e35_6.1.7601.17514_none_a851f4adbb0d5141/secur32.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-lsa_31bf3856ad364e35_6.1.7601.17514_none_a851f4adbb0d5141/secur32.dll" "$W_SYSTEM32_DLLS/secur32.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-lsa_31bf3856ad364e35_6.1.7601.17514_none_a851f4adbb0d5141/secur32.dll" "${W_SYSTEM32_DLLS}/secur32.dll"
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-lsa_31bf3856ad364e35_6.1.7601.17514_none_04709031736ac277/secur32.dll
-        w_try cp "$W_TMP/amd64_microsoft-windows-lsa_31bf3856ad364e35_6.1.7601.17514_none_04709031736ac277/secur32.dll" "$W_SYSTEM64_DLLS/secur32.dll"
+        w_try cp "${W_TMP}/amd64_microsoft-windows-lsa_31bf3856ad364e35_6.1.7601.17514_none_04709031736ac277/secur32.dll" "${W_SYSTEM64_DLLS}/secur32.dll"
     fi
 
     w_override_dlls native,builtin secur32
@@ -11727,12 +11727,12 @@ w_metadata setupapi dlls \
     year="2004" \
     media="download" \
     file1="../winxpsp3/WindowsXP-KB936929-SP3-x86-ENU.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/setupapi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/setupapi.dll"
 
 load_setupapi()
 {
     helper_winxpsp3 i386/setupapi.dl_
-    w_try_cabextract --directory="$W_SYSTEM32_DLLS" "$W_TMP"/i386/setupapi.dl_
+    w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_TMP}"/i386/setupapi.dl_
 
     w_override_dlls native,builtin setupapi
 }
@@ -11745,7 +11745,7 @@ w_metadata shockwave dlls \
     year="2018" \
     media="download" \
     file1="sw_lic_full_installer.msi" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/Adobe/Shockwave 12/shockwave_Projector_Loader.dcr"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/Adobe/Shockwave 12/shockwave_Projector_Loader.dcr"
 
 load_shockwave() {
     # 2017/03/12: 39715a84b1d85347066fbf89a3af9f5e612b59402093b055cd423bd30a7f637d
@@ -11758,8 +11758,8 @@ load_shockwave() {
     # 2019/04/02: 8e414c1a218157d2b83877fb0b6a5002c2e9bff4dc2a3095bae774a13e3e9dbf
     w_download https://fpdownload.macromedia.com/get/shockwave/default/english/win95nt/latest/sw_lic_full_installer.msi 8e414c1a218157d2b83877fb0b6a5002c2e9bff4dc2a3095bae774a13e3e9dbf
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" msiexec /i sw_lic_full_installer.msi ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" msiexec /i sw_lic_full_installer.msi ${W_OPT_UNATTENDED:+/q}
 }
 
 #----------------------------------------------------------------
@@ -11772,7 +11772,7 @@ w_metadata speechsdk dlls \
     year="2009" \
     media="download" \
     file1="SpeechSDK51.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/Microsoft Speech SDK 5.1/Bin/SAPI51SampleApp.exe"
+    installed_file1="${W_PROGRAMS_X86_WIN}/Microsoft Speech SDK 5.1/Bin/SAPI51SampleApp.exe"
 
 load_speechsdk()
 {
@@ -11781,25 +11781,25 @@ load_speechsdk()
     # https://www.microsoft.com/en-us/download/details.aspx?id=10121
     w_download https://download.microsoft.com/download/B/4/3/B4314928-7B71-4336-9DE7-6FA4CF00B7B3/SpeechSDK51.exe 520aa5d1a72dc6f41dc9b8b88603228ffd5d5d6f696224fc237ec4828fe7f6e0
 
-    w_try_unzip "$W_TMP" "$W_CACHE"/speechsdk/SpeechSDK51.exe
+    w_try_unzip "${W_TMP}" "${W_CACHE}"/speechsdk/SpeechSDK51.exe
 
     # Otherwise it only installs the SDK and not the redistributable:
     w_set_winver win2k
 
     # Only added in wine-2.18
-    for stub in "$W_SYSTEM32_DLLS/Speech/Common/sapi.dll" "$W_SYSTEM64_DLLS/Speech/Common/sapi.dll"; do
-        if [ -f "$stub" ]; then
-            w_try rm "$stub"
+    for stub in "${W_SYSTEM32_DLLS}/Speech/Common/sapi.dll" "${W_SYSTEM64_DLLS}/Speech/Common/sapi.dll"; do
+        if [ -f "${stub}" ]; then
+            w_try rm "${stub}"
         fi
     done
 
-    w_try_cd "$W_TMP"
-    w_try "$WINE" msiexec /i "Microsoft Speech SDK 5.1.msi" ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_TMP}"
+    w_try "${WINE}" msiexec /i "Microsoft Speech SDK 5.1.msi" ${W_OPT_UNATTENDED:+/q}
 
     # If sapi.dll isn't in original location, applications won't start, see
     # e.g., https://bugs.winehq.org/show_bug.cgi?id=43841
-    mkdir -p "$W_SYSTEM32_DLLS/Speech/Common/"
-    w_try ln -s "$W_COMMONFILES_X86/Microsoft Shared/Speech/sapi.dll" "$W_SYSTEM32_DLLS/Speech/Common"
+    mkdir -p "${W_SYSTEM32_DLLS}/Speech/Common/"
+    w_try ln -s "${W_COMMONFILES_X86}/Microsoft Shared/Speech/sapi.dll" "${W_SYSTEM32_DLLS}/Speech/Common"
 
     w_override_dlls native sapi
 
@@ -11815,12 +11815,12 @@ w_metadata tabctl32 dlls \
     year="2012" \
     media="download" \
     file1="../vb6sp6/VB60SP6-KB2708437-x86-ENU.msi" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/tabctl32.ocx"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/tabctl32.ocx"
 
 load_tabctl32()
 {
-    helper_vb6sp6 "$W_TMP" TabCtl32.ocx
-    w_try mv "${W_TMP}/TabCtl32.ocx" "$W_SYSTEM32_DLLS/tabctl32.ocx"
+    helper_vb6sp6 "${W_TMP}" TabCtl32.ocx
+    w_try mv "${W_TMP}/TabCtl32.ocx" "${W_SYSTEM32_DLLS}/tabctl32.ocx"
     w_try_regsvr tabctl32.ocx
 }
 
@@ -11832,12 +11832,12 @@ w_metadata updspapi dlls \
     year="2004" \
     media="download" \
     file1="../winxpsp3/WindowsXP-KB936929-SP3-x86-ENU.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/updspapi.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/updspapi.dll"
 
 load_updspapi()
 {
     helper_winxpsp3 i386/update/updspapi.dll
-    w_try cp -f "$W_TMP"/i386/update/updspapi.dll "$W_SYSTEM32_DLLS"
+    w_try cp -f "${W_TMP}"/i386/update/updspapi.dll "${W_SYSTEM32_DLLS}"
 
     w_override_dlls native,builtin updspapi
 }
@@ -11850,16 +11850,16 @@ w_metadata urlmon dlls \
     year="2011" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/urlmon.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/urlmon.dll"
 
 load_urlmon()
 {
     helper_win7sp1 x86_microsoft-windows-i..ersandsecurityzones_31bf3856ad364e35_8.0.7601.17514_none_d1a4c8feac0dfcdb/urlmon.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-i..ersandsecurityzones_31bf3856ad364e35_8.0.7601.17514_none_d1a4c8feac0dfcdb/urlmon.dll" "$W_SYSTEM32_DLLS/urlmon.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-i..ersandsecurityzones_31bf3856ad364e35_8.0.7601.17514_none_d1a4c8feac0dfcdb/urlmon.dll" "${W_SYSTEM32_DLLS}/urlmon.dll"
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-i..ersandsecurityzones_31bf3856ad364e35_8.0.7601.17514_none_2dc36482646b6e11/urlmon.dll
-        w_try cp "$W_TMP/amd64_microsoft-windows-i..ersandsecurityzones_31bf3856ad364e35_8.0.7601.17514_none_2dc36482646b6e11/urlmon.dll" "$W_SYSTEM64_DLLS/urlmon.dll"
+        w_try cp "${W_TMP}/amd64_microsoft-windows-i..ersandsecurityzones_31bf3856ad364e35_8.0.7601.17514_none_2dc36482646b6e11/urlmon.dll" "${W_SYSTEM64_DLLS}/urlmon.dll"
     fi
 
     w_override_dlls native,builtin urlmon
@@ -11875,16 +11875,16 @@ w_metadata usp10 dlls \
     year="2011" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/usp10.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/usp10.dll"
 
 load_usp10()
 {
     helper_win7sp1 x86_microsoft-windows-usp_31bf3856ad364e35_6.1.7601.17514_none_af01e2f9b6be7939/usp10.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-usp_31bf3856ad364e35_6.1.7601.17514_none_af01e2f9b6be7939/usp10.dll" "$W_SYSTEM32_DLLS/usp10.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-usp_31bf3856ad364e35_6.1.7601.17514_none_af01e2f9b6be7939/usp10.dll" "${W_SYSTEM32_DLLS}/usp10.dll"
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-usp_31bf3856ad364e35_6.1.7601.17514_none_0b207e7d6f1bea6f/usp10.dll
-        w_try cp "$W_TMP/amd64_microsoft-windows-usp_31bf3856ad364e35_6.1.7601.17514_none_0b207e7d6f1bea6f/usp10.dll" "$W_SYSTEM64_DLLS/usp10.dll"
+        w_try cp "${W_TMP}/amd64_microsoft-windows-usp_31bf3856ad364e35_6.1.7601.17514_none_0b207e7d6f1bea6f/usp10.dll" "${W_SYSTEM64_DLLS}/usp10.dll"
     fi
 
     w_override_dlls native,builtin usp10
@@ -11898,7 +11898,7 @@ w_metadata vb2run dlls \
     year="1993" \
     media="download" \
     file1="VBRUN200.EXE" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/VBRUN200.DLL"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/VBRUN200.DLL"
 
 load_vb2run()
 {
@@ -11908,8 +11908,8 @@ load_vb2run()
     # 2015/08/10: chatnfiles is down, conradshome.com is up (and has a LOT of old MS installers archived!)
     # 2018/11/15: now conradshome is down ,but quaddicted.com also has it (and a lot more)
     w_download https://www.quaddicted.com/files/mirrors/ftp.planetquake.com/aoe/downloads/VBRUN200.EXE 4b0811d8fdcac1fd9411786c9119dc8d98d0540948211bdbc1ac682fbe5c0228
-    w_try_unzip "$W_TMP" "$W_CACHE"/vb2run/VBRUN200.EXE
-    w_try cp -f "$W_TMP/VBRUN200.DLL" "$W_SYSTEM32_DLLS"
+    w_try_unzip "${W_TMP}" "${W_CACHE}"/vb2run/VBRUN200.EXE
+    w_try cp -f "${W_TMP}/VBRUN200.DLL" "${W_SYSTEM32_DLLS}"
 }
 
 #----------------------------------------------------------------
@@ -11920,14 +11920,14 @@ w_metadata vb3run dlls \
     year="1998" \
     media="download" \
     file1="vb3run.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/Vbrun300.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/Vbrun300.dll"
 
 load_vb3run()
 {
     # See https://support.microsoft.com/kb/196285
     w_download https://download.microsoft.com/download/vb30/utility/1/w9xnt4/en-us/vb3run.exe 3ca3ad6332f83b5c2b86e4758afa400150f07ae66ce8b850d8f9d6bcd47ad4cd
-    w_try_unzip "$W_TMP" "$W_CACHE"/vb3run/vb3run.exe
-    w_try cp -f "$W_TMP/Vbrun300.dll" "$W_SYSTEM32_DLLS"
+    w_try_unzip "${W_TMP}" "${W_CACHE}"/vb3run/vb3run.exe
+    w_try cp -f "${W_TMP}/Vbrun300.dll" "${W_SYSTEM32_DLLS}"
 }
 
 #----------------------------------------------------------------
@@ -11938,15 +11938,15 @@ w_metadata vb4run dlls \
     year="1998" \
     media="download" \
     file1="vb4run.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/Vb40032.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/Vb40032.dll"
 
 load_vb4run()
 {
     # See https://support.microsoft.com/kb/196286
     w_download https://download.microsoft.com/download/vb40ent/sample27/1/w9xnt4/en-us/vb4run.exe 40931308b5a137f9ce3e9da9b43f4ca6688e18b523687cfea8be6cdffa3153fb
-    w_try_unzip "$W_TMP" "$W_CACHE"/vb4run/vb4run.exe
-    w_try cp -f "$W_TMP/Vb40032.dll" "$W_SYSTEM32_DLLS"
-    w_try cp -f "$W_TMP/Vb40016.dll" "$W_SYSTEM32_DLLS"
+    w_try_unzip "${W_TMP}" "${W_CACHE}"/vb4run/vb4run.exe
+    w_try cp -f "${W_TMP}/Vb40032.dll" "${W_SYSTEM32_DLLS}"
+    w_try cp -f "${W_TMP}/Vb40016.dll" "${W_SYSTEM32_DLLS}"
 }
 
 #----------------------------------------------------------------
@@ -11957,13 +11957,13 @@ w_metadata vb5run dlls \
     year="2001" \
     media="download" \
     file1="msvbvm50.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/msvbvm50.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/msvbvm50.dll"
 
 load_vb5run()
 {
     w_download https://download.microsoft.com/download/vb50pro/utility/1/win98/en-us/msvbvm50.exe b5f8ea5b9d8b30822a2be2cdcb89cda99ec0149832659ad81f45360daa6e6965
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" msvbvm50.exe ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" msvbvm50.exe ${W_OPT_UNATTENDED:+/q}
 }
 
 #----------------------------------------------------------------
@@ -11974,49 +11974,49 @@ w_metadata vb6run dlls \
     year="2004" \
     media="download" \
     file1="vbrun60sp6.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/MSVBVM60.DLL"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/MSVBVM60.DLL"
 
 load_vb6run()
 {
     # https://support.microsoft.com/kb/290887
-    if test ! -f "$W_CACHE"/vb6run/vbrun60sp6.exe; then
+    if test ! -f "${W_CACHE}"/vb6run/vbrun60sp6.exe; then
         w_download https://download.microsoft.com/download/5/a/d/5ad868a0-8ecd-4bb0-a882-fe53eb7ef348/VB6.0-KB290887-X86.exe 467b5a10c369865f2021d379fc0933cb382146b702bbca4bcb703fc86f4322bb
 
-        w_try "$WINE" "$W_CACHE"/vb6run/VB6.0-KB290887-X86.exe "/T:$W_TMP_WIN" /c ${W_OPT_UNATTENDED:+/q}
-        if test ! -f "$W_TMP"/vbrun60sp6.exe; then
+        w_try "${WINE}" "${W_CACHE}"/vb6run/VB6.0-KB290887-X86.exe "/T:${W_TMP_WIN}" /c ${W_OPT_UNATTENDED:+/q}
+        if test ! -f "${W_TMP}"/vbrun60sp6.exe; then
             w_die vbrun60sp6.exe not found
         fi
-        w_try mv "$W_TMP"/vbrun60sp6.exe "$W_CACHE"/vb6run
+        w_try mv "${W_TMP}"/vbrun60sp6.exe "${W_CACHE}"/vb6run
     fi
 
     # Delete some fake DLLs to ensure that the installer overwrites them.
-    rm -f "$W_SYSTEM32_DLLS"/comcat.dll
-    rm -f "$W_SYSTEM32_DLLS"/oleaut32.dll
-    rm -f "$W_SYSTEM32_DLLS"/olepro32.dll
-    rm -f "$W_SYSTEM32_DLLS"/stdole2.tlb
+    rm -f "${W_SYSTEM32_DLLS}"/comcat.dll
+    rm -f "${W_SYSTEM32_DLLS}"/oleaut32.dll
+    rm -f "${W_SYSTEM32_DLLS}"/olepro32.dll
+    rm -f "${W_SYSTEM32_DLLS}"/stdole2.tlb
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     # Exits with status 43 for some reason?
-    "$WINE" vbrun60sp6.exe ${W_OPT_UNATTENDED:+/q}
+    "${WINE}" vbrun60sp6.exe ${W_OPT_UNATTENDED:+/q}
 
     status=$?
-    case $status in
+    case ${status} in
         0|43) ;;
-        *) w_die "$W_PACKAGE installation failed"
+        *) w_die "${W_PACKAGE} installation failed"
     esac
 }
 
 #----------------------------------------------------------------
 
 winetricks_vcrun6_helper() {
-    if test ! -f "$W_CACHE"/vcrun6/vcredist.exe; then
+    if test ! -f "${W_CACHE}"/vcrun6/vcredist.exe; then
         w_download_to vcrun6 https://download.microsoft.com/download/vc60pro/Update/2/W9XNT4/EN-US/VC6RedistSetup_deu.exe c2eb91d9c4448d50e46a32fecbcc3b418706d002beab9b5f4981de552098cee7
 
-        w_try "$WINE" "$W_CACHE"/vcrun6/vc6redistsetup_deu.exe "/T:$W_TMP_WIN" /c ${W_OPT_UNATTENDED:+/q}
-        if test ! -f "$W_TMP"/vcredist.exe; then
+        w_try "${WINE}" "${W_CACHE}"/vcrun6/vc6redistsetup_deu.exe "/T:${W_TMP_WIN}" /c ${W_OPT_UNATTENDED:+/q}
+        if test ! -f "${W_TMP}"/vcredist.exe; then
             w_die vcredist.exe not found
         fi
-        mv "$W_TMP"/vcredist.exe "$W_CACHE"/vcrun6
+        mv "${W_TMP}"/vcredist.exe "${W_CACHE}"/vcrun6
     fi
 }
 
@@ -12026,7 +12026,7 @@ w_metadata vcrun6 dlls \
     year="2000" \
     media="download" \
     file1="vc6redistsetup_deu.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc42.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/mfc42.dll"
 
 load_vcrun6()
 {
@@ -12034,15 +12034,15 @@ load_vcrun6()
     winetricks_vcrun6_helper
 
     # Delete some fake DLLs to avoid vcredist installer warnings
-    rm -f "$W_SYSTEM32_DLLS"/comcat.dll
-    rm -f "$W_SYSTEM32_DLLS"/msvcrt.dll
-    rm -f "$W_SYSTEM32_DLLS"/oleaut32.dll
-    rm -f "$W_SYSTEM32_DLLS"/olepro32.dll
-    rm -f "$W_SYSTEM32_DLLS"/stdole2.tlb
-    "$WINE" "$W_CACHE"/vcrun6/vcredist.exe
+    rm -f "${W_SYSTEM32_DLLS}"/comcat.dll
+    rm -f "${W_SYSTEM32_DLLS}"/msvcrt.dll
+    rm -f "${W_SYSTEM32_DLLS}"/oleaut32.dll
+    rm -f "${W_SYSTEM32_DLLS}"/olepro32.dll
+    rm -f "${W_SYSTEM32_DLLS}"/stdole2.tlb
+    "${WINE}" "${W_CACHE}"/vcrun6/vcredist.exe
 
     status=$?
-    case $status in
+    case ${status} in
         0|43) ;;
         *) w_die vcrun6 installation failed
     esac
@@ -12058,13 +12058,13 @@ w_metadata mfc42 dlls \
     year="2000" \
     media="download" \
     file1="../vcrun6/vc6redistsetup_deu.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc42u.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/mfc42u.dll"
 
 load_mfc42()
 {
     winetricks_vcrun6_helper
 
-    w_try_cabextract "$W_CACHE"/vcrun6/vcredist.exe -d "$W_SYSTEM32_DLLS" -F "mfc42*.dll"
+    w_try_cabextract "${W_CACHE}"/vcrun6/vcredist.exe -d "${W_SYSTEM32_DLLS}" -F "mfc42*.dll"
 }
 
 w_metadata msvcirt dlls \
@@ -12073,13 +12073,13 @@ w_metadata msvcirt dlls \
     year="2000" \
     media="download" \
     file1="../vcrun6/vc6redistsetup_deu.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/msvcirt.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/msvcirt.dll"
 
 load_msvcirt()
 {
     winetricks_vcrun6_helper
 
-    w_try_cabextract "$W_CACHE"/vcrun6/vcredist.exe -d "$W_SYSTEM32_DLLS" -F msvcirt.dll
+    w_try_cabextract "${W_CACHE}"/vcrun6/vcredist.exe -d "${W_SYSTEM32_DLLS}" -F msvcirt.dll
 }
 
 #----------------------------------------------------------------
@@ -12094,7 +12094,7 @@ w_metadata vcrun6sp6 dlls \
     year="2004" \
     media="download" \
     file1="Vs6sp6.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc42.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/mfc42.dll"
 
 load_vcrun6sp6()
 {
@@ -12102,27 +12102,27 @@ load_vcrun6sp6()
 
     # No EULA is presented when passing command-line extraction arguments,
     # so we'll simplify extraction with cabextract.
-    w_try_cabextract "$W_CACHE"/vcrun6sp6/Vs6sp6.exe -d "$W_TMP" -F vcredist.exe
-    w_try_cd "$W_TMP"
+    w_try_cabextract "${W_CACHE}"/vcrun6sp6/Vs6sp6.exe -d "${W_TMP}" -F vcredist.exe
+    w_try_cd "${W_TMP}"
 
     # Delete some fake DLLs to avoid vcredist installer warnings
-    w_try rm -f "$W_SYSTEM32_DLLS"/comcat.dll
-    w_try rm -f "$W_SYSTEM32_DLLS"/msvcrt.dll
-    w_try rm -f "$W_SYSTEM32_DLLS"/oleaut32.dll
-    w_try rm -f "$W_SYSTEM32_DLLS"/olepro32.dll
-    w_try rm -f "$W_SYSTEM32_DLLS"/stdole2.tlb
+    w_try rm -f "${W_SYSTEM32_DLLS}"/comcat.dll
+    w_try rm -f "${W_SYSTEM32_DLLS}"/msvcrt.dll
+    w_try rm -f "${W_SYSTEM32_DLLS}"/oleaut32.dll
+    w_try rm -f "${W_SYSTEM32_DLLS}"/olepro32.dll
+    w_try rm -f "${W_SYSTEM32_DLLS}"/stdole2.tlb
     # vcredist still exits with status 43.  Anyone know why?
-    "$WINE" vcredist.exe
+    "${WINE}" vcredist.exe
 
     status=$?
-    case $status in
+    case ${status} in
         0|43) ;;
-        *) w_die "$W_PACKAGE installation failed"
+        *) w_die "${W_PACKAGE} installation failed"
     esac
 
     # And then some apps need mfc42u.dll, dont know what right way
     # is to get it, vcredist doesn't install it by default?
-    w_try_cabextract vcredist.exe -d "$W_SYSTEM32_DLLS" -F mfc42u.dll
+    w_try_cabextract vcredist.exe -d "${W_SYSTEM32_DLLS}" -F mfc42u.dll
     # Should the mfc42 verb install this one instead?
 }
 
@@ -12134,7 +12134,7 @@ w_metadata vcrun2003 dlls \
     year="2003" \
     media="download" \
     file1="BZEditW32_1.6.5.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/msvcp71.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/msvcp71.dll"
 
 load_vcrun2003()
 {
@@ -12142,7 +12142,7 @@ load_vcrun2003()
     # winetricks-test can't handle ${file1} in url since it does a raw parsing :/
     w_download https://sourceforge.net/projects/bzflag/files/bzedit%20win32/1.6.5/BZEditW32_1.6.5.exe 84d1bda5dbf814742898a2e1c0e4bc793e9bc1fba4b7a93d59a7ef12bd0fd802
 
-    w_try_7z "$W_SYSTEM32_DLLS" "${W_CACHE}/vcrun2003/BZEditW32_1.6.5.exe" "mfc71.dll" "msvcp71.dll" "msvcr71.dll" -y
+    w_try_7z "${W_SYSTEM32_DLLS}" "${W_CACHE}/vcrun2003/BZEditW32_1.6.5.exe" "mfc71.dll" "msvcp71.dll" "msvcr71.dll" -y
 }
 
 w_metadata mfc71 dlls \
@@ -12151,13 +12151,13 @@ w_metadata mfc71 dlls \
     year="2003" \
     media="download" \
     file1="BZEditW32_1.6.5.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc71.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/mfc71.dll"
 
 load_mfc71()
 {
     w_download_to vcrun2003 https://sourceforge.net/projects/bzflag/files/bzedit%20win32/1.6.5/BZEditW32_1.6.5.exe 84d1bda5dbf814742898a2e1c0e4bc793e9bc1fba4b7a93d59a7ef12bd0fd802
 
-    w_try_7z "$W_SYSTEM32_DLLS" "${W_CACHE}/vcrun2003/BZEditW32_1.6.5.exe" "mfc71.dll" -y
+    w_try_7z "${W_SYSTEM32_DLLS}" "${W_CACHE}/vcrun2003/BZEditW32_1.6.5.exe" "mfc71.dll" -y
 }
 
 #----------------------------------------------------------------
@@ -12167,7 +12167,7 @@ load_mfc71()
 # (Adding an installed_file2 would mean 'and'.)
 # Perhaps we should test for one if winxp mode, and the other if win7 mode;
 # if that becomes important to get right, we'll do something like
-# "if installed_file1 is just the single char @, call test_installed_$verb"
+# "if installed_file1 is just the single char @, call test_installed_${verb}"
 # and then define that function here.
 w_metadata vcrun2005 dlls \
     title="Visual C++ 2005 libraries (mfc80,msvcp80,msvcr80)" \
@@ -12193,12 +12193,12 @@ load_vcrun2005()
     # https://bugs.winehq.org/show_bug.cgi?id=42859
     w_override_dlls native,builtin atl80 msvcm80 msvcp80 msvcr80 vcomp
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" "$file1" ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+/q}
 
-    if [ "$W_ARCH" = "win64" ] ;then
+    if [ "${W_ARCH}" = "win64" ] ;then
         w_download https://download.microsoft.com/download/8/B/4/8B42259F-5D70-43F4-AC2E-4B208FD8D66A/vcredist_x64.EXE 0551a61c85b718e1fa015b0c3e3f4c4eea0637055536c00e7969286b4fa663e0
-        w_try "$WINE" vcredist_x64.exe ${W_OPT_UNATTENDED:+/q}
+        w_try "${WINE}" vcredist_x64.exe ${W_OPT_UNATTENDED:+/q}
     fi
 }
 
@@ -12208,30 +12208,30 @@ w_metadata mfc80 dlls \
     year="2011" \
     media="download" \
     file1="../vcrun2005/vcredist_x86.EXE" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc80.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/mfc80.dll"
 
 load_mfc80()
 {
     w_download_to vcrun2005 https://download.microsoft.com/download/8/B/4/8B42259F-5D70-43F4-AC2E-4B208FD8D66A/vcredist_x86.EXE 4ee4da0fe62d5fa1b5e80c6e6d88a4a2f8b3b140c35da51053d0d7b72a381d29
 
-    w_try_cabextract --directory="$W_TMP/win32" "$W_CACHE"/vcrun2005/vcredist_x86.EXE -F 'vcredist.msi'
-    w_try_cabextract --directory="$W_TMP/win32" "$W_TMP/win32/vcredist.msi"
+    w_try_cabextract --directory="${W_TMP}/win32" "${W_CACHE}"/vcrun2005/vcredist_x86.EXE -F 'vcredist.msi'
+    w_try_cabextract --directory="${W_TMP}/win32" "${W_TMP}/win32/vcredist.msi"
 
-    w_try cp "$W_TMP/win32"/mfc80.dll.8.0.50727.6195.9BAE13A2_E7AF_D6C3_FF1F_C8B3B9A1E18E "$W_SYSTEM32_DLLS"/mfc80.dll
-    w_try cp "$W_TMP/win32"/mfc80u.dll.8.0.50727.6195.9BAE13A2_E7AF_D6C3_FF1F_C8B3B9A1E18E "$W_SYSTEM32_DLLS"/mfc80u.dll
-    w_try cp "$W_TMP/win32"/mfcm80.dll.8.0.50727.6195.9BAE13A2_E7AF_D6C3_FF1F_C8B3B9A1E18E "$W_SYSTEM32_DLLS"/mfcm80.dll
-    w_try cp "$W_TMP/win32"/mfcm80u.dll.8.0.50727.6195.9BAE13A2_E7AF_D6C3_FF1F_C8B3B9A1E18E "$W_SYSTEM32_DLLS"/mfcm80u.dll
+    w_try cp "${W_TMP}/win32"/mfc80.dll.8.0.50727.6195.9BAE13A2_E7AF_D6C3_FF1F_C8B3B9A1E18E "${W_SYSTEM32_DLLS}"/mfc80.dll
+    w_try cp "${W_TMP}/win32"/mfc80u.dll.8.0.50727.6195.9BAE13A2_E7AF_D6C3_FF1F_C8B3B9A1E18E "${W_SYSTEM32_DLLS}"/mfc80u.dll
+    w_try cp "${W_TMP}/win32"/mfcm80.dll.8.0.50727.6195.9BAE13A2_E7AF_D6C3_FF1F_C8B3B9A1E18E "${W_SYSTEM32_DLLS}"/mfcm80.dll
+    w_try cp "${W_TMP}/win32"/mfcm80u.dll.8.0.50727.6195.9BAE13A2_E7AF_D6C3_FF1F_C8B3B9A1E18E "${W_SYSTEM32_DLLS}"/mfcm80u.dll
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         w_download_to vcrun2005 https://download.microsoft.com/download/8/B/4/8B42259F-5D70-43F4-AC2E-4B208FD8D66A/vcredist_x64.EXE 0551a61c85b718e1fa015b0c3e3f4c4eea0637055536c00e7969286b4fa663e0
 
-        w_try_cabextract --directory="$W_TMP/win64" "$W_CACHE"/vcrun2005/vcredist_x64.EXE -F 'vcredist.msi'
-        w_try_cabextract --directory="$W_TMP/win64" "$W_TMP/win64/vcredist.msi"
+        w_try_cabextract --directory="${W_TMP}/win64" "${W_CACHE}"/vcrun2005/vcredist_x64.EXE -F 'vcredist.msi'
+        w_try_cabextract --directory="${W_TMP}/win64" "${W_TMP}/win64/vcredist.msi"
 
-        w_try cp "$W_TMP/win64"/mfc80.dll.8.0.50727.6195.8731EA9C_B0D8_8F16_FF1F_C8B3B9A1E18E "$W_SYSTEM64_DLLS"/mfc80.dll
-        w_try cp "$W_TMP/win64"/mfc80u.dll.8.0.50727.6195.8731EA9C_B0D8_8F16_FF1F_C8B3B9A1E18E "$W_SYSTEM64_DLLS"/mfc80u.dll
-        w_try cp "$W_TMP/win64"/mfcm80.dll.8.0.50727.6195.8731EA9C_B0D8_8F16_FF1F_C8B3B9A1E18E "$W_SYSTEM64_DLLS"/mfcm80.dll
-        w_try cp "$W_TMP/win64"/mfcm80u.dll.8.0.50727.6195.8731EA9C_B0D8_8F16_FF1F_C8B3B9A1E18E "$W_SYSTEM64_DLLS"/mfcm80u.dll
+        w_try cp "${W_TMP}/win64"/mfc80.dll.8.0.50727.6195.8731EA9C_B0D8_8F16_FF1F_C8B3B9A1E18E "${W_SYSTEM64_DLLS}"/mfc80.dll
+        w_try cp "${W_TMP}/win64"/mfc80u.dll.8.0.50727.6195.8731EA9C_B0D8_8F16_FF1F_C8B3B9A1E18E "${W_SYSTEM64_DLLS}"/mfc80u.dll
+        w_try cp "${W_TMP}/win64"/mfcm80.dll.8.0.50727.6195.8731EA9C_B0D8_8F16_FF1F_C8B3B9A1E18E "${W_SYSTEM64_DLLS}"/mfcm80.dll
+        w_try cp "${W_TMP}/win64"/mfcm80u.dll.8.0.50727.6195.8731EA9C_B0D8_8F16_FF1F_C8B3B9A1E18E "${W_SYSTEM64_DLLS}"/mfcm80u.dll
     fi
 }
 
@@ -12243,7 +12243,7 @@ w_metadata vcrun2008 dlls \
     year="2011" \
     media="download" \
     file1="vcredist_x86.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/Common Files/Microsoft Shared/VC/msdia90.dll"
+    installed_file1="${W_PROGRAMS_X86_WIN}/Common Files/Microsoft Shared/VC/msdia90.dll"
 
 load_vcrun2008()
 {
@@ -12261,28 +12261,28 @@ load_vcrun2008()
     # https://bugs.winehq.org/show_bug.cgi?id=42859
     w_override_dlls native,builtin atl90 msvcm90 msvcp90 msvcr90 vcomp90
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" "$file1" ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+/q}
 
-    case "$W_ARCH" in
+    case "${W_ARCH}" in
         win64)
             # Also install the 64-bit version
             # 2016/11/15: b811f2c047a3e828517c234bd4aa4883e1ec591d88fad21289ae68a6915a6665
             w_download https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x64.exe b811f2c047a3e828517c234bd4aa4883e1ec591d88fad21289ae68a6915a6665
             if w_workaround_wine_bug 30713 "Manually extracting the 64-bit dlls" ,3.8; then
-                rm -f "$W_TMP"/*  # Avoid permission error
-                w_try_cabextract --directory="$W_TMP" vcredist_x64.exe
-                w_try_cabextract --directory="$W_TMP" "$W_TMP/vc_red.cab"
+                rm -f "${W_TMP}"/*  # Avoid permission error
+                w_try_cabextract --directory="${W_TMP}" vcredist_x64.exe
+                w_try_cabextract --directory="${W_TMP}" "${W_TMP}/vc_red.cab"
 
-                w_try cp "$W_TMP"/atl90.dll.30729.6161.Microsoft_VC90_ATL_x64.QFE "$W_SYSTEM64_DLLS"/atl90.dll
-                w_try cp "$W_TMP"/mfc90.dll.30729.6161.Microsoft_VC90_MFC_x64.QFE "$W_SYSTEM64_DLLS"/mfc90.dll
-                w_try cp "$W_TMP"/mfcm90.dll.30729.6161.Microsoft_VC90_MFC_x64.QFE "$W_SYSTEM64_DLLS"/mfcm90.dll
-                w_try cp "$W_TMP"/msvcm90.dll.30729.6161.Microsoft_VC90_CRT_x64.QFE "$W_SYSTEM64_DLLS"/msvcm90.dll
-                w_try cp "$W_TMP"/msvcp90.dll.30729.6161.Microsoft_VC90_CRT_x64.QFE "$W_SYSTEM64_DLLS"/msvcp90.dll
-                w_try cp "$W_TMP"/msvcr90.dll.30729.6161.Microsoft_VC90_CRT_x64.QFE "$W_SYSTEM64_DLLS"/msvcr90.dll
-                w_try cp "$W_TMP"/vcomp90.dll.30729.6161.Microsoft_VC90_OpenMP_x64.QFE "$W_SYSTEM64_DLLS"/vcomp90.dll
+                w_try cp "${W_TMP}"/atl90.dll.30729.6161.Microsoft_VC90_ATL_x64.QFE "${W_SYSTEM64_DLLS}"/atl90.dll
+                w_try cp "${W_TMP}"/mfc90.dll.30729.6161.Microsoft_VC90_MFC_x64.QFE "${W_SYSTEM64_DLLS}"/mfc90.dll
+                w_try cp "${W_TMP}"/mfcm90.dll.30729.6161.Microsoft_VC90_MFC_x64.QFE "${W_SYSTEM64_DLLS}"/mfcm90.dll
+                w_try cp "${W_TMP}"/msvcm90.dll.30729.6161.Microsoft_VC90_CRT_x64.QFE "${W_SYSTEM64_DLLS}"/msvcm90.dll
+                w_try cp "${W_TMP}"/msvcp90.dll.30729.6161.Microsoft_VC90_CRT_x64.QFE "${W_SYSTEM64_DLLS}"/msvcp90.dll
+                w_try cp "${W_TMP}"/msvcr90.dll.30729.6161.Microsoft_VC90_CRT_x64.QFE "${W_SYSTEM64_DLLS}"/msvcr90.dll
+                w_try cp "${W_TMP}"/vcomp90.dll.30729.6161.Microsoft_VC90_OpenMP_x64.QFE "${W_SYSTEM64_DLLS}"/vcomp90.dll
             else
-                w_try "$WINE" vcredist_x64.exe ${W_OPT_UNATTENDED:+/q}
+                w_try "${WINE}" vcredist_x64.exe ${W_OPT_UNATTENDED:+/q}
             fi
             ;;
     esac
@@ -12294,30 +12294,30 @@ w_metadata mfc90 dlls \
     year="2011" \
     media="download" \
     file1="../vcrun2008/vcredist_x86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc90.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/mfc90.dll"
 
 load_mfc90()
 {
     w_download_to vcrun2008 https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x86.exe 6b3e4c51c6c0e5f68c8a72b497445af3dbf976394cbb62aa23569065c28deeb6
 
-    w_try_cabextract --directory="$W_TMP/win32" "$W_CACHE"/vcrun2008/vcredist_x86.exe -F 'vc_red.cab'
-    w_try_cabextract --directory="$W_TMP/win32" "$W_TMP/win32/vc_red.cab"
+    w_try_cabextract --directory="${W_TMP}/win32" "${W_CACHE}"/vcrun2008/vcredist_x86.exe -F 'vc_red.cab'
+    w_try_cabextract --directory="${W_TMP}/win32" "${W_TMP}/win32/vc_red.cab"
 
-    w_try cp "$W_TMP/win32"/mfc90.dll.30729.6161.Microsoft_VC90_MFC_x86.QFE "$W_SYSTEM32_DLLS"/mfc90.dll
-    w_try cp "$W_TMP/win32"/mfc90u.dll.30729.6161.Microsoft_VC90_MFC_x86.QFE "$W_SYSTEM32_DLLS"/mfc90u.dll
-    w_try cp "$W_TMP/win32"/mfcm90.dll.30729.6161.Microsoft_VC90_MFC_x86.QFE "$W_SYSTEM32_DLLS"/mfcm90.dll
-    w_try cp "$W_TMP/win32"/mfcm90u.dll.30729.6161.Microsoft_VC90_MFC_x86.QFE "$W_SYSTEM32_DLLS"/mfcm90u.dll
+    w_try cp "${W_TMP}/win32"/mfc90.dll.30729.6161.Microsoft_VC90_MFC_x86.QFE "${W_SYSTEM32_DLLS}"/mfc90.dll
+    w_try cp "${W_TMP}/win32"/mfc90u.dll.30729.6161.Microsoft_VC90_MFC_x86.QFE "${W_SYSTEM32_DLLS}"/mfc90u.dll
+    w_try cp "${W_TMP}/win32"/mfcm90.dll.30729.6161.Microsoft_VC90_MFC_x86.QFE "${W_SYSTEM32_DLLS}"/mfcm90.dll
+    w_try cp "${W_TMP}/win32"/mfcm90u.dll.30729.6161.Microsoft_VC90_MFC_x86.QFE "${W_SYSTEM32_DLLS}"/mfcm90u.dll
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         w_download_to vcrun2008 https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x64.exe b811f2c047a3e828517c234bd4aa4883e1ec591d88fad21289ae68a6915a6665
 
-        w_try_cabextract --directory="$W_TMP/win64" "$W_CACHE"/vcrun2008/vcredist_x64.exe -F 'vc_red.cab'
-        w_try_cabextract --directory="$W_TMP/win64" "$W_TMP/win64/vc_red.cab"
+        w_try_cabextract --directory="${W_TMP}/win64" "${W_CACHE}"/vcrun2008/vcredist_x64.exe -F 'vc_red.cab'
+        w_try_cabextract --directory="${W_TMP}/win64" "${W_TMP}/win64/vc_red.cab"
 
-        w_try cp "$W_TMP/win64"/mfc90.dll.30729.6161.Microsoft_VC90_MFC_x64.QFE "$W_SYSTEM64_DLLS"/mfc90.dll
-        w_try cp "$W_TMP/win64"/mfc90u.dll.30729.6161.Microsoft_VC90_MFC_x64.QFE "$W_SYSTEM64_DLLS"/mfc90u.dll
-        w_try cp "$W_TMP/win64"/mfcm90.dll.30729.6161.Microsoft_VC90_MFC_x64.QFE "$W_SYSTEM64_DLLS"/mfcm90.dll
-        w_try cp "$W_TMP/win64"/mfcm90u.dll.30729.6161.Microsoft_VC90_MFC_x64.QFE "$W_SYSTEM64_DLLS"/mfcm90u.dll
+        w_try cp "${W_TMP}/win64"/mfc90.dll.30729.6161.Microsoft_VC90_MFC_x64.QFE "${W_SYSTEM64_DLLS}"/mfc90.dll
+        w_try cp "${W_TMP}/win64"/mfc90u.dll.30729.6161.Microsoft_VC90_MFC_x64.QFE "${W_SYSTEM64_DLLS}"/mfc90u.dll
+        w_try cp "${W_TMP}/win64"/mfcm90.dll.30729.6161.Microsoft_VC90_MFC_x64.QFE "${W_SYSTEM64_DLLS}"/mfcm90.dll
+        w_try cp "${W_TMP}/win64"/mfcm90u.dll.30729.6161.Microsoft_VC90_MFC_x64.QFE "${W_SYSTEM64_DLLS}"/mfcm90u.dll
     fi
 }
 
@@ -12329,7 +12329,7 @@ w_metadata vcrun2010 dlls \
     year="2010" \
     media="download" \
     file1="vcredist_x86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc100.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/mfc100.dll"
 
 load_vcrun2010()
 {
@@ -12337,25 +12337,25 @@ load_vcrun2010()
     w_download https://download.microsoft.com/download/5/B/C/5BC5DBB3-652D-4DCE-B14A-475AB85EEF6E/vcredist_x86.exe 8162b2d665ca52884507ede19549e99939ce4ea4a638c537fa653539819138c8
 
     w_override_dlls native,builtin msvcp100 msvcr100 vcomp100 atl100
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" vcredist_x86.exe ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" vcredist_x86.exe ${W_OPT_UNATTENDED:+/q}
 
-    case "$W_ARCH" in
+    case "${W_ARCH}" in
         win64)
             # Also install the 64-bit version
             # https://www.microsoft.com/en-us/download/details.aspx?id=13523
             w_download https://download.microsoft.com/download/A/8/0/A80747C3-41BD-45DF-B505-E9710D2744E0/vcredist_x64.exe c6cd2d3f0b11dc2a604ffdc4dd97861a83b77e21709ba71b962a47759c93f4c8
             if w_workaround_wine_bug 30713 "Manually extracting the 64-bit dlls" ,3.8; then
-                w_try_cabextract --directory="$W_TMP" vcredist_x64.exe -F '*.cab'
-                w_try_cabextract --directory="$W_TMP" "$W_TMP"/vc_red.cab
-                cp "$W_TMP"/F_CENTRAL_mfc100_x64 "$W_SYSTEM64_DLLS"/mfc100.dll
-                cp "$W_TMP"/F_CENTRAL_mfc100u_x64 "$W_SYSTEM64_DLLS"/mfc100u.dll
-                cp "$W_TMP"/F_CENTRAL_msvcr100_x64 "$W_SYSTEM64_DLLS"/msvcr100.dll
-                cp "$W_TMP"/F_CENTRAL_msvcp100_x64 "$W_SYSTEM64_DLLS"/msvcp100.dll
-                cp "$W_TMP"/F_CENTRAL_vcomp100_x64 "$W_SYSTEM64_DLLS"/vcomp100.dll
-                cp "$W_TMP"/F_CENTRAL_atl100_x64 "$W_SYSTEM64_DLLS"/atl100.dll
+                w_try_cabextract --directory="${W_TMP}" vcredist_x64.exe -F '*.cab'
+                w_try_cabextract --directory="${W_TMP}" "${W_TMP}"/vc_red.cab
+                cp "${W_TMP}"/F_CENTRAL_mfc100_x64 "${W_SYSTEM64_DLLS}"/mfc100.dll
+                cp "${W_TMP}"/F_CENTRAL_mfc100u_x64 "${W_SYSTEM64_DLLS}"/mfc100u.dll
+                cp "${W_TMP}"/F_CENTRAL_msvcr100_x64 "${W_SYSTEM64_DLLS}"/msvcr100.dll
+                cp "${W_TMP}"/F_CENTRAL_msvcp100_x64 "${W_SYSTEM64_DLLS}"/msvcp100.dll
+                cp "${W_TMP}"/F_CENTRAL_vcomp100_x64 "${W_SYSTEM64_DLLS}"/vcomp100.dll
+                cp "${W_TMP}"/F_CENTRAL_atl100_x64 "${W_SYSTEM64_DLLS}"/atl100.dll
             else
-                w_try "$WINE" vcredist_x64.exe ${W_OPT_UNATTENDED:+/q}
+                w_try "${WINE}" vcredist_x64.exe ${W_OPT_UNATTENDED:+/q}
             fi
             ;;
     esac
@@ -12367,30 +12367,30 @@ w_metadata mfc100 dlls \
     year="2010" \
     media="download" \
     file1="../vcrun2010/vcredist_x86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc100u.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/mfc100u.dll"
 
 load_mfc100()
 {
     w_download_to vcrun2010 https://download.microsoft.com/download/5/B/C/5BC5DBB3-652D-4DCE-B14A-475AB85EEF6E/vcredist_x86.exe 8162b2d665ca52884507ede19549e99939ce4ea4a638c537fa653539819138c8
 
-    w_try_cabextract --directory="$W_TMP/win32" "$W_CACHE"/vcrun2010/vcredist_x86.exe -F '*.cab'
-    w_try_cabextract --directory="$W_TMP/win32" "$W_TMP/win32/vc_red.cab"
+    w_try_cabextract --directory="${W_TMP}/win32" "${W_CACHE}"/vcrun2010/vcredist_x86.exe -F '*.cab'
+    w_try_cabextract --directory="${W_TMP}/win32" "${W_TMP}/win32/vc_red.cab"
 
-    w_try cp "$W_TMP/win32"/F_CENTRAL_mfc100_x86 "$W_SYSTEM32_DLLS"/mfc100.dll
-    w_try cp "$W_TMP/win32"/F_CENTRAL_mfc100u_x86 "$W_SYSTEM32_DLLS"/mfc100u.dll
-    w_try cp "$W_TMP/win32"/F_CENTRAL_mfcm100_x86 "$W_SYSTEM32_DLLS"/mfcm100.dll
-    w_try cp "$W_TMP/win32"/F_CENTRAL_mfcm100u_x86 "$W_SYSTEM32_DLLS"/mfcm100u.dll
+    w_try cp "${W_TMP}/win32"/F_CENTRAL_mfc100_x86 "${W_SYSTEM32_DLLS}"/mfc100.dll
+    w_try cp "${W_TMP}/win32"/F_CENTRAL_mfc100u_x86 "${W_SYSTEM32_DLLS}"/mfc100u.dll
+    w_try cp "${W_TMP}/win32"/F_CENTRAL_mfcm100_x86 "${W_SYSTEM32_DLLS}"/mfcm100.dll
+    w_try cp "${W_TMP}/win32"/F_CENTRAL_mfcm100u_x86 "${W_SYSTEM32_DLLS}"/mfcm100u.dll
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         w_download_to vcrun2010 https://download.microsoft.com/download/A/8/0/A80747C3-41BD-45DF-B505-E9710D2744E0/vcredist_x64.exe c6cd2d3f0b11dc2a604ffdc4dd97861a83b77e21709ba71b962a47759c93f4c8
 
-        w_try_cabextract --directory="$W_TMP/win64" "$W_CACHE"/vcrun2010/vcredist_x64.exe -F '*.cab'
-        w_try_cabextract --directory="$W_TMP/win64" "$W_TMP/win64/vc_red.cab"
+        w_try_cabextract --directory="${W_TMP}/win64" "${W_CACHE}"/vcrun2010/vcredist_x64.exe -F '*.cab'
+        w_try_cabextract --directory="${W_TMP}/win64" "${W_TMP}/win64/vc_red.cab"
 
-        w_try cp "$W_TMP/win64"/F_CENTRAL_mfc100_x64 "$W_SYSTEM64_DLLS"/mfc100.dll
-        w_try cp "$W_TMP/win64"/F_CENTRAL_mfc100u_x64 "$W_SYSTEM64_DLLS"/mfc100u.dll
-        w_try cp "$W_TMP/win64"/F_CENTRAL_mfcm100_x64 "$W_SYSTEM64_DLLS"/mfcm100.dll
-        w_try cp "$W_TMP/win64"/F_CENTRAL_mfcm100u_x64 "$W_SYSTEM64_DLLS"/mfcm100u.dll
+        w_try cp "${W_TMP}/win64"/F_CENTRAL_mfc100_x64 "${W_SYSTEM64_DLLS}"/mfc100.dll
+        w_try cp "${W_TMP}/win64"/F_CENTRAL_mfc100u_x64 "${W_SYSTEM64_DLLS}"/mfc100u.dll
+        w_try cp "${W_TMP}/win64"/F_CENTRAL_mfcm100_x64 "${W_SYSTEM64_DLLS}"/mfcm100.dll
+        w_try cp "${W_TMP}/win64"/F_CENTRAL_mfcm100u_x64 "${W_SYSTEM64_DLLS}"/mfcm100u.dll
     fi
 }
 
@@ -12402,7 +12402,7 @@ w_metadata vcrun2012 dlls \
     year="2012" \
     media="download" \
     file1="vcredist_x86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc110.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/mfc110.dll"
 
 load_vcrun2012()
 {
@@ -12410,27 +12410,27 @@ load_vcrun2012()
     w_download https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe b924ad8062eaf4e70437c8be50fa612162795ff0839479546ce907ffa8d6e386
 
     w_override_dlls native,builtin atl110 msvcp110 msvcr110 vcomp110
-    w_try_cd "$W_CACHE"/"$W_PACKAGE"
-    w_try "$WINE" vcredist_x86.exe ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_CACHE}"/"${W_PACKAGE}"
+    w_try "${WINE}" vcredist_x86.exe ${W_OPT_UNATTENDED:+/q}
 
-    case "$W_ARCH" in
+    case "${W_ARCH}" in
         win64)
             # Also install the 64-bit version
             # 2015/10/19: 681be3e5ba9fd3da02c09d7e565adfa078640ed66a0d58583efad2c1e3cc4064
             w_download https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe 681be3e5ba9fd3da02c09d7e565adfa078640ed66a0d58583efad2c1e3cc4064
             if w_workaround_wine_bug 30713 "Manually extracting the 64-bit dlls" ,3.8; then
-                rm -f "$W_TMP"/*  # Avoid permission error
-                w_try_cabextract --directory="$W_TMP" vcredist_x64.exe
-                w_try_cabextract --directory="$W_TMP" "$W_TMP/a2"
-                w_try_cabextract --directory="$W_TMP" "$W_TMP/a3"
-                cp "$W_TMP"/F_CENTRAL_atl110_x64 "$W_SYSTEM64_DLLS"/atl110.dll
-                cp "$W_TMP"/F_CENTRAL_mfc110_x64 "$W_SYSTEM64_DLLS"/mfc110.dll
-                cp "$W_TMP"/F_CENTRAL_mfc110u_x64 "$W_SYSTEM64_DLLS"/mfc110u.dll
-                cp "$W_TMP"/F_CENTRAL_msvcp110_x64 "$W_SYSTEM64_DLLS"/msvcp110.dll
-                cp "$W_TMP"/F_CENTRAL_msvcr110_x64 "$W_SYSTEM64_DLLS"/msvcr110.dll
-                cp "$W_TMP"/F_CENTRAL_vcomp110_x64 "$W_SYSTEM64_DLLS"/vcomp110.dll
+                rm -f "${W_TMP}"/*  # Avoid permission error
+                w_try_cabextract --directory="${W_TMP}" vcredist_x64.exe
+                w_try_cabextract --directory="${W_TMP}" "${W_TMP}/a2"
+                w_try_cabextract --directory="${W_TMP}" "${W_TMP}/a3"
+                cp "${W_TMP}"/F_CENTRAL_atl110_x64 "${W_SYSTEM64_DLLS}"/atl110.dll
+                cp "${W_TMP}"/F_CENTRAL_mfc110_x64 "${W_SYSTEM64_DLLS}"/mfc110.dll
+                cp "${W_TMP}"/F_CENTRAL_mfc110u_x64 "${W_SYSTEM64_DLLS}"/mfc110u.dll
+                cp "${W_TMP}"/F_CENTRAL_msvcp110_x64 "${W_SYSTEM64_DLLS}"/msvcp110.dll
+                cp "${W_TMP}"/F_CENTRAL_msvcr110_x64 "${W_SYSTEM64_DLLS}"/msvcr110.dll
+                cp "${W_TMP}"/F_CENTRAL_vcomp110_x64 "${W_SYSTEM64_DLLS}"/vcomp110.dll
             else
-                w_try "$WINE" vcredist_x64.exe ${W_OPT_UNATTENDED:+/q}
+                w_try "${WINE}" vcredist_x64.exe ${W_OPT_UNATTENDED:+/q}
             fi
             ;;
     esac
@@ -12442,30 +12442,30 @@ w_metadata mfc110 dlls \
     year="2012" \
     media="download" \
     file1="../vcrun2012/vcredist_x86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc110u.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/mfc110u.dll"
 
 load_mfc110()
 {
     w_download_to vcrun2012 https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe b924ad8062eaf4e70437c8be50fa612162795ff0839479546ce907ffa8d6e386
 
-    w_try_cabextract --directory="$W_TMP/win32"  "$W_CACHE"/vcrun2012/vcredist_x86.exe -F 'a3'
-    w_try_cabextract --directory="$W_TMP/win32" "$W_TMP/win32/a3"
+    w_try_cabextract --directory="${W_TMP}/win32"  "${W_CACHE}"/vcrun2012/vcredist_x86.exe -F 'a3'
+    w_try_cabextract --directory="${W_TMP}/win32" "${W_TMP}/win32/a3"
 
-    w_try cp "$W_TMP/win32"/F_CENTRAL_mfc110_x86 "$W_SYSTEM32_DLLS"/mfc110.dll
-    w_try cp "$W_TMP/win32"/F_CENTRAL_mfc110u_x86 "$W_SYSTEM32_DLLS"/mfc110u.dll
-    w_try cp "$W_TMP/win32"/F_CENTRAL_mfcm110_x86 "$W_SYSTEM32_DLLS"/mfcm110.dll
-    w_try cp "$W_TMP/win32"/F_CENTRAL_mfcm110u_x86 "$W_SYSTEM32_DLLS"/mfcm110u.dll
+    w_try cp "${W_TMP}/win32"/F_CENTRAL_mfc110_x86 "${W_SYSTEM32_DLLS}"/mfc110.dll
+    w_try cp "${W_TMP}/win32"/F_CENTRAL_mfc110u_x86 "${W_SYSTEM32_DLLS}"/mfc110u.dll
+    w_try cp "${W_TMP}/win32"/F_CENTRAL_mfcm110_x86 "${W_SYSTEM32_DLLS}"/mfcm110.dll
+    w_try cp "${W_TMP}/win32"/F_CENTRAL_mfcm110u_x86 "${W_SYSTEM32_DLLS}"/mfcm110u.dll
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         w_download_to vcrun2012 https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe 681be3e5ba9fd3da02c09d7e565adfa078640ed66a0d58583efad2c1e3cc4064
 
-        w_try_cabextract --directory="$W_TMP/win64"  "$W_CACHE"/vcrun2012/vcredist_x64.exe -F 'a3'
-        w_try_cabextract --directory="$W_TMP/win64" "$W_TMP/win64/a3"
+        w_try_cabextract --directory="${W_TMP}/win64"  "${W_CACHE}"/vcrun2012/vcredist_x64.exe -F 'a3'
+        w_try_cabextract --directory="${W_TMP}/win64" "${W_TMP}/win64/a3"
 
-        w_try cp "$W_TMP/win64"/F_CENTRAL_mfc110_x64 "$W_SYSTEM64_DLLS"/mfc110.dll
-        w_try cp "$W_TMP/win64"/F_CENTRAL_mfc110u_x64 "$W_SYSTEM64_DLLS"/mfc110u.dll
-        w_try cp "$W_TMP/win64"/F_CENTRAL_mfcm110_x64 "$W_SYSTEM64_DLLS"/mfcm110.dll
-        w_try cp "$W_TMP/win64"/F_CENTRAL_mfcm110u_x64 "$W_SYSTEM64_DLLS"/mfcm110u.dll
+        w_try cp "${W_TMP}/win64"/F_CENTRAL_mfc110_x64 "${W_SYSTEM64_DLLS}"/mfc110.dll
+        w_try cp "${W_TMP}/win64"/F_CENTRAL_mfc110u_x64 "${W_SYSTEM64_DLLS}"/mfc110u.dll
+        w_try cp "${W_TMP}/win64"/F_CENTRAL_mfcm110_x64 "${W_SYSTEM64_DLLS}"/mfcm110.dll
+        w_try cp "${W_TMP}/win64"/F_CENTRAL_mfcm110u_x64 "${W_SYSTEM64_DLLS}"/mfcm110u.dll
     fi
 }
 
@@ -12477,7 +12477,7 @@ w_metadata vcrun2013 dlls \
     year="2013" \
     media="download" \
     file1="vcredist_x86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc120.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/mfc120.dll"
 
 load_vcrun2013()
 {
@@ -12487,27 +12487,27 @@ load_vcrun2013()
     w_download https://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x86.exe 89f4e593ea5541d1c53f983923124f9fd061a1c0c967339109e375c661573c17
 
     w_override_dlls native,builtin atl120 msvcp120 msvcr120 vcomp120
-    w_try_cd "$W_CACHE"/"$W_PACKAGE"
-    w_try "$WINE" vcredist_x86.exe ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_CACHE}"/"${W_PACKAGE}"
+    w_try "${WINE}" vcredist_x86.exe ${W_OPT_UNATTENDED:+/q}
 
-    case "$W_ARCH" in
+    case "${W_ARCH}" in
         win64)
             # Also install the 64-bit version
             # 2015/10/19: e554425243e3e8ca1cd5fe550db41e6fa58a007c74fad400274b128452f38fb8
             # 2019/03/24: 20e2645b7cd5873b1fa3462b99a665ac8d6e14aae83ded9d875fea35ffdd7d7e
             w_download https://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x64.exe 20e2645b7cd5873b1fa3462b99a665ac8d6e14aae83ded9d875fea35ffdd7d7e
             if w_workaround_wine_bug 30713 "Manually extracting the 64-bit dlls" ,3.8; then
-                rm -f "$W_TMP"/*  # Avoid permission error
-                w_try_cabextract --directory="$W_TMP" vcredist_x64.exe
-                w_try_cabextract --directory="$W_TMP" "$W_TMP/a2"
-                w_try_cabextract --directory="$W_TMP" "$W_TMP/a3"
-                cp "$W_TMP"/F_CENTRAL_mfc120_x64 "$W_SYSTEM64_DLLS"/mfc120.dll
-                cp "$W_TMP"/F_CENTRAL_mfc120u_x64 "$W_SYSTEM64_DLLS"/mfc120u.dll
-                cp "$W_TMP"/F_CENTRAL_msvcp120_x64 "$W_SYSTEM64_DLLS"/msvcp120.dll
-                cp "$W_TMP"/F_CENTRAL_msvcr120_x64 "$W_SYSTEM64_DLLS"/msvcr120.dll
-                cp "$W_TMP"/F_CENTRAL_vcomp120_x64 "$W_SYSTEM64_DLLS"/vcomp120.dll
+                rm -f "${W_TMP}"/*  # Avoid permission error
+                w_try_cabextract --directory="${W_TMP}" vcredist_x64.exe
+                w_try_cabextract --directory="${W_TMP}" "${W_TMP}/a2"
+                w_try_cabextract --directory="${W_TMP}" "${W_TMP}/a3"
+                cp "${W_TMP}"/F_CENTRAL_mfc120_x64 "${W_SYSTEM64_DLLS}"/mfc120.dll
+                cp "${W_TMP}"/F_CENTRAL_mfc120u_x64 "${W_SYSTEM64_DLLS}"/mfc120u.dll
+                cp "${W_TMP}"/F_CENTRAL_msvcp120_x64 "${W_SYSTEM64_DLLS}"/msvcp120.dll
+                cp "${W_TMP}"/F_CENTRAL_msvcr120_x64 "${W_SYSTEM64_DLLS}"/msvcr120.dll
+                cp "${W_TMP}"/F_CENTRAL_vcomp120_x64 "${W_SYSTEM64_DLLS}"/vcomp120.dll
             else
-                w_try "$WINE" vcredist_x64.exe ${W_OPT_UNATTENDED:+/q}
+                w_try "${WINE}" vcredist_x64.exe ${W_OPT_UNATTENDED:+/q}
             fi
             ;;
     esac
@@ -12519,30 +12519,30 @@ w_metadata mfc120 dlls \
     year="2013" \
     media="download" \
     file1="../vcrun2013/vcredist_x86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc120u.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/mfc120u.dll"
 
 load_mfc120()
 {
     w_download_to vcrun2013 https://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x86.exe 89f4e593ea5541d1c53f983923124f9fd061a1c0c967339109e375c661573c17
 
-    w_try_cabextract --directory="$W_TMP/win32"  "$W_CACHE"/vcrun2013/vcredist_x86.exe -F 'a3'
-    w_try_cabextract --directory="$W_TMP/win32" "$W_TMP/win32/a3"
+    w_try_cabextract --directory="${W_TMP}/win32"  "${W_CACHE}"/vcrun2013/vcredist_x86.exe -F 'a3'
+    w_try_cabextract --directory="${W_TMP}/win32" "${W_TMP}/win32/a3"
 
-    w_try cp "$W_TMP/win32"/F_CENTRAL_mfc120_x86 "$W_SYSTEM32_DLLS"/mfc120.dll
-    w_try cp "$W_TMP/win32"/F_CENTRAL_mfc120u_x86 "$W_SYSTEM32_DLLS"/mfc120u.dll
-    w_try cp "$W_TMP/win32"/F_CENTRAL_mfcm120_x86 "$W_SYSTEM32_DLLS"/mfcm120.dll
-    w_try cp "$W_TMP/win32"/F_CENTRAL_mfcm120u_x86 "$W_SYSTEM32_DLLS"/mfcm120u.dll
+    w_try cp "${W_TMP}/win32"/F_CENTRAL_mfc120_x86 "${W_SYSTEM32_DLLS}"/mfc120.dll
+    w_try cp "${W_TMP}/win32"/F_CENTRAL_mfc120u_x86 "${W_SYSTEM32_DLLS}"/mfc120u.dll
+    w_try cp "${W_TMP}/win32"/F_CENTRAL_mfcm120_x86 "${W_SYSTEM32_DLLS}"/mfcm120.dll
+    w_try cp "${W_TMP}/win32"/F_CENTRAL_mfcm120u_x86 "${W_SYSTEM32_DLLS}"/mfcm120u.dll
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         w_download_to vcrun2013 https://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x64.exe 20e2645b7cd5873b1fa3462b99a665ac8d6e14aae83ded9d875fea35ffdd7d7e
 
-        w_try_cabextract --directory="$W_TMP/win64"  "$W_CACHE"/vcrun2013/vcredist_x64.exe -F 'a3'
-        w_try_cabextract --directory="$W_TMP/win64" "$W_TMP/win64/a3"
+        w_try_cabextract --directory="${W_TMP}/win64"  "${W_CACHE}"/vcrun2013/vcredist_x64.exe -F 'a3'
+        w_try_cabextract --directory="${W_TMP}/win64" "${W_TMP}/win64/a3"
 
-        w_try cp "$W_TMP/win64"/F_CENTRAL_mfc120_x64 "$W_SYSTEM64_DLLS"/mfc120.dll
-        w_try cp "$W_TMP/win64"/F_CENTRAL_mfc120u_x64 "$W_SYSTEM64_DLLS"/mfc120u.dll
-        w_try cp "$W_TMP/win64"/F_CENTRAL_mfcm120_x64 "$W_SYSTEM64_DLLS"/mfcm120.dll
-        w_try cp "$W_TMP/win64"/F_CENTRAL_mfcm120u_x64 "$W_SYSTEM64_DLLS"/mfcm120u.dll
+        w_try cp "${W_TMP}/win64"/F_CENTRAL_mfc120_x64 "${W_SYSTEM64_DLLS}"/mfc120.dll
+        w_try cp "${W_TMP}/win64"/F_CENTRAL_mfc120u_x64 "${W_SYSTEM64_DLLS}"/mfc120u.dll
+        w_try cp "${W_TMP}/win64"/F_CENTRAL_mfcm120_x64 "${W_SYSTEM64_DLLS}"/mfcm120.dll
+        w_try cp "${W_TMP}/win64"/F_CENTRAL_mfcm120u_x64 "${W_SYSTEM64_DLLS}"/mfcm120u.dll
     fi
 }
 
@@ -12555,7 +12555,7 @@ w_metadata vcrun2015 dlls \
     media="download" \
     conflicts="vcrun2017 vcrun2019" \
     file1="vc_redist.x86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc140.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/mfc140.dll"
 
 load_vcrun2015()
 {
@@ -12571,39 +12571,39 @@ load_vcrun2015()
 
     w_set_winver winxp
 
-    w_try_cd "$W_CACHE"/"$W_PACKAGE"
-    w_try "$WINE" vc_redist.x86.exe ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_CACHE}"/"${W_PACKAGE}"
+    w_try "${WINE}" vc_redist.x86.exe ${W_OPT_UNATTENDED:+/q}
 
-    case "$W_ARCH" in
+    case "${W_ARCH}" in
         win64)
             # Also install the 64-bit version
             # 2015/10/12: 5eea714e1f22f1875c1cb7b1738b0c0b1f02aec5ecb95f0fdb1c5171c6cd93a3
             w_download https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe 5eea714e1f22f1875c1cb7b1738b0c0b1f02aec5ecb95f0fdb1c5171c6cd93a3
             if w_workaround_wine_bug 30713 "Manually extracting the 64-bit dlls", 3.8; then
-                rm -f "$W_TMP"/*  # Avoid permission error
-                w_try_cabextract --directory="$W_TMP" vc_redist.x64.exe
-                w_try_cabextract --directory="$W_TMP" "$W_TMP/a10"
-                w_try_cabextract --directory="$W_TMP" "$W_TMP/a11"
-                cp "$W_TMP"/concrt140.dll "$W_SYSTEM64_DLLS"/concrt140.dll
-                cp "$W_TMP"/mfc140.dll "$W_SYSTEM64_DLLS"/mfc140.dll
-                cp "$W_TMP"/mfc140u.dll "$W_SYSTEM64_DLLS"/mfc140u.dll
-                cp "$W_TMP"/mfcm140.dll "$W_SYSTEM64_DLLS"/mfcm140.dll
-                cp "$W_TMP"/mfcm140u.dll "$W_SYSTEM64_DLLS"/mfcm140u.dll
-                cp "$W_TMP"/msvcp140.dll "$W_SYSTEM64_DLLS"/msvcp140.dll
-                cp "$W_TMP"/vcamp140.dll "$W_SYSTEM64_DLLS"/vcamp140.dll
-                cp "$W_TMP"/vccorlib140.dll "$W_SYSTEM64_DLLS"/vccorlib140.dll
-                cp "$W_TMP"/vcomp140.dll "$W_SYSTEM64_DLLS"/vcomp140.dll
-                cp "$W_TMP"/vcruntime140.dll "$W_SYSTEM64_DLLS"/vcruntime140.dll
+                rm -f "${W_TMP}"/*  # Avoid permission error
+                w_try_cabextract --directory="${W_TMP}" vc_redist.x64.exe
+                w_try_cabextract --directory="${W_TMP}" "${W_TMP}/a10"
+                w_try_cabextract --directory="${W_TMP}" "${W_TMP}/a11"
+                cp "${W_TMP}"/concrt140.dll "${W_SYSTEM64_DLLS}"/concrt140.dll
+                cp "${W_TMP}"/mfc140.dll "${W_SYSTEM64_DLLS}"/mfc140.dll
+                cp "${W_TMP}"/mfc140u.dll "${W_SYSTEM64_DLLS}"/mfc140u.dll
+                cp "${W_TMP}"/mfcm140.dll "${W_SYSTEM64_DLLS}"/mfcm140.dll
+                cp "${W_TMP}"/mfcm140u.dll "${W_SYSTEM64_DLLS}"/mfcm140u.dll
+                cp "${W_TMP}"/msvcp140.dll "${W_SYSTEM64_DLLS}"/msvcp140.dll
+                cp "${W_TMP}"/vcamp140.dll "${W_SYSTEM64_DLLS}"/vcamp140.dll
+                cp "${W_TMP}"/vccorlib140.dll "${W_SYSTEM64_DLLS}"/vccorlib140.dll
+                cp "${W_TMP}"/vcomp140.dll "${W_SYSTEM64_DLLS}"/vcomp140.dll
+                cp "${W_TMP}"/vcruntime140.dll "${W_SYSTEM64_DLLS}"/vcruntime140.dll
 
-                cp "$W_TMP"/api_ms_win_crt_conio_l1_1_0.dll "$W_SYSTEM64_DLLS"/api-ms-win-crt-conio-l1-1-0.dll
-                cp "$W_TMP"/api_ms_win_crt_heap_l1_1_0.dll "$W_SYSTEM64_DLLS"/api-ms-win-crt-heap-l1-1-0.dll
-                cp "$W_TMP"/api_ms_win_crt_locale_l1_1_0.dll "$W_SYSTEM64_DLLS"/api-ms-win-crt-locale-l1-1-0.dll
-                cp "$W_TMP"/api_ms_win_crt_math_l1_1_0.dll "$W_SYSTEM64_DLLS"/api-ms-win-crt-math-l1-1-0.dll
-                cp "$W_TMP"/api_ms_win_crt_runtime_l1_1_0.dll "$W_SYSTEM64_DLLS"/api-ms-win-crt-runtime-l1-1-0.dll
-                cp "$W_TMP"/api_ms_win_crt_stdio_l1_1_0.dll "$W_SYSTEM64_DLLS"/api-ms-win-crt-stdio-l1-1-0.dll
-                cp "$W_TMP"/ucrtbase.dll "$W_SYSTEM64_DLLS"/ucrtbase.dll
+                cp "${W_TMP}"/api_ms_win_crt_conio_l1_1_0.dll "${W_SYSTEM64_DLLS}"/api-ms-win-crt-conio-l1-1-0.dll
+                cp "${W_TMP}"/api_ms_win_crt_heap_l1_1_0.dll "${W_SYSTEM64_DLLS}"/api-ms-win-crt-heap-l1-1-0.dll
+                cp "${W_TMP}"/api_ms_win_crt_locale_l1_1_0.dll "${W_SYSTEM64_DLLS}"/api-ms-win-crt-locale-l1-1-0.dll
+                cp "${W_TMP}"/api_ms_win_crt_math_l1_1_0.dll "${W_SYSTEM64_DLLS}"/api-ms-win-crt-math-l1-1-0.dll
+                cp "${W_TMP}"/api_ms_win_crt_runtime_l1_1_0.dll "${W_SYSTEM64_DLLS}"/api-ms-win-crt-runtime-l1-1-0.dll
+                cp "${W_TMP}"/api_ms_win_crt_stdio_l1_1_0.dll "${W_SYSTEM64_DLLS}"/api-ms-win-crt-stdio-l1-1-0.dll
+                cp "${W_TMP}"/ucrtbase.dll "${W_SYSTEM64_DLLS}"/ucrtbase.dll
             else
-                w_try "$WINE" vc_redist.x64.exe ${W_OPT_UNATTENDED:+/q}
+                w_try "${WINE}" vc_redist.x64.exe ${W_OPT_UNATTENDED:+/q}
             fi
             ;;
     esac
@@ -12615,30 +12615,30 @@ w_metadata mfc140 dlls \
     year="2015" \
     media="download" \
     file1="../vcrun2015/vc_redist.x86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc140u.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/mfc140u.dll"
 
 load_mfc140()
 {
     w_download_to vcrun2015 https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x86.exe fdd1e1f0dcae2d0aa0720895eff33b927d13076e64464bb7c7e5843b7667cd14
 
-    w_try_cabextract --directory="$W_TMP/win32"  "$W_CACHE"/vcrun2015/vc_redist.x86.exe -F 'a11'
-    w_try_cabextract --directory="$W_TMP/win32" "$W_TMP/win32/a11"
+    w_try_cabextract --directory="${W_TMP}/win32"  "${W_CACHE}"/vcrun2015/vc_redist.x86.exe -F 'a11'
+    w_try_cabextract --directory="${W_TMP}/win32" "${W_TMP}/win32/a11"
 
-    w_try cp "$W_TMP/win32"/mfc140.dll "$W_SYSTEM32_DLLS"/mfc140.dll
-    w_try cp "$W_TMP/win32"/mfc140u.dll "$W_SYSTEM32_DLLS"/mfc140u.dll
-    w_try cp "$W_TMP/win32"/mfcm140.dll "$W_SYSTEM32_DLLS"/mfcm140.dll
-    w_try cp "$W_TMP/win32"/mfcm140u.dll "$W_SYSTEM32_DLLS"/mfcm140u.dll
+    w_try cp "${W_TMP}/win32"/mfc140.dll "${W_SYSTEM32_DLLS}"/mfc140.dll
+    w_try cp "${W_TMP}/win32"/mfc140u.dll "${W_SYSTEM32_DLLS}"/mfc140u.dll
+    w_try cp "${W_TMP}/win32"/mfcm140.dll "${W_SYSTEM32_DLLS}"/mfcm140.dll
+    w_try cp "${W_TMP}/win32"/mfcm140u.dll "${W_SYSTEM32_DLLS}"/mfcm140u.dll
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         w_download_to vcrun2015 https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe 5eea714e1f22f1875c1cb7b1738b0c0b1f02aec5ecb95f0fdb1c5171c6cd93a3
 
-        w_try_cabextract --directory="$W_TMP/win64"  "$W_CACHE"/vcrun2015/vc_redist.x64.exe -F 'a11'
-        w_try_cabextract --directory="$W_TMP/win64" "$W_TMP/win64/a11"
+        w_try_cabextract --directory="${W_TMP}/win64"  "${W_CACHE}"/vcrun2015/vc_redist.x64.exe -F 'a11'
+        w_try_cabextract --directory="${W_TMP}/win64" "${W_TMP}/win64/a11"
 
-        w_try cp "$W_TMP/win64"/mfc140.dll "$W_SYSTEM64_DLLS"/mfc140.dll
-        w_try cp "$W_TMP/win64"/mfc140u.dll "$W_SYSTEM64_DLLS"/mfc140u.dll
-        w_try cp "$W_TMP/win64"/mfcm140.dll "$W_SYSTEM64_DLLS"/mfcm140.dll
-        w_try cp "$W_TMP/win64"/mfcm140u.dll "$W_SYSTEM64_DLLS"/mfcm140u.dll
+        w_try cp "${W_TMP}/win64"/mfc140.dll "${W_SYSTEM64_DLLS}"/mfc140.dll
+        w_try cp "${W_TMP}/win64"/mfc140u.dll "${W_SYSTEM64_DLLS}"/mfc140u.dll
+        w_try cp "${W_TMP}/win64"/mfcm140.dll "${W_SYSTEM64_DLLS}"/mfcm140.dll
+        w_try cp "${W_TMP}/win64"/mfcm140u.dll "${W_SYSTEM64_DLLS}"/mfcm140u.dll
     fi
 }
 
@@ -12651,7 +12651,7 @@ w_metadata vcrun2017 dlls \
     media="download" \
     conflicts="vcrun2015 vcrun2019" \
     file1="vc_redist.x86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc140.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/mfc140.dll"
 
 load_vcrun2017()
 {
@@ -12669,10 +12669,10 @@ load_vcrun2017()
 
     w_set_winver winxp
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" vc_redist.x86.exe ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" vc_redist.x86.exe ${W_OPT_UNATTENDED:+/q}
 
-    case "$W_ARCH" in
+    case "${W_ARCH}" in
         win64)
             # Also install the 64-bit version
             # https://support.microsoft.com/en-gb/help/2977003/the-latest-supported-visual-c-downloads
@@ -12681,30 +12681,30 @@ load_vcrun2017()
             # 2019/08/14: 5b0cbb977f2f5253b1ebe5c9d30edbda35dbd68fb70de7af5faac6423db575b5
             w_download https://aka.ms/vs/15/release/vc_redist.x64.exe 5b0cbb977f2f5253b1ebe5c9d30edbda35dbd68fb70de7af5faac6423db575b5
             if w_workaround_wine_bug 30713 "Manually extracting the 64-bit dlls" ,3.8; then
-                rm -f "$W_TMP"/*  # Avoid permission error
-                w_try_cabextract --directory="$W_TMP" vc_redist.x64.exe
-                w_try_cabextract --directory="$W_TMP" "$W_TMP/a10"
-                w_try_cabextract --directory="$W_TMP" "$W_TMP/a11"
-                cp "$W_TMP"/concrt140.dll "$W_SYSTEM64_DLLS"/concrt140.dll
-                cp "$W_TMP"/mfc140.dll "$W_SYSTEM64_DLLS"/mfc140.dll
-                cp "$W_TMP"/mfc140u.dll "$W_SYSTEM64_DLLS"/mfc140u.dll
-                cp "$W_TMP"/mfcm140.dll "$W_SYSTEM64_DLLS"/mfcm140.dll
-                cp "$W_TMP"/mfcm140u.dll "$W_SYSTEM64_DLLS"/mfcm140u.dll
-                cp "$W_TMP"/msvcp140.dll "$W_SYSTEM64_DLLS"/msvcp140.dll
-                cp "$W_TMP"/vcamp140.dll "$W_SYSTEM64_DLLS"/vcamp140.dll
-                cp "$W_TMP"/vccorlib140.dll "$W_SYSTEM64_DLLS"/vccorlib140.dll
-                cp "$W_TMP"/vcomp140.dll "$W_SYSTEM64_DLLS"/vcomp140.dll
-                cp "$W_TMP"/vcruntime140.dll "$W_SYSTEM64_DLLS"/vcruntime140.dll
+                rm -f "${W_TMP}"/*  # Avoid permission error
+                w_try_cabextract --directory="${W_TMP}" vc_redist.x64.exe
+                w_try_cabextract --directory="${W_TMP}" "${W_TMP}/a10"
+                w_try_cabextract --directory="${W_TMP}" "${W_TMP}/a11"
+                cp "${W_TMP}"/concrt140.dll "${W_SYSTEM64_DLLS}"/concrt140.dll
+                cp "${W_TMP}"/mfc140.dll "${W_SYSTEM64_DLLS}"/mfc140.dll
+                cp "${W_TMP}"/mfc140u.dll "${W_SYSTEM64_DLLS}"/mfc140u.dll
+                cp "${W_TMP}"/mfcm140.dll "${W_SYSTEM64_DLLS}"/mfcm140.dll
+                cp "${W_TMP}"/mfcm140u.dll "${W_SYSTEM64_DLLS}"/mfcm140u.dll
+                cp "${W_TMP}"/msvcp140.dll "${W_SYSTEM64_DLLS}"/msvcp140.dll
+                cp "${W_TMP}"/vcamp140.dll "${W_SYSTEM64_DLLS}"/vcamp140.dll
+                cp "${W_TMP}"/vccorlib140.dll "${W_SYSTEM64_DLLS}"/vccorlib140.dll
+                cp "${W_TMP}"/vcomp140.dll "${W_SYSTEM64_DLLS}"/vcomp140.dll
+                cp "${W_TMP}"/vcruntime140.dll "${W_SYSTEM64_DLLS}"/vcruntime140.dll
 
-                cp "$W_TMP"/api_ms_win_crt_conio_l1_1_0.dll "$W_SYSTEM64_DLLS"/api-ms-win-crt-conio-l1-1-0.dll
-                cp "$W_TMP"/api_ms_win_crt_heap_l1_1_0.dll "$W_SYSTEM64_DLLS"/api-ms-win-crt-heap-l1-1-0.dll
-                cp "$W_TMP"/api_ms_win_crt_locale_l1_1_0.dll "$W_SYSTEM64_DLLS"/api-ms-win-crt-locale-l1-1-0.dll
-                cp "$W_TMP"/api_ms_win_crt_math_l1_1_0.dll "$W_SYSTEM64_DLLS"/api-ms-win-crt-math-l1-1-0.dll
-                cp "$W_TMP"/api_ms_win_crt_runtime_l1_1_0.dll "$W_SYSTEM64_DLLS"/api-ms-win-crt-runtime-l1-1-0.dll
-                cp "$W_TMP"/api_ms_win_crt_stdio_l1_1_0.dll "$W_SYSTEM64_DLLS"/api-ms-win-crt-stdio-l1-1-0.dll
-                cp "$W_TMP"/ucrtbase.dll "$W_SYSTEM64_DLLS"/ucrtbase.dll
+                cp "${W_TMP}"/api_ms_win_crt_conio_l1_1_0.dll "${W_SYSTEM64_DLLS}"/api-ms-win-crt-conio-l1-1-0.dll
+                cp "${W_TMP}"/api_ms_win_crt_heap_l1_1_0.dll "${W_SYSTEM64_DLLS}"/api-ms-win-crt-heap-l1-1-0.dll
+                cp "${W_TMP}"/api_ms_win_crt_locale_l1_1_0.dll "${W_SYSTEM64_DLLS}"/api-ms-win-crt-locale-l1-1-0.dll
+                cp "${W_TMP}"/api_ms_win_crt_math_l1_1_0.dll "${W_SYSTEM64_DLLS}"/api-ms-win-crt-math-l1-1-0.dll
+                cp "${W_TMP}"/api_ms_win_crt_runtime_l1_1_0.dll "${W_SYSTEM64_DLLS}"/api-ms-win-crt-runtime-l1-1-0.dll
+                cp "${W_TMP}"/api_ms_win_crt_stdio_l1_1_0.dll "${W_SYSTEM64_DLLS}"/api-ms-win-crt-stdio-l1-1-0.dll
+                cp "${W_TMP}"/ucrtbase.dll "${W_SYSTEM64_DLLS}"/ucrtbase.dll
             else
-                w_try "$WINE" vc_redist.x64.exe ${W_OPT_UNATTENDED:+/q}
+                w_try "${WINE}" vc_redist.x64.exe ${W_OPT_UNATTENDED:+/q}
             fi
             ;;
     esac
@@ -12719,7 +12719,7 @@ w_metadata vcrun2019 dlls \
     media="download" \
     conflicts="vcrun2015 vcrun2017" \
     file1="vc_redist.x86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/mfc140.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/mfc140.dll"
 
 load_vcrun2019()
 {
@@ -12732,10 +12732,10 @@ load_vcrun2019()
 
     w_override_dlls native,builtin api-ms-win-crt-private-l1-1-0 api-ms-win-crt-conio-l1-1-0 api-ms-win-crt-heap-l1-1-0 api-ms-win-crt-locale-l1-1-0 api-ms-win-crt-math-l1-1-0 api-ms-win-crt-runtime-l1-1-0 api-ms-win-crt-stdio-l1-1-0 api-ms-win-crt-time-l1-1-0 atl140 concrt140 msvcp140 msvcr140 ucrtbase vcomp140 vcruntime140
 
-    w_try_cd "$W_CACHE"/"$W_PACKAGE"
-    w_try "$WINE" vc_redist.x86.exe ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_CACHE}"/"${W_PACKAGE}"
+    w_try "${WINE}" vc_redist.x86.exe ${W_OPT_UNATTENDED:+/q}
 
-    case "$W_ARCH" in
+    case "${W_ARCH}" in
         win64)
             # Also install the 64-bit version
             # 2019/12/26: 40ea2955391c9eae3e35619c4c24b5aaf3d17aeaa6d09424ee9672aa9372aeed
@@ -12747,7 +12747,7 @@ load_vcrun2019()
             w_override_dlls native,builtin vcruntime140_1
 
             w_download https://aka.ms/vs/16/release/vc_redist.x64.exe 952a0c6cb4a3dd14c3666ef05bb1982c5ff7f87b7103c2ba896354f00651e358
-            w_try "$WINE" vc_redist.x64.exe ${W_OPT_UNATTENDED:+/q}
+            w_try "${WINE}" vc_redist.x64.exe ${W_OPT_UNATTENDED:+/q}
             ;;
     esac
 }
@@ -12770,8 +12770,8 @@ load_vjrun20()
 
     # See https://www.microsoft.com/en-us/download/details.aspx?id=18084
     w_download https://download.microsoft.com/download/9/2/3/92338cd0-759f-4815-8981-24b437be74ef/vjredist.exe cf8f3dd4ad41453a302870b74de1c6489e7ed255ad3f652ce4af0b424a933b41
-    w_try_cd "$W_CACHE"/"$W_PACKAGE"
-    w_try "$WINE" vjredist.exe ${W_OPT_UNATTENDED:+/q /C:"install /qnt"}
+    w_try_cd "${W_CACHE}"/"${W_PACKAGE}"
+    w_try "${WINE}" vjredist.exe ${W_OPT_UNATTENDED:+/q /C:"install /qnt"}
 }
 
 #----------------------------------------------------------------
@@ -12782,14 +12782,14 @@ w_metadata vulkanrt121412 dlls \
     year="2020" \
     media="download" \
     file1="VulkanRT-1.2.141.2-Installer.exe" \
-    installed_exe1="$W_SYSTEM32_DLLS_WIN/vulkaninfo.exe"
+    installed_exe1="${W_SYSTEM32_DLLS_WIN}/vulkaninfo.exe"
 
 load_vulkanrt121412()
 {
     # https://vulkan.lunarg.com/sdk/home
-    w_download "https://sdk.lunarg.com/sdk/download/1.2.141.2/windows/VulkanRT-1.2.141.2-Installer.exe?Human=true;u=" bf5050ead980e66fdd7b8eb5664d2b92e037ec5c400f75c2dc209a595828aaf7 "$file1"
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" "$file1" ${W_OPT_UNATTENDED:+/S}
+    w_download "https://sdk.lunarg.com/sdk/download/1.2.141.2/windows/VulkanRT-1.2.141.2-Installer.exe?Human=true;u=" bf5050ead980e66fdd7b8eb5664d2b92e037ec5c400f75c2dc209a595828aaf7 "${file1}"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+/S}
 }
 
 #----------------------------------------------------------------
@@ -12808,28 +12808,28 @@ load_vulkansdk121412()
     _W_vulkan_version="${file1%-*.exe}"
     _W_vulkan_version="${_W_vulkan_version#*-}"
     # https://vulkan.lunarg.com/sdk/home
-    w_download "https://sdk.lunarg.com/sdk/download/1.2.141.2/windows/VulkanSDK-1.2.141.2-Installer.exe?Human=true;u=" d732eaee50c5f924ee64c9408bec7073b7a230464f1636f346833727c9bbddd0 "$file1"
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" "$file1" ${W_OPT_UNATTENDED:+/S}
+    w_download "https://sdk.lunarg.com/sdk/download/1.2.141.2/windows/VulkanSDK-1.2.141.2-Installer.exe?Human=true;u=" d732eaee50c5f924ee64c9408bec7073b7a230464f1636f346833727c9bbddd0 "${file1}"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+/S}
     echo "Creating C:\\windows\\winevulkan.json winevulkan json file"
-    cat > "$W_WINDIR_UNIX"/winevulkan.json <<_EOF_
+    cat > "${W_WINDIR_UNIX}"/winevulkan.json <<_EOF_
 {
     "file_format_version": "1.0.0",
     "ICD": {
         "library_path": "c:\\\\windows\\\\system32\\\\winevulkan.dll",
-        "api_version": "$_W_vulkan_version"
+        "api_version": "${_W_vulkan_version}"
     }
 }
 _EOF_
     echo "Creating winevulkan registry settings"
-    cat > "$W_TMP"/winevulkan.reg <<_EOF_
+    cat > "${W_TMP}"/winevulkan.reg <<_EOF_
 REGEDIT4
 
 [HKEY_LOCAL_MACHINE\\SOFTWARE\\Khronos\\Vulkan\\Drivers\\]
 "C:\\\\Windows\\\\winevulkan.json"=dword:00000000
 
 _EOF_
-    w_try_regedit "$W_TMP_WIN"\\winevulkan.reg
+    w_try_regedit "${W_TMP_WIN}"\\winevulkan.reg
 }
 
 #----------------------------------------------------------------
@@ -12840,7 +12840,7 @@ w_metadata vulkanrt dlls \
     year="2020" \
     media="download" \
     file1="vulkan-rt.exe" \
-    installed_exe1="$W_SYSTEM32_DLLS_WIN/vulkaninfo.exe"
+    installed_exe1="${W_SYSTEM32_DLLS_WIN}/vulkaninfo.exe"
 
 load_vulkanrt()
 {
@@ -12853,8 +12853,8 @@ load_vulkanrt()
     _W_vulkan_sha256="$(cut -d ' ' -f1 "${W_TMP}/${_W_vulkan_shafile}")"
     w_download "https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-rt.exe?Human=true;u=" "${_W_vulkan_sha256}" "${file1}"
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" "$file1" ${W_OPT_UNATTENDED:+/S}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+/S}
 }
 
 #----------------------------------------------------------------
@@ -12881,29 +12881,29 @@ load_vulkansdk()
     _W_vulkan_sha256="$(cut -d ' ' -f1 "${W_TMP}/${_W_vulkan_shafile}")"
     w_download "https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe?Human=true;u=" "${_W_vulkan_sha256}" "${file1}"
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" "$file1" ${W_OPT_UNATTENDED:+/S}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+/S}
     echo "Creating C:\\windows\\winevulkan.json winevulkan json file"
-    cat > "$W_WINDIR_UNIX"/winevulkan.json <<_EOF_
+    cat > "${W_WINDIR_UNIX}"/winevulkan.json <<_EOF_
 {
     "file_format_version": "1.0.0",
     "ICD": {
         "library_path": "c:\\\\windows\\\\system32\\\\winevulkan.dll",
-        "api_version": "$_W_vulkan_version"
+        "api_version": "${_W_vulkan_version}"
     }
 }
 _EOF_
     echo "Creating winevulkan registry settings"
-    cat > "$W_TMP"/winevulkan.reg <<_EOF_
+    cat > "${W_TMP}"/winevulkan.reg <<_EOF_
 REGEDIT4
 
 [HKEY_LOCAL_MACHINE\\SOFTWARE\\Khronos\\Vulkan\\Drivers\\]
 "C:\\\\Windows\\\\winevulkan.json"=dword:00000000
 
 _EOF_
-    w_try_regedit "$W_TMP_WIN"\\winevulkan.reg
+    w_try_regedit "${W_TMP_WIN}"\\winevulkan.reg
 
-    w_try_cd "$W_DRIVE_C/VulkanSDK"
+    w_try_cd "${W_DRIVE_C}/VulkanSDK"
     # We're assuming here that only the sdks are installed here. This is really only for the installed_file check,
     # as there are no files with non-versioned filenames installed
     w_try ln -sf "$(find . -maxdepth 1 -mindepth 1 -type d | grep -v latest | sort -V | tail -n 1)" latest
@@ -12917,16 +12917,16 @@ w_metadata webio dlls \
     year="2011" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/webio.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/webio.dll"
 
 load_webio()
 {
     helper_win7sp1 x86_microsoft-windows-webio_31bf3856ad364e35_6.1.7601.17514_none_5ef1a4093cf55387/webio.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-webio_31bf3856ad364e35_6.1.7601.17514_none_5ef1a4093cf55387/webio.dll" "$W_SYSTEM32_DLLS/webio.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-webio_31bf3856ad364e35_6.1.7601.17514_none_5ef1a4093cf55387/webio.dll" "${W_SYSTEM32_DLLS}/webio.dll"
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-webio_31bf3856ad364e35_6.1.7601.17514_none_bb103f8cf552c4bd/webio.dll
-        w_try cp "$W_TMP/amd64_microsoft-windows-webio_31bf3856ad364e35_6.1.7601.17514_none_bb103f8cf552c4bd/webio.dll" "$W_SYSTEM64_DLLS/webio.dll"
+        w_try cp "${W_TMP}/amd64_microsoft-windows-webio_31bf3856ad364e35_6.1.7601.17514_none_bb103f8cf552c4bd/webio.dll" "${W_SYSTEM64_DLLS}/webio.dll"
     fi
 
     w_override_dlls native,builtin webio
@@ -12941,28 +12941,28 @@ w_metadata windowscodecs dlls \
     year="2006" \
     media="download" \
     file1="wic_x86_enu.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/WindowsCodecs.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/WindowsCodecs.dll"
 
 load_windowscodecs()
 {
     # Separate 32/64-bit installers:
-    if [ "$W_ARCH" = "win32" ] ; then
+    if [ "${W_ARCH}" = "win32" ] ; then
         # https://www.microsoft.com/en-us/download/details.aspx?id=32
         w_download https://download.microsoft.com/download/f/f/1/ff178bb1-da91-48ed-89e5-478a99387d4f/wic_x86_enu.exe 196868b09d87ae04e4ab42b4a3e0abbb160500e8ff13deb38e2956ee854868b1
         EXE="wic_x86_enu.exe"
-    elif [ "$W_ARCH" = "win64" ] ; then
+    elif [ "${W_ARCH}" = "win64" ] ; then
         # https://www.microsoft.com/en-us/download/details.aspx?id=1385
         w_download https://download.microsoft.com/download/6/4/5/645FED5F-A6E7-44D9-9D10-FE83348796B0/wic_x64_enu.exe 5822fecd69a90c2833965a25e8779000825d69cc8c9250933f0ab70df52171e1
         EXE="wic_x64_enu.exe"
     else
-        w_die "Invalid W_ARCH value, $W_ARCH"
+        w_die "Invalid W_ARCH value, ${W_ARCH}"
     fi
 
     # Avoid a file existence check.
-    w_try rm -f "$W_SYSTEM32_DLLS"/windowscodecs.dll "$W_SYSTEM32_DLLS"/windowscodecsext.dll "$W_SYSTEM32_DLLS"/wmphoto.dll "$W_SYSTEM32_DLLS"/photometadatahandler.dll
+    w_try rm -f "${W_SYSTEM32_DLLS}"/windowscodecs.dll "${W_SYSTEM32_DLLS}"/windowscodecsext.dll "${W_SYSTEM32_DLLS}"/wmphoto.dll "${W_SYSTEM32_DLLS}"/photometadatahandler.dll
 
-    if [ "$W_ARCH" = "win64" ]; then
-         w_try rm -f "$W_SYSTEM64_DLLS"/windowscodecs.dll "$W_SYSTEM64_DLLS"/windowscodecsext.dll "$W_SYSTEM64_DLLS"/wmphoto.dll "$W_SYSTEM64_DLLS"/photometadatahandler.dll
+    if [ "${W_ARCH}" = "win64" ]; then
+         w_try rm -f "${W_SYSTEM64_DLLS}"/windowscodecs.dll "${W_SYSTEM64_DLLS}"/windowscodecsext.dll "${W_SYSTEM64_DLLS}"/wmphoto.dll "${W_SYSTEM64_DLLS}"/photometadatahandler.dll
     fi
 
     # AF says in AppDB entry for .NET 3.0 that windowscodecs has to be native only
@@ -12974,13 +12974,13 @@ load_windowscodecs()
     # Always run the WIC installer in passive mode.
     # See https://bugs.winehq.org/show_bug.cgi?id=16876 and
     # https://bugs.winehq.org/show_bug.cgi?id=23232
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
     if w_workaround_wine_bug 32859 "Working around possibly broken libX11"; then
         # shellcheck disable=SC2086
-        w_try $W_TASKSET "$WINE" "$EXE" /passive
+        w_try ${W_TASKSET} "${WINE}" "${EXE}" /passive
     else
-        w_try "$WINE" "$EXE" /passive
+        w_try "${WINE}" "${EXE}" /passive
     fi
 
     w_set_winver 'default'
@@ -12994,7 +12994,7 @@ w_metadata winhttp dlls \
     year="2005" \
     media="download" \
     file1="../win2ksp4/W2KSP4_EN.EXE" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/winhttp.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/winhttp.dll"
 
 load_winhttp()
 {
@@ -13003,7 +13003,7 @@ load_winhttp()
     # See https://github.com/Winetricks/winetricks/issues/831
 
     helper_win2ksp4 i386/new/winhttp.dl_
-    w_try_cabextract --directory="$W_SYSTEM32_DLLS" "$W_TMP"/i386/new/winhttp.dl_
+    w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_TMP}"/i386/new/winhttp.dl_
     w_override_dlls native,builtin winhttp
 }
 
@@ -13015,16 +13015,16 @@ w_metadata wininet dlls \
     year="2011" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/wininet.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/wininet.dll"
 
 load_wininet()
 {
     helper_win7sp1 x86_microsoft-windows-i..tocolimplementation_31bf3856ad364e35_8.0.7601.17514_none_1eaaa4a07717236e/wininet.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-i..tocolimplementation_31bf3856ad364e35_8.0.7601.17514_none_1eaaa4a07717236e/wininet.dll" "$W_SYSTEM32_DLLS/wininet.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-i..tocolimplementation_31bf3856ad364e35_8.0.7601.17514_none_1eaaa4a07717236e/wininet.dll" "${W_SYSTEM32_DLLS}/wininet.dll"
 
-    if [ "$W_ARCH" = "win64" ]; then
+    if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-i..tocolimplementation_31bf3856ad364e35_8.0.7601.17514_none_7ac940242f7494a4/wininet.dll
-        w_try cp "$W_TMP/amd64_microsoft-windows-i..tocolimplementation_31bf3856ad364e35_8.0.7601.17514_none_7ac940242f7494a4/wininet.dll" "$W_SYSTEM64_DLLS/wininet.dll"
+        w_try cp "${W_TMP}/amd64_microsoft-windows-i..tocolimplementation_31bf3856ad364e35_8.0.7601.17514_none_7ac940242f7494a4/wininet.dll" "${W_SYSTEM64_DLLS}/wininet.dll"
     fi
 
     w_override_dlls native,builtin wininet
@@ -13040,12 +13040,12 @@ w_metadata wininet_win2k dlls \
     year="2008" \
     media="download" \
     file1="../win2ksp4/W2KSP4_EN.EXE" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/wininet.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/wininet.dll"
 
 load_wininet_win2k()
 {
     helper_win2ksp4 i386/wininet.dl_
-    w_try_cabextract --directory="$W_SYSTEM32_DLLS" "$W_TMP"/i386/wininet.dl_
+    w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_TMP}"/i386/wininet.dl_
 
     w_override_dlls native,builtin wininet
 }
@@ -13058,7 +13058,7 @@ w_metadata wmi dlls \
     year="2000" \
     media="download" \
     file1="wmi9x.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/wbem/wbemcore.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/wbem/wbemcore.dll"
 
 load_wmi()
 {
@@ -13077,8 +13077,8 @@ load_wmi()
     w_override_dlls native,builtin wbemprox wmiutils
 
     # Note: there is a crash in the background towards the end, doesn't seem to hurt; see https://bugs.winehq.org/show_bug.cgi?id=7920
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" wmi9x.exe ${W_OPT_UNATTENDED:+/S}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" wmi9x.exe ${W_OPT_UNATTENDED:+/S}
     w_killall "WinMgmt.exe"
 
     w_set_winver 'default'
@@ -13092,24 +13092,24 @@ w_metadata wmv9vcm dlls \
     year="2013" \
     media="download" \
     file1="WindowsServer2003-WindowsMedia-KB2845142-x86-ENU.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/wmv9vcm.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/wmv9vcm.dll"
 
 load_wmv9vcm()
 {
     # https://www.microsoft.com/en-us/download/details.aspx?id=39486
     # See also https://www.microsoft.com/en-us/download/details.aspx?id=6191
     w_download https://download.microsoft.com/download/2/8/D/28DA9C3E-6DA2-456F-BD33-1F937EB6E0FF/WindowsServer2003-WindowsMedia-KB2845142-x86-ENU.exe 51e11691339c1c817b12f92e613145ffcd7b6f7e869d994cc8dbc4591b24f155
-    w_try_cabextract --directory="$W_TMP" "$W_CACHE/$W_PACKAGE/$file1"
-    w_try cp -f "$W_TMP"/wm64/wmv9vcm.dll "$W_SYSTEM32_DLLS"
+    w_try_cabextract --directory="${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${file1}"
+    w_try cp -f "${W_TMP}"/wm64/wmv9vcm.dll "${W_SYSTEM32_DLLS}"
 
     # Register codec:
-    cat > "$W_TMP"/tmp.reg <<_EOF_
+    cat > "${W_TMP}"/tmp.reg <<_EOF_
 REGEDIT4
 [HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Drivers32]
 "vidc.WMV3"="wmv9vcm.dll"
 
 _EOF_
-    w_try_regedit "$W_TMP_WIN"\\tmp.reg
+    w_try_regedit "${W_TMP_WIN}"\\tmp.reg
 }
 
 #----------------------------------------------------------------
@@ -13120,14 +13120,14 @@ w_metadata wsh57 dlls \
     year="2007" \
     media="download" \
     file1="scripten.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/scrrun.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/scrrun.dll"
 
 load_wsh57()
 {
     # See also https://www.microsoft.com/en-us/download/details.aspx?id=8247
     w_download https://download.microsoft.com/download/4/4/d/44de8a9e-630d-4c10-9f17-b9b34d3f6417/scripten.exe 63c781b9e50bfd55f10700eb70b5c571a9bedfd8d35af29f6a22a77550df5e7b
 
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" "$W_CACHE"/wsh57/scripten.exe
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" "${W_CACHE}"/wsh57/scripten.exe
 
     # Wine doesn't provide the other dll's (yet?)
     w_override_dlls native,builtin jscript scrrun vbscript cscript.exe wscript.exe
@@ -13142,22 +13142,22 @@ w_metadata xact dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_Jun2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/xactengine2_0.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/xactengine2_0.dll"
 
 load_xact()
 {
     helper_directx_Jun2010
 
     # Extract xactengine?_?.dll, X3DAudio?_?.dll, xaudio?_?.dll, xapofx?_?.dll
-    w_try_cabextract -d "$W_TMP" -L -F '*_xact_*x86*' "$W_CACHE/directx9/$DIRECTX_NAME"
-    w_try_cabextract -d "$W_TMP" -L -F '*_x3daudio_*x86*' "$W_CACHE/directx9/$DIRECTX_NAME"
-    w_try_cabextract -d "$W_TMP" -L -F '*_xaudio_*x86*' "$W_CACHE/directx9/$DIRECTX_NAME"
+    w_try_cabextract -d "${W_TMP}" -L -F '*_xact_*x86*' "${W_CACHE}/directx9/${DIRECTX_NAME}"
+    w_try_cabextract -d "${W_TMP}" -L -F '*_x3daudio_*x86*' "${W_CACHE}/directx9/${DIRECTX_NAME}"
+    w_try_cabextract -d "${W_TMP}" -L -F '*_xaudio_*x86*' "${W_CACHE}/directx9/${DIRECTX_NAME}"
 
-    for x in "$W_TMP"/*.cab ; do
-        w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'xactengine*.dll' "$x"
-        w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'xaudio*.dll' "$x"
-        w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'x3daudio*.dll' "$x"
-        w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'xapofx*.dll' "$x"
+    for x in "${W_TMP}"/*.cab ; do
+        w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'xactengine*.dll' "${x}"
+        w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'xaudio*.dll' "${x}"
+        w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'x3daudio*.dll' "${x}"
+        w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'xapofx*.dll' "${x}"
     done
 
     # Don't install 64-bit xact DLLs by default. They are broken in Wine, see:
@@ -13168,13 +13168,13 @@ load_xact()
     w_override_dlls native,builtin xapofx1_1 xapofx1_2 xapofx1_3 xapofx1_4 xapofx1_5
 
     # Register xactengine?_?.dll
-    for x in "$W_SYSTEM32_DLLS"/xactengine* ; do
-        w_try_regsvr "$(basename "$x")"
+    for x in "${W_SYSTEM32_DLLS}"/xactengine* ; do
+        w_try_regsvr "$(basename "${x}")"
     done
 
     # and xaudio?_?.dll, but not xaudio2_8 (unsupported)
     for x in 0 1 2 3 4 5 6 7 ; do
-        w_try_regsvr "$(basename "$W_SYSTEM32_DLLS/xaudio2_${x}")"
+        w_try_regsvr "$(basename "${W_SYSTEM32_DLLS}/xaudio2_${x}")"
     done
 }
 
@@ -13198,15 +13198,15 @@ load_xact_x64()
     helper_directx_Jun2010
 
     # Extract xactengine?_?.dll, X3DAudio?_?.dll, xaudio?_?.dll, xapofx?_?.dll
-    w_try_cabextract -d "$W_TMP" -L -F '*_xact_*x64*' "$W_CACHE/directx9/$DIRECTX_NAME"
-    w_try_cabextract -d "$W_TMP" -L -F '*_x3daudio_*x64*' "$W_CACHE/directx9/$DIRECTX_NAME"
-    w_try_cabextract -d "$W_TMP" -L -F '*_xaudio_*x64*' "$W_CACHE/directx9/$DIRECTX_NAME"
+    w_try_cabextract -d "${W_TMP}" -L -F '*_xact_*x64*' "${W_CACHE}/directx9/${DIRECTX_NAME}"
+    w_try_cabextract -d "${W_TMP}" -L -F '*_x3daudio_*x64*' "${W_CACHE}/directx9/${DIRECTX_NAME}"
+    w_try_cabextract -d "${W_TMP}" -L -F '*_xaudio_*x64*' "${W_CACHE}/directx9/${DIRECTX_NAME}"
 
-    for x in "$W_TMP"/*.cab ; do
-        w_try_cabextract -d "$W_SYSTEM64_DLLS" -L -F 'xactengine*.dll' "$x"
-        w_try_cabextract -d "$W_SYSTEM64_DLLS" -L -F 'xaudio*.dll' "$x"
-        w_try_cabextract -d "$W_SYSTEM64_DLLS" -L -F 'x3daudio*.dll' "$x"
-        w_try_cabextract -d "$W_SYSTEM64_DLLS" -L -F 'xapofx*.dll' "$x"
+    for x in "${W_TMP}"/*.cab ; do
+        w_try_cabextract -d "${W_SYSTEM64_DLLS}" -L -F 'xactengine*.dll' "${x}"
+        w_try_cabextract -d "${W_SYSTEM64_DLLS}" -L -F 'xaudio*.dll' "${x}"
+        w_try_cabextract -d "${W_SYSTEM64_DLLS}" -L -F 'x3daudio*.dll' "${x}"
+        w_try_cabextract -d "${W_SYSTEM64_DLLS}" -L -F 'xapofx*.dll' "${x}"
     done
 
     w_override_dlls native,builtin xaudio2_0 xaudio2_1 xaudio2_2 xaudio2_3 xaudio2_4 xaudio2_5 xaudio2_6 xaudio2_7
@@ -13214,13 +13214,13 @@ load_xact_x64()
     w_override_dlls native,builtin xapofx1_1 xapofx1_2 xapofx1_3 xapofx1_4 xapofx1_5
 
     # Register xactengine?_?.dll
-    for x in "$W_SYSTEM64_DLLS"/xactengine* ; do
-        w_try_regsvr64 "$(basename "$x")"
+    for x in "${W_SYSTEM64_DLLS}"/xactengine* ; do
+        w_try_regsvr64 "$(basename "${x}")"
     done
 
     # and xaudio?_?.dll, but not xaudio2_8 (unsupported)
     for x in 0 1 2 3 4 5 6 7 ; do
-        w_try_regsvr64 "$(basename "$W_SYSTEM64_DLLS/xaudio2_${x}")"
+        w_try_regsvr64 "$(basename "${W_SYSTEM64_DLLS}/xaudio2_${x}")"
     done
 }
 
@@ -13232,20 +13232,20 @@ w_metadata xinput dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/xinput1_1.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/xinput1_1.dll"
 
 load_xinput()
 {
     helper_directx_Jun2010
 
-    w_try_cabextract -d "$W_TMP" -L -F '*_xinput_*x86*' "$W_CACHE"/directx9/$DIRECTX_NAME
-    for x in "$W_TMP"/*.cab; do
-      w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F 'xinput*.dll' "$x"
+    w_try_cabextract -d "${W_TMP}" -L -F '*_xinput_*x86*' "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    for x in "${W_TMP}"/*.cab; do
+      w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'xinput*.dll' "${x}"
     done
-    if test "$W_ARCH" = "win64"; then
-        w_try_cabextract -d "$W_TMP" -L -F '*_xinput_*x64*' "$W_CACHE"/directx9/$DIRECTX_NAME
-        for x in "$W_TMP"/*x64.cab; do
-            w_try_cabextract -d "$W_SYSTEM64_DLLS" -L -F 'xinput*.dll' "$x"
+    if test "${W_ARCH}" = "win64"; then
+        w_try_cabextract -d "${W_TMP}" -L -F '*_xinput_*x64*' "${W_CACHE}"/directx9/${DIRECTX_NAME}
+        for x in "${W_TMP}"/*x64.cab; do
+            w_try_cabextract -d "${W_SYSTEM64_DLLS}" -L -F 'xinput*.dll' "${x}"
         done
     fi
     w_override_dlls native xinput1_1
@@ -13262,16 +13262,16 @@ w_metadata xmllite dlls \
     year="2011" \
     media="download" \
     file1="../win7sp1/windows6.1-KB976932-X86.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/xmllite.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/xmllite.dll"
 
 load_xmllite()
 {
     helper_win7sp1 x86_microsoft-windows-servicingstack_31bf3856ad364e35_6.1.7601.17514_none_0b66cb34258c936f/xmllite.dll
-    w_try cp "$W_TMP/x86_microsoft-windows-servicingstack_31bf3856ad364e35_6.1.7601.17514_none_0b66cb34258c936f/xmllite.dll" "$W_SYSTEM32_DLLS/xmllite.dll"
+    w_try cp "${W_TMP}/x86_microsoft-windows-servicingstack_31bf3856ad364e35_6.1.7601.17514_none_0b66cb34258c936f/xmllite.dll" "${W_SYSTEM32_DLLS}/xmllite.dll"
 
-    if [ "$W_ARCH" = "win64" ]; then
-        helper_win7sp1_x64 amd64_microsoft-windows-servicingstack_31bf3856ad364e35_6.1.7601.17514_none_678566b7ddea04a5/xmllite.dll "$W_SYSTEM64_DLLS/xmllite.dll"
-        w_try cp "$W_TMP/amd64_microsoft-windows-servicingstack_31bf3856ad364e35_6.1.7601.17514_none_678566b7ddea04a5/xmllite.dll" "$W_SYSTEM64_DLLS/xmllite.dll"
+    if [ "${W_ARCH}" = "win64" ]; then
+        helper_win7sp1_x64 amd64_microsoft-windows-servicingstack_31bf3856ad364e35_6.1.7601.17514_none_678566b7ddea04a5/xmllite.dll "${W_SYSTEM64_DLLS}/xmllite.dll"
+        w_try cp "${W_TMP}/amd64_microsoft-windows-servicingstack_31bf3856ad364e35_6.1.7601.17514_none_678566b7ddea04a5/xmllite.dll" "${W_SYSTEM64_DLLS}/xmllite.dll"
     fi
 
     w_override_dlls native,builtin xmllite
@@ -13291,8 +13291,8 @@ load_xna31()
 {
     w_call dotnet20sp2
     w_download https://download.microsoft.com/download/5/9/1/5912526C-B950-4662-99B6-119A83E60E5C/xnafx31_redist.msi 187e7e6b08fe35428d945612a7d258bfed25fad53cc54882983abdc73fe60f91
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" msiexec ${W_OPT_UNATTENDED:+/quiet} /i "$file1"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" msiexec ${W_OPT_UNATTENDED:+/quiet} /i "${file1}"
 }
 
 #----------------------------------------------------------------
@@ -13303,12 +13303,12 @@ w_metadata xna40 dlls \
     year="2010" \
     media="download" \
     file1="xnafx40_redist.msi" \
-    installed_file1="$W_PROGRAMS_X86_WIN/Common Files/Microsoft Shared/XNA/Framework/v4.0/XnaNative.dll"
+    installed_file1="${W_PROGRAMS_X86_WIN}/Common Files/Microsoft Shared/XNA/Framework/v4.0/XnaNative.dll"
 
 load_xna40()
 {
     if w_workaround_wine_bug 30718; then
-        w_warn "$W_PACKAGE may not install properly in Wine yet"
+        w_warn "${W_PACKAGE} may not install properly in Wine yet"
     fi
 
     # See https://bugs.winehq.org/show_bug.cgi?id=30718#c8
@@ -13317,8 +13317,8 @@ load_xna40()
 
     # https://www.microsoft.com/en-us/download/details.aspx?id=20914
     w_download https://download.microsoft.com/download/A/C/2/AC2C903B-E6E8-42C2-9FD7-BEBAC362A930/xnafx40_redist.msi e6c41d692ebcba854dad4b1c52bb7ddd05926bad3105595d6596b8bab01c25e7
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" msiexec ${W_OPT_UNATTENDED:+/quiet} /i "$file1"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" msiexec ${W_OPT_UNATTENDED:+/quiet} /i "${file1}"
 }
 
 #----------------------------------------------------------------
@@ -13329,14 +13329,14 @@ w_metadata xvid dlls \
     year="2009" \
     media="download" \
     file1="Xvid-1.3.2-20110601.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/Xvid/xvid.ico"
+    installed_file1="${W_PROGRAMS_X86_WIN}/Xvid/xvid.ico"
 
 load_xvid()
 {
     w_call vcrun6
     w_download http://www.koepi.info/Xvid-1.3.2-20110601.exe 74b23965cebe59e388eab6dba224b6b751ef4519454cc12086ade51c81f0a33c
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" "$file1" ${W_OPT_UNATTENDED:+ --mode unattended --decode_divx 1 --decode_3ivx 1 --decode_other 1}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+ --mode unattended --decode_divx 1 --decode_3ivx 1 --decode_other 1}
 }
 
 #######################
@@ -13349,7 +13349,7 @@ w_metadata baekmuk fonts \
     year="1999" \
     media="download" \
     file1="fonts-baekmuk_2.2.orig.tar.gz" \
-    installed_file1="$W_FONTSDIR_WIN/batang.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/batang.ttf"
 
 load_baekmuk()
 {
@@ -13357,9 +13357,9 @@ load_baekmuk()
     # Need to download from Debian as the project page has unique captcha tokens per visitor
     w_download "https://deb.debian.org/debian/pool/main/f/fonts-baekmuk/fonts-baekmuk_2.2.orig.tar.gz" 08ab7dffb55d5887cc942ce370f5e33b756a55fbb4eaf0b90f244070e8d51882
 
-    w_try_cd "$W_TMP"
-    w_try tar -zxf "$W_CACHE/$W_PACKAGE/$file1" baekmuk-ttf-2.2/ttf
-    w_try_cp_font_files baekmuk-ttf-2.2/ttf/ "$W_FONTSDIR_UNIX"
+    w_try_cd "${W_TMP}"
+    w_try tar -zxf "${W_CACHE}/${W_PACKAGE}/${file1}" baekmuk-ttf-2.2/ttf
+    w_try_cp_font_files baekmuk-ttf-2.2/ttf/ "${W_FONTSDIR_UNIX}"
     w_register_font batang.ttf "Baekmuk Batang"
     w_register_font gulim.ttf "Baekmuk Gulim"
     w_register_font dotum.ttf "Baekmuk Dotum"
@@ -13390,7 +13390,7 @@ w_metadata calibri fonts \
     year="2007" \
     media="download" \
     file1="PowerPointViewer.exe" \
-    installed_file1="$W_FONTSDIR_WIN/calibri.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/calibri.ttf"
 
 load_calibri()
 {
@@ -13409,7 +13409,7 @@ w_metadata cambria fonts \
     year="2009" \
     media="download" \
     file1="PowerPointViewer.exe" \
-    installed_file1="$W_FONTSDIR_WIN/cambria.ttc"
+    installed_file1="${W_FONTSDIR_WIN}/cambria.ttc"
 
 load_cambria()
 {
@@ -13428,7 +13428,7 @@ w_metadata candara fonts \
     year="2009" \
     media="download" \
     file1="PowerPointViewer.exe" \
-    installed_file1="$W_FONTSDIR_WIN/candara.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/candara.ttf"
 
 load_candara()
 {
@@ -13447,7 +13447,7 @@ w_metadata consolas fonts \
     year="2011" \
     media="download" \
     file1="PowerPointViewer.exe" \
-    installed_file1="$W_FONTSDIR_WIN/consola.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/consola.ttf"
 
 load_consolas()
 {
@@ -13466,7 +13466,7 @@ w_metadata constantia fonts \
     year="2009" \
     media="download" \
     file1="PowerPointViewer.exe" \
-    installed_file1="$W_FONTSDIR_WIN/constan.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/constan.ttf"
 
 load_constantia()
 {
@@ -13485,7 +13485,7 @@ w_metadata corbel fonts \
     year="2009" \
     media="download" \
     file1="PowerPointViewer.exe" \
-    installed_file1="$W_FONTSDIR_WIN/corbel.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/corbel.ttf"
 
 load_corbel()
 {
@@ -13505,7 +13505,7 @@ w_metadata meiryo fonts \
     media="download" \
     conflicts="fakejapanese_vlgothic" \
     file1="PowerPointViewer.exe" \
-    installed_file1="$W_FONTSDIR_WIN/meiryo.ttc"
+    installed_file1="${W_FONTSDIR_WIN}/meiryo.ttc"
 
 load_meiryo()
 {
@@ -13535,15 +13535,15 @@ load_pptfonts()
 
 helper_pptfonts()
 {
-    # download PowerPointViewer, extract the given files, and copy them to $W_FONTSDIR_UNIX
+    # download PowerPointViewer, extract the given files, and copy them to ${W_FONTSDIR_UNIX}
     # Font registration should still be done by the respective verbs
     # $1 - font pattern to extract
 
     pptfont="$1"
     w_download_to PowerPointViewer "https://web.archive.org/web/20171225132744if_/https://download.microsoft.com/download/E/6/7/E675FFFC-2A6D-4AB0-B3EB-27C9F8C8F696/PowerPointViewer.exe" 249473568eba7a1e4f95498acba594e0f42e6581add4dead70c1dfb908a09423
-    w_try_cabextract -d "$W_TMP" -F "ppviewer.cab" "$W_CACHE/PowerPointViewer/PowerPointViewer.exe"
-    w_try_cabextract -d "$W_TMP" -F "$pptfont" "$W_TMP/ppviewer.cab"
-    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "$pptfont"
+    w_try_cabextract -d "${W_TMP}" -F "ppviewer.cab" "${W_CACHE}/PowerPointViewer/PowerPointViewer.exe"
+    w_try_cabextract -d "${W_TMP}" -F "${pptfont}" "${W_TMP}/ppviewer.cab"
+    w_try_cp_font_files "${W_TMP}" "${W_FONTSDIR_UNIX}" "${pptfont}"
 }
 
 #----------------------------------------------------------------
@@ -13554,13 +13554,13 @@ w_metadata andale fonts \
     year="2008" \
     media="download" \
     file1="andale32.exe" \
-    installed_file1="$W_FONTSDIR_WIN/andalemo.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/andalemo.ttf"
 
 load_andale()
 {
     w_download_to corefonts "https://mirrors.kernel.org/gentoo/distfiles/andale32.exe" 0524fe42951adc3a7eb870e32f0920313c71f170c859b5f770d82b4ee111e970
-    w_try_cabextract -d "$W_TMP" "$W_CACHE"/corefonts/andale32.exe
-    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "AndaleMo.TTF"
+    w_try_cabextract -d "${W_TMP}" "${W_CACHE}"/corefonts/andale32.exe
+    w_try_cp_font_files "${W_TMP}" "${W_FONTSDIR_UNIX}" "AndaleMo.TTF"
     w_register_font andalemo.ttf "Andale Mono"
 }
 
@@ -13572,22 +13572,22 @@ w_metadata arial fonts \
     year="2008" \
     media="download" \
     file1="arial32.exe" \
-    installed_file1="$W_FONTSDIR_WIN/arial.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/arial.ttf"
 
 load_arial()
 {
     w_download_to corefonts "https://mirrors.kernel.org/gentoo/distfiles/arial32.exe" 85297a4d146e9c87ac6f74822734bdee5f4b2a722d7eaa584b7f2cbf76f478f6
     w_download_to corefonts "https://mirrors.kernel.org/gentoo/distfiles/arialb32.exe" a425f0ffb6a1a5ede5b979ed6177f4f4f4fdef6ae7c302a7b7720ef332fec0a8
 
-    w_try_cabextract -d "$W_TMP" "$W_CACHE"/corefonts/arial32.exe
-    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "Arial*.TTF"
+    w_try_cabextract -d "${W_TMP}" "${W_CACHE}"/corefonts/arial32.exe
+    w_try_cp_font_files "${W_TMP}" "${W_FONTSDIR_UNIX}" "Arial*.TTF"
     w_register_font arialbd.ttf "Arial Bold"
     w_register_font arialbi.ttf "Arial Bold Italic"
     w_register_font ariali.ttf "Arial Italic"
     w_register_font arial.ttf "Arial"
 
-    w_try_cabextract -d "$W_TMP" "$W_CACHE"/corefonts/arialb32.exe
-    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "AriBlk.TTF"
+    w_try_cabextract -d "${W_TMP}" "${W_CACHE}"/corefonts/arialb32.exe
+    w_try_cp_font_files "${W_TMP}" "${W_FONTSDIR_UNIX}" "AriBlk.TTF"
     w_register_font ariblk.ttf "Arial Black"
 }
 
@@ -13599,13 +13599,13 @@ w_metadata comicsans fonts \
     year="2008" \
     media="download" \
     file1="comic32.exe" \
-    installed_file1="$W_FONTSDIR_WIN/comic.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/comic.ttf"
 
 load_comicsans()
 {
     w_download_to corefonts "https://mirrors.kernel.org/gentoo/distfiles/comic32.exe" 9c6df3feefde26d4e41d4a4fe5db2a89f9123a772594d7f59afd062625cd204e
-    w_try_cabextract -d "$W_TMP" "$W_CACHE"/corefonts/comic32.exe
-    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "Comic*.TTF"
+    w_try_cabextract -d "${W_TMP}" "${W_CACHE}"/corefonts/comic32.exe
+    w_try_cp_font_files "${W_TMP}" "${W_FONTSDIR_UNIX}" "Comic*.TTF"
     w_register_font comicbd.ttf "Comic Sans MS Bold"
     w_register_font comic.ttf "Comic Sans MS"
 }
@@ -13618,12 +13618,12 @@ w_metadata courier fonts \
     year="2008" \
     media="download" \
     file1="courie32.exe" \
-    installed_file1="$W_FONTSDIR_WIN/cour.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/cour.ttf"
 load_courier()
 {
     w_download_to corefonts "https://mirrors.kernel.org/gentoo/distfiles/courie32.exe" bb511d861655dde879ae552eb86b134d6fae67cb58502e6ff73ec5d9151f3384
-    w_try_cabextract -d "$W_TMP" "$W_CACHE"/corefonts/courie32.exe
-    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "cour*.ttf"
+    w_try_cabextract -d "${W_TMP}" "${W_CACHE}"/corefonts/courie32.exe
+    w_try_cp_font_files "${W_TMP}" "${W_FONTSDIR_UNIX}" "cour*.ttf"
     w_register_font courbd.ttf "Courier New Bold"
     w_register_font courbi.ttf "Courier New Bold Italic"
     w_register_font couri.ttf "Courier New Italic"
@@ -13638,12 +13638,12 @@ w_metadata georgia fonts \
     year="2008" \
     media="download" \
     file1="georgi32.exe" \
-    installed_file1="$W_FONTSDIR_WIN/georgia.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/georgia.ttf"
 load_georgia()
 {
     w_download_to corefonts "https://mirrors.kernel.org/gentoo/distfiles/georgi32.exe" 2c2c7dcda6606ea5cf08918fb7cd3f3359e9e84338dc690013f20cd42e930301
-    w_try_cabextract -d "$W_TMP" "$W_CACHE"/corefonts/georgi32.exe
-    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "Georgia*.TTF"
+    w_try_cabextract -d "${W_TMP}" "${W_CACHE}"/corefonts/georgi32.exe
+    w_try_cp_font_files "${W_TMP}" "${W_FONTSDIR_UNIX}" "Georgia*.TTF"
     w_register_font georgiab.ttf "Georgia Bold"
     w_register_font georgiai.ttf "Georgia Italic"
     w_register_font georgia.ttf "Georgia"
@@ -13658,13 +13658,13 @@ w_metadata impact fonts \
     year="2008" \
     media="download" \
     file1="impact32.exe" \
-    installed_file1="$W_FONTSDIR_WIN/impact.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/impact.ttf"
 
 load_impact()
 {
     w_download_to corefonts "https://mirrors.kernel.org/gentoo/distfiles/impact32.exe" 6061ef3b7401d9642f5dfdb5f2b376aa14663f6275e60a51207ad4facf2fccfb
-    w_try_cabextract -d "$W_TMP" "$W_CACHE"/corefonts/impact32.exe
-    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "Impact.TTF"
+    w_try_cabextract -d "${W_TMP}" "${W_CACHE}"/corefonts/impact32.exe
+    w_try_cp_font_files "${W_TMP}" "${W_FONTSDIR_UNIX}" "Impact.TTF"
     w_register_font impact.ttf "Impact"
 }
 
@@ -13676,13 +13676,13 @@ w_metadata times fonts \
     year="2008" \
     media="download" \
     file1="times32.exe" \
-    installed_file1="$W_FONTSDIR_WIN/times.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/times.ttf"
 
 load_times()
 {
     w_download_to corefonts "https://mirrors.kernel.org/gentoo/distfiles/times32.exe" db56595ec6ef5d3de5c24994f001f03b2a13e37cee27bc25c58f6f43e8f807ab
-    w_try_cabextract -d "$W_TMP" "$W_CACHE"/corefonts/times32.exe
-    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "Times*.TTF"
+    w_try_cabextract -d "${W_TMP}" "${W_CACHE}"/corefonts/times32.exe
+    w_try_cp_font_files "${W_TMP}" "${W_FONTSDIR_UNIX}" "Times*.TTF"
     w_register_font timesbd.ttf "Times New Roman Bold"
     w_register_font timesbi.ttf "Times New Roman Bold Italic"
     w_register_font timesi.ttf "Times New Roman Italic"
@@ -13697,13 +13697,13 @@ w_metadata trebuchet fonts \
     year="2008" \
     media="download" \
     file1="trebuchet32.exe" \
-    installed_file1="$W_FONTSDIR_WIN/trebuc.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/trebuc.ttf"
 
 load_trebuchet()
 {
     w_download_to corefonts "https://mirrors.kernel.org/gentoo/distfiles/trebuc32.exe" 5a690d9bb8510be1b8b4fe49f1f2319651fe51bbe54775ddddd8ef0bd07fdac9
-    w_try_cabextract -d "$W_TMP" "$W_CACHE"/corefonts/trebuc32.exe
-    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "[tT]rebuc*.ttf"
+    w_try_cabextract -d "${W_TMP}" "${W_CACHE}"/corefonts/trebuc32.exe
+    w_try_cp_font_files "${W_TMP}" "${W_FONTSDIR_UNIX}" "[tT]rebuc*.ttf"
     w_register_font trebucbd.ttf "Trebuchet MS Bold"
     w_register_font trebucbi.ttf "Trebuchet MS Bold Italic"
     w_register_font trebucit.ttf "Trebuchet MS Italic"
@@ -13718,13 +13718,13 @@ w_metadata verdana fonts \
     year="2008" \
     media="download" \
     file1="verdan32.exe" \
-    installed_file1="$W_FONTSDIR_WIN/verdana.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/verdana.ttf"
 
 load_verdana()
 {
     w_download_to corefonts "https://mirrors.kernel.org/gentoo/distfiles/verdan32.exe" c1cb61255e363166794e47664e2f21af8e3a26cb6346eb8d2ae2fa85dd5aad96
-    w_try_cabextract -d "$W_TMP" "$W_CACHE"/corefonts/verdan32.exe
-    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "Verdana*.TTF"
+    w_try_cabextract -d "${W_TMP}" "${W_CACHE}"/corefonts/verdan32.exe
+    w_try_cp_font_files "${W_TMP}" "${W_FONTSDIR_UNIX}" "Verdana*.TTF"
     w_register_font verdanab.ttf "Verdana Bold"
     w_register_font verdanai.ttf "Verdana Italic"
     w_register_font verdana.ttf "Verdana"
@@ -13739,13 +13739,13 @@ w_metadata webdings fonts \
     year="2008" \
     media="download" \
     file1="webdin32.exe" \
-    installed_file1="$W_FONTSDIR_WIN/webdings.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/webdings.ttf"
 
 load_webdings()
 {
     w_download_to corefonts "https://mirrors.kernel.org/gentoo/distfiles/webdin32.exe" 64595b5abc1080fba8610c5c34fab5863408e806aafe84653ca8575bed17d75a
-    w_try_cabextract -d "$W_TMP" "$W_CACHE"/corefonts/webdin32.exe
-    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "Webdings.TTF"
+    w_try_cabextract -d "${W_TMP}" "${W_CACHE}"/corefonts/webdin32.exe
+    w_try_cp_font_files "${W_TMP}" "${W_FONTSDIR_UNIX}" "Webdings.TTF"
     w_register_font webdings.ttf "Webdings"
 }
 
@@ -13757,7 +13757,7 @@ w_metadata corefonts fonts \
     year="2008" \
     media="download" \
     file1="arial32.exe" \
-    installed_file1="$W_FONTSDIR_WIN/corefonts.installed"
+    installed_file1="${W_FONTSDIR_WIN}/corefonts.installed"
 
 load_corefonts()
 {
@@ -13777,7 +13777,7 @@ load_corefonts()
     w_call verdana
     w_call webdings
 
-    touch "$W_FONTSDIR_UNIX/corefonts.installed"
+    touch "${W_FONTSDIR_UNIX}/corefonts.installed"
 }
 
 #----------------------------------------------------------------
@@ -13788,11 +13788,11 @@ w_metadata droid fonts \
     year="2009" \
     media="download" \
     file1="DroidSans-Bold.ttf" \
-    installed_file1="$W_FONTSDIR_WIN/droidsans-bold.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/droidsans-bold.ttf"
 
 do_droid() {
     w_download "${_W_droid_url}${1}?raw=true" "$3"  "$1"
-    w_try_cp_font_files "$W_CACHE/droid" "$W_FONTSDIR_UNIX" "$1"
+    w_try_cp_font_files "${W_CACHE}/droid" "${W_FONTSDIR_UNIX}" "$1"
     w_register_font "$(echo "$1" | tr "[:upper:]" "[:lower:]")" "$2"
 }
 
@@ -13825,14 +13825,14 @@ w_metadata eufonts fonts \
     year="2008" \
     media="download" \
     file1="EUupdate.EXE" \
-    installed_file1="$W_FONTSDIR_WIN/trebucbd.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/trebucbd.ttf"
 
 load_eufonts()
 {
     # https://www.microsoft.com/en-us/download/details.aspx?id=16083
     w_download "https://download.microsoft.com/download/a/1/8/a180e21e-9c2b-4b54-9c32-bf7fd7429970/EUupdate.EXE" 464dd2cd5f09f489f9ac86ea7790b7b8548fc4e46d9f889b68d2cdce47e09ea8
-    w_try_cabextract -d "$W_TMP" "$W_CACHE"/eufonts/EUupdate.EXE
-    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX"
+    w_try_cabextract -d "${W_TMP}" "${W_CACHE}"/eufonts/EUupdate.EXE
+    w_try_cp_font_files "${W_TMP}" "${W_FONTSDIR_UNIX}"
 
     w_register_font arialbd.ttf "Arial Bold"
     w_register_font arialbi.ttf "Arial Bold Italic"
@@ -14009,16 +14009,16 @@ w_metadata ipamona fonts \
     year="2008" \
     media="download" \
     file1="opfc-ModuleHP-1.1.1_withIPAMonaFonts-1.0.8.tar.gz" \
-    installed_file1="$W_FONTSDIR_WIN/ipag-mona.ttf" \
+    installed_file1="${W_FONTSDIR_WIN}/ipag-mona.ttf" \
     homepage="http://www.geocities.jp/ipa_mona/"
 
 load_ipamona()
 {
     w_download "https://web.archive.org/web/20190309175311/http://www.geocities.jp/ipa_mona/opfc-ModuleHP-1.1.1_withIPAMonaFonts-1.0.8.tar.gz" ab77beea3b051abf606cd8cd3badf6cb24141ef145c60f508fcfef1e3852bb9d
 
-    w_try_cd "$W_TMP"
-    w_try tar -zxf "$W_CACHE/$W_PACKAGE/$file1" "${file1%.tar.gz}/fonts"
-    w_try_cp_font_files "${file1%.tar.gz}/fonts" "$W_FONTSDIR_UNIX"
+    w_try_cd "${W_TMP}"
+    w_try tar -zxf "${W_CACHE}/${W_PACKAGE}/${file1}" "${file1%.tar.gz}/fonts"
+    w_try_cp_font_files "${file1%.tar.gz}/fonts" "${W_FONTSDIR_UNIX}"
 
     w_register_font ipagui-mona.ttf "IPAMonaUIGothic"
     w_register_font ipag-mona.ttf "IPAMonaGothic"
@@ -14035,16 +14035,16 @@ w_metadata liberation fonts \
     year="2008" \
     media="download" \
     file1="liberation-fonts-ttf-1.07.4.tar.gz" \
-    installed_file1="$W_FONTSDIR_WIN/liberationmono-bolditalic.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/liberationmono-bolditalic.ttf"
 
 load_liberation()
 {
     # https://pagure.io/liberation-fonts
     w_download "https://releases.pagure.org/liberation-fonts/liberation-fonts-ttf-1.07.4.tar.gz" 61a7e2b6742a43c73e8762cdfeaf6dfcf9abdd2cfa0b099a9854d69bc4cfee5c
 
-    w_try_cd "$W_TMP"
-    w_try tar -zxf "$W_CACHE/$W_PACKAGE/$file1"
-    w_try_cp_font_files "${file1%.tar.gz}" "$W_FONTSDIR_UNIX"
+    w_try_cd "${W_TMP}"
+    w_try tar -zxf "${W_CACHE}/${W_PACKAGE}/${file1}"
+    w_try_cp_font_files "${file1%.tar.gz}" "${W_FONTSDIR_UNIX}"
 
     w_register_font liberationmono-bolditalic.ttf "Liberation Mono Bold Italic"
     w_register_font liberationmono-bold.ttf "Liberation Mono Bold"
@@ -14075,13 +14075,13 @@ w_metadata lucida fonts \
     year="1998" \
     media="download" \
     file1="eurofixi.exe" \
-    installed_file1="$W_FONTSDIR_WIN/lucon.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/lucon.ttf"
 
 load_lucida()
 {
     w_download "https://ftpmirror.your.org/pub/misc/ftp.microsoft.com/bussys/winnt/winnt-public/fixes/usa/NT40TSE/hotfixes-postSP3/Euro-fix/eurofixi.exe" 41f272a33521f6e15f2cce9ff1e049f2badd5ff0dc327fc81b60825766d5b6c7
-    w_try_cabextract -d "$W_TMP" -F "lucon.ttf" "$W_CACHE"/lucida/eurofixi.exe
-    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX"
+    w_try_cabextract -d "${W_TMP}" -F "lucon.ttf" "${W_CACHE}"/lucida/eurofixi.exe
+    w_try_cp_font_files "${W_TMP}" "${W_FONTSDIR_UNIX}"
     w_register_font lucon.ttf "Lucida Console"
 }
 
@@ -14093,7 +14093,7 @@ w_metadata opensymbol fonts \
     year="2017" \
     media="download" \
     file1="fonts-opensymbol_102.10+LibO6.1.5-3+deb10u4_all.deb" \
-    installed_file1="$W_FONTSDIR_WIN/opens___.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/opens___.ttf"
 
 load_opensymbol()
 {
@@ -14101,10 +14101,10 @@ load_opensymbol()
     # Need to w_download Debian since I can't find a standalone download from OpenOffice
     # Note: The source download package on debian is for _all_ of OpenOffice, which is 266 MB.
     w_download "https://cdn-aws.deb.debian.org/debian-security/pool/updates/main/libr/libreoffice/fonts-opensymbol_102.10+LibO6.1.5-3+deb10u4_all.deb" 1b2ab1e8eeb9a3a4a07e4a1c9bf539bb721734bf8b9881f4d0b8e71e822cecde
-    w_try_cd "$W_TMP"
-    w_try_ar "$W_CACHE/$W_PACKAGE/$file1" data.tar.xz
-    w_try tar -Jxf "$W_TMP/data.tar.xz" ./usr/share/fonts/truetype/openoffice/opens___.ttf
-    w_try_cp_font_files "usr/share/fonts/truetype/openoffice" "$W_FONTSDIR_UNIX"
+    w_try_cd "${W_TMP}"
+    w_try_ar "${W_CACHE}/${W_PACKAGE}/${file1}" data.tar.xz
+    w_try tar -Jxf "${W_TMP}/data.tar.xz" ./usr/share/fonts/truetype/openoffice/opens___.ttf
+    w_try_cp_font_files "usr/share/fonts/truetype/openoffice" "${W_FONTSDIR_UNIX}"
     w_register_font opens___.ttf "OpenSymbol"
 }
 
@@ -14116,13 +14116,13 @@ w_metadata sourcehansans fonts \
     year="2019" \
     media="download" \
     file1="SourceHanSans.ttc" \
-    installed_file1="$W_FONTSDIR_WIN/sourcehansans.ttc"
+    installed_file1="${W_FONTSDIR_WIN}/sourcehansans.ttc"
 
 load_sourcehansans()
 {
     w_download "https://github.com/adobe-fonts/source-han-sans/releases/download/2.001R/SourceHanSans.ttc" 9e94fe493685a7c99ce61e4488169007e3b97badb9f1ef43d3c13da501463780
-    w_try cp "$W_CACHE/$W_PACKAGE/$file1" "$W_TMP/sourcehansans.ttc"
-    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "*.ttc"
+    w_try cp "${W_CACHE}/${W_PACKAGE}/${file1}" "${W_TMP}/sourcehansans.ttc"
+    w_try_cp_font_files "${W_TMP}" "${W_FONTSDIR_UNIX}" "*.ttc"
 
     # Simplified Chinese
     w_register_font sourcehansans.ttc "Source Han Sans SC ExtraLight"
@@ -14169,15 +14169,15 @@ w_metadata tahoma fonts \
     year="1999" \
     media="download" \
     file1="IELPKTH.CAB" \
-    installed_file1="$W_FONTSDIR_WIN/tahoma.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/tahoma.ttf"
 
 load_tahoma()
 {
     # Formerly at https://download.microsoft.com/download/ie55sp2/Install/5.5_SP2/WIN98Me/EN-US/IELPKTH.CAB
     w_download https://downloads.sourceforge.net/corefonts/OldFiles/IELPKTH.CAB c1be3fb8f0042570be76ec6daa03a99142c88367c1bc810240b85827c715961a
 
-    w_try_cabextract -d "$W_TMP" "$W_CACHE/$W_PACKAGE/$file1"
-    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX" "*.TTF"
+    w_try_cabextract -d "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${file1}"
+    w_try_cp_font_files "${W_TMP}" "${W_FONTSDIR_UNIX}" "*.TTF"
 
     w_register_font tahoma.ttf "Tahoma"
     w_register_font tahomabd.ttf "Tahoma Bold"
@@ -14191,15 +14191,15 @@ w_metadata takao fonts \
     year="2010" \
     media="download" \
     file1="takao-fonts-ttf-003.02.01.zip" \
-    installed_file1="$W_FONTSDIR_WIN/takaogothic.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/takaogothic.ttf"
 
 load_takao()
 {
     # The Takao font provides Japanese glyphs. May also be needed with fakejapanese function above.
     # See https://launchpad.net/takao-fonts for project page
     w_download "https://launchpad.net/takao-fonts/trunk/003.02.01/+download/takao-fonts-ttf-003.02.01.zip" 2f526a16c7931958f560697d494d8304949b3ce0aef246fb0c727fbbcc39089e
-    w_try_unzip "$W_TMP" "$W_CACHE"/takao/takao-fonts-ttf-003.02.01.zip
-    w_try_cp_font_files "$W_TMP/takao-fonts-ttf-003.02.01" "$W_FONTSDIR_UNIX"
+    w_try_unzip "${W_TMP}" "${W_CACHE}"/takao/takao-fonts-ttf-003.02.01.zip
+    w_try_cp_font_files "${W_TMP}/takao-fonts-ttf-003.02.01" "${W_FONTSDIR_UNIX}"
 
     w_register_font takaogothic.ttf "TakaoGothic"
     w_register_font takaopgothic.ttf "TakaoPGothic"
@@ -14217,15 +14217,15 @@ w_metadata uff fonts \
     year="2010" \
     media="download" \
     file1="ubuntu-font-family-0.83.zip" \
-    installed_file1="$W_FONTSDIR_WIN/ubuntu-r.ttf" \
+    installed_file1="${W_FONTSDIR_WIN}/ubuntu-r.ttf" \
     homepage="https://launchpad.net/ubuntu-font-family"
 
 load_uff()
 {
     w_download "https://assets.ubuntu.com/v1/fad7939b-ubuntu-font-family-0.83.zip" 456d7d42797febd0d7d4cf1b782a2e03680bb4a5ee43cc9d06bda172bac05b42 ubuntu-font-family-0.83.zip
-    w_try_unzip "$W_TMP" "$W_CACHE/$W_PACKAGE/$file1"
+    w_try_unzip "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${file1}"
 
-    w_try_cp_font_files "$W_TMP/$(basename "${file1}" .zip)" "$W_FONTSDIR_UNIX"
+    w_try_cp_font_files "${W_TMP}/$(basename "${file1}" .zip)" "${W_FONTSDIR_UNIX}"
 
     w_register_font ubuntu-bi.ttf "Ubuntu Bold Italic"
     w_register_font ubuntu-b.ttf "Ubuntu Bold"
@@ -14252,16 +14252,16 @@ w_metadata vlgothic fonts \
     year="2014" \
     media="download" \
     file1="VLGothic-20141206.tar.xz" \
-    installed_file1="$W_FONTSDIR_WIN/vl-gothic-regular.ttf" \
+    installed_file1="${W_FONTSDIR_WIN}/vl-gothic-regular.ttf" \
     homepage="https://ja.osdn.net/projects/vlgothic"
 
 load_vlgothic()
 {
     w_download "https://ja.osdn.net/projects/vlgothic/downloads/62375/VLGothic-20141206.tar.xz" 982040db2f9cb73d7c6ab7d9d163f2ed46d1180f330c9ba2fae303649bf8102d
 
-    w_try_cd "$W_TMP"
-    w_try tar -Jxf "$W_CACHE/vlgothic/VLGothic-20141206.tar.xz"
-    w_try_cp_font_files "$W_TMP/VLGothic" "$W_FONTSDIR_UNIX"
+    w_try_cd "${W_TMP}"
+    w_try tar -Jxf "${W_CACHE}/vlgothic/VLGothic-20141206.tar.xz"
+    w_try_cp_font_files "${W_TMP}/VLGothic" "${W_FONTSDIR_UNIX}"
 
     w_register_font vl-gothic-regular.ttf "VL Gothic"
     w_register_font vl-pgothic-regular.ttf "VL PGothic"
@@ -14275,16 +14275,16 @@ w_metadata wenquanyi fonts \
     year="2009" \
     media="download" \
     file1="wqy-microhei-0.2.0-beta.tar.gz" \
-    installed_file1="$W_FONTSDIR_WIN/wqy-microhei.ttc"
+    installed_file1="${W_FONTSDIR_WIN}/wqy-microhei.ttc"
 
 load_wenquanyi()
 {
     # See http://wenq.org/enindex.cgi
     # Donate at http://wenq.org/enindex.cgi?Download(en)#MicroHei_Beta if you want to help support free CJK font development
     w_download "https://downloads.sourceforge.net/wqy/wqy-microhei-0.2.0-beta.tar.gz" 2802ac8023aa36a66ea6e7445854e3a078d377ffff42169341bd237871f7213e
-    w_try_cd "$W_TMP"
-    w_try tar -zxf "$W_CACHE/$W_PACKAGE/$file1"
-    w_try_cp_font_files "$W_TMP/wqy-microhei" "$W_FONTSDIR_UNIX" "*.ttc"
+    w_try_cd "${W_TMP}"
+    w_try tar -zxf "${W_CACHE}/${W_PACKAGE}/${file1}"
+    w_try_cp_font_files "${W_TMP}/wqy-microhei" "${W_FONTSDIR_UNIX}" "*.ttc"
 
     w_register_font wqy-microhei.ttc "WenQuanYi Micro Hei"
 }
@@ -14297,16 +14297,16 @@ w_metadata wenquanyizenhei fonts \
     year="2009" \
     media="download" \
     file1="wqy-zenhei-0.8.38-1.tar.gz" \
-    installed_file1="$W_FONTSDIR_WIN/wqy-zenhei.ttc"
+    installed_file1="${W_FONTSDIR_WIN}/wqy-zenhei.ttc"
 
 load_wenquanyizenhei()
 {
     # See http://wenq.org/wqy2/index.cgi?ZenHei
     # Donate at http://wenq.org/wqy2/index.cgi?Donation if you want to help support free font development
     w_download "http://downloads.sourceforge.net/wqy/wqy-zenhei-0.8.38-1.tar.gz" 6018eb54243eddc41e9cbe0b71feefa5cb2570ecbaccd39daa025961235dea22
-    w_try_cd "$W_TMP"
-    w_try tar -zxf "$W_CACHE/$W_PACKAGE/$file1"
-    w_try_cp_font_files "$W_TMP/wqy-zenhei" "$W_FONTSDIR_UNIX" "*.ttc"
+    w_try_cd "${W_TMP}"
+    w_try tar -zxf "${W_CACHE}/${W_PACKAGE}/${file1}"
+    w_try_cp_font_files "${W_TMP}/wqy-zenhei" "${W_FONTSDIR_UNIX}" "*.ttc"
 
     w_register_font wqy-zenhei.ttc "WenQuanYi Zen Hei"
 }
@@ -14319,15 +14319,15 @@ w_metadata unifont fonts \
     year="2019" \
     media="download" \
     file1="unifont-12.1.02.ttf" \
-    installed_file1="$W_FONTSDIR_WIN/unifont.ttf"
+    installed_file1="${W_FONTSDIR_WIN}/unifont.ttf"
 
 load_unifont()
 {
     # The GNU Unifont provides glyphs for just about everything in common language.  It is intended for multilingual usage.
     # See http://unifoundry.com/unifont.html for project page
     w_download "http://unifoundry.com/pub/unifont/unifont-12.1.02/font-builds/unifont-12.1.02.ttf" da4961540b9d02e01fb8755924db730db233c360b20ee321fda8ab7d0b9ca549
-    w_try cp "$W_CACHE/$W_PACKAGE/$file1" "$W_TMP/unifont.ttf"
-    w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX"
+    w_try cp "${W_CACHE}/${W_PACKAGE}/${file1}" "${W_TMP}/unifont.ttf"
+    w_try_cp_font_files "${W_TMP}" "${W_FONTSDIR_UNIX}"
 
     w_register_font unifont.ttf "Unifont"
     w_register_font_replacement "Arial Unicode MS" "Unifont"
@@ -14344,16 +14344,16 @@ w_metadata allfonts fonts \
 load_allfonts()
 {
     # This verb uses reflection, should probably do it portably instead, but that would require keeping it up to date
-    for file in "$WINETRICKS_METADATA"/fonts/*.vars; do
-        cmd=$(basename "$file" .vars)
-        case $cmd in
+    for file in "${WINETRICKS_METADATA}"/fonts/*.vars; do
+        cmd=$(basename "${file}" .vars)
+        case ${cmd} in
             # "fake*" verbs need to be skipped because
             # this "allfonts" verb is intended to only install real fonts and
             # adding font replacements at the same time may invalidate the replacements
             # "pptfonts" can be skipped because it only calls other verbs for installing fonts
             # See https://github.com/Winetricks/winetricks/issues/899
             allfonts|cjkfonts|fake*|pptfonts) ;;
-            *) w_call "$cmd";;
+            *) w_call "${cmd}";;
         esac
     done
 }
@@ -14370,14 +14370,14 @@ w_metadata 3m_library apps \
     year="2015" \
     media="download" \
     file1="cloudLibrary-2.1.1702011951-Setup.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/cloudLibrary/cloudLibrary.exe" \
+    installed_exe1="${W_PROGRAMS_X86_WIN}/cloudLibrary/cloudLibrary.exe" \
     homepage="https://www.yourcloudlibrary.com/"
 
 load_3m_library()
 {
     w_download https://usestrwebaccess.blob.core.windows.net/apps/pc/cloudLibrary-2.1.1702011951-Setup.exe bb3d854cc525c065e7298423bf0019309f4b65497c1d8bc6af09460cd6fcb57f
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" "${file1}" ${W_OPT_UNATTENDED:+/S}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+/S}
 }
 
 #----------------------------------------------------------------
@@ -14388,13 +14388,13 @@ w_metadata 7zip apps \
     year="2019" \
     media="download" \
     file1="7z1900.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/7-Zip/7zFM.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/7-Zip/7zFM.exe"
 
 load_7zip()
 {
     w_download https://www.7-zip.org/a/7z1900.exe 759aa04d5b03ebeee13ba01df554e8c962ca339c74f56627c8bed6984bb7ef80
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" "${file1}" ${W_OPT_UNATTENDED:+/S}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+/S}
 }
 
 #----------------------------------------------------------------
@@ -14405,13 +14405,13 @@ w_metadata abiword apps \
     year="2010" \
     media="download" \
     file1="abiword-setup-2.8.6.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/AbiWord/bin/AbiWord.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/AbiWord/bin/AbiWord.exe"
 
 load_abiword()
 {
     w_download https://www.abisource.com/downloads/abiword/2.8.6/Windows/abiword-setup-2.8.6.exe f85c7f32044bbb4d31f1672c86951e35319f8e89fbd6c01ab4c19e960efd9ff8
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" abiword-setup-2.8.6.exe ${W_OPT_UNATTENDED:+/S}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" abiword-setup-2.8.6.exe ${W_OPT_UNATTENDED:+/S}
 }
 
 #----------------------------------------------------------------
@@ -14422,14 +14422,14 @@ w_metadata adobe_diged apps \
     year="2011" \
     media="download" \
     file1="setup.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Adobe/Adobe Digital Editions/digitaleditions.exe" \
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Adobe/Adobe Digital Editions/digitaleditions.exe" \
     homepage="https://www.adobe.com/solutions/ebook/digital-editions.html"
 
 load_adobe_diged()
 {
     w_download https://kb2.adobe.com/cps/403/kb403051/attachments/setup.exe 4ebe0fcefbe68900ca6bf499432030c9f8eb8828f8cb5a7e1fd1a16c0eba918e
     # NSIS installer
-    w_try "$WINE" "$W_CACHE/$W_PACKAGE/setup.exe" ${W_OPT_UNATTENDED:+ /S}
+    w_try "${WINE}" "${W_CACHE}/${W_PACKAGE}/setup.exe" ${W_OPT_UNATTENDED:+ /S}
 }
 
 #----------------------------------------------------------------
@@ -14440,7 +14440,7 @@ w_metadata adobe_diged4 apps \
     year="2015" \
     media="download" \
     file1="ADE_4.5_Installer.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Adobe/Adobe Digital Editions 4.5/DigitalEditions.exe" \
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Adobe/Adobe Digital Editions 4.5/DigitalEditions.exe" \
     homepage="https://www.adobe.com/solutions/ebook/digital-editions.html"
 
 load_adobe_diged4()
@@ -14458,7 +14458,7 @@ load_adobe_diged4()
     w_call dotnet40
 
     #w_call win7
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     if w_workaround_wine_bug 46019 "Installer fails under wine, manually unpacking it instead"; then
         w_try_7z "${W_PROGRAMS_X86_UNIX}/Adobe/Adobe Digital Editions 4.5" "${file1}" -y
     else
@@ -14480,13 +14480,13 @@ w_metadata autohotkey apps \
     year="2010" \
     media="download" \
     file1="AutoHotkey104805_Install.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/AutoHotkey/AutoHotkey.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/AutoHotkey/AutoHotkey.exe"
 
 load_autohotkey()
 {
     w_download https://github.com/AutoHotkey/AutoHotkey/releases/download/v1.0.48.05/AutoHotkey104805_Install.exe 4311c3e7c29ed2d67f415138360210bc2f55ff78758b20b003b91d775ee207b9
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" AutoHotkey104805_Install.exe ${W_OPT_UNATTENDED:+/S}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" AutoHotkey104805_Install.exe ${W_OPT_UNATTENDED:+/S}
 }
 
 #----------------------------------------------------------------
@@ -14504,12 +14504,12 @@ load_busybox()
     # Could use https://frippery.org/files/busybox/busybox.exe, but it hasn't updated in last 3 years..
     w_download https://frippery.org/files/busybox/busybox-w32-FRP-2121-ga316078ad.exe 1bab530f2fd2a9d69528bc2b35ba1f9f75481ae053443b47cb23ad2c2740d887
 
-    if test "$W_ARCH" = "win64"; then
+    if test "${W_ARCH}" = "win64"; then
         w_download https://frippery.org/files/busybox/busybox-w64-FRP-2121-ga316078ad.exe dcb2faf17f996fda8d273d513bc195aec615ef468e3d55b8b4dc9c089b22e035
-        w_try cp "${W_CACHE}/${W_PACKAGE}/${file1}" "$W_SYSTEM32_DLLS/busybox.exe"
-        w_try cp "${W_CACHE}/${W_PACKAGE}/busybox-w64-FRP-2121-ga316078ad.exe" "$W_SYSTEM64_DLLS/busybox.exe"
+        w_try cp "${W_CACHE}/${W_PACKAGE}/${file1}" "${W_SYSTEM32_DLLS}/busybox.exe"
+        w_try cp "${W_CACHE}/${W_PACKAGE}/busybox-w64-FRP-2121-ga316078ad.exe" "${W_SYSTEM64_DLLS}/busybox.exe"
     else
-        w_try cp "${W_CACHE}/${W_PACKAGE}/${file1}" "$W_SYSTEM32_DLLS/busybox.exe"
+        w_try cp "${W_CACHE}/${W_PACKAGE}/${file1}" "${W_SYSTEM32_DLLS}/busybox.exe"
     fi
 }
 
@@ -14521,13 +14521,13 @@ w_metadata cmake apps \
     year="2013" \
     media="download" \
     file1="cmake-2.8.11.2-win32-x86.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/CMake 2.8/bin/cmake-gui.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/CMake 2.8/bin/cmake-gui.exe"
 
 load_cmake()
 {
     w_download https://www.cmake.org/files/v2.8/cmake-2.8.11.2-win32-x86.exe cb6a7df8fd6f2eca66512279991f3c2349e3f788477c3be8eaa362d46c21dbf0
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" cmake-2.8.11.2-win32-x86.exe ${W_OPT_UNATTENDED:+/S}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" cmake-2.8.11.2-win32-x86.exe ${W_OPT_UNATTENDED:+/S}
 }
 
 #----------------------------------------------------------------
@@ -14543,11 +14543,11 @@ w_metadata colorprofile apps \
 load_colorprofile()
 {
     w_download https://download.microsoft.com/download/whistler/hwdev1/1.0/wxp/en-us/ColorProfile.exe d04ac910acdd97abd663f559bebc6440d8d68664bf977ec586035247d7b0f728
-    w_try_unzip "$W_TMP" "$W_CACHE"/colorprofile/ColorProfile.exe
+    w_try_unzip "${W_TMP}" "${W_CACHE}"/colorprofile/ColorProfile.exe
 
     # It's in system32 for both win32/win64
-    mkdir -p "$W_WINDIR_UNIX"/system32/spool/drivers/color
-    w_try cp -f "$W_TMP/sRGB Color Space Profile.icm" "$W_WINDIR_UNIX"/system32/spool/drivers/color
+    mkdir -p "${W_WINDIR_UNIX}"/system32/spool/drivers/color
+    w_try cp -f "${W_TMP}/sRGB Color Space Profile.icm" "${W_WINDIR_UNIX}"/system32/spool/drivers/color
 }
 
 #----------------------------------------------------------------
@@ -14558,21 +14558,21 @@ w_metadata controlpad apps \
     year="1997" \
     media="download" \
     file1="setuppad.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/ActiveX Control Pad/PED.EXE"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/ActiveX Control Pad/PED.EXE"
 
 load_controlpad()
 {
     # https://msdn.microsoft.com/en-us/library/ms968493.aspx
     w_call wsh57
     w_download https://download.microsoft.com/download/activexcontrolpad/install/4.0.0.950/win98mexp/en-us/setuppad.exe eab94091ac391f9bbc8e355a1d231e6a08b8dbbb0f6539245b7f0c58d94f420c
-    w_try_cabextract --directory="$W_TMP" "$W_CACHE"/controlpad/setuppad.exe
+    w_try_cabextract --directory="${W_TMP}" "${W_CACHE}"/controlpad/setuppad.exe
 
     echo "If setup says 'Unable to start DDE ...', press Ignore"
 
-    w_try_cd "$W_TMP"
-    w_try "$WINE" setup ${W_OPT_UNATTENDED:+/qt}
+    w_try_cd "${W_TMP}"
+    w_try "${WINE}" setup ${W_OPT_UNATTENDED:+/qt}
 
-    if ! test -f "$W_SYSTEM32_DLLS"/FM20.DLL; then
+    if ! test -f "${W_SYSTEM32_DLLS}"/FM20.DLL; then
         w_die "Install failed.  Please report,  If you just wanted fm20.dll, try installing art2min instead."
     fi
 }
@@ -14585,7 +14585,7 @@ w_metadata controlspy apps \
     year="2005" \
     media="download" \
     file1="ControlSpyV6.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Microsoft/ControlSpy/ControlSpyV6.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Microsoft/ControlSpy/ControlSpyV6.exe"
 
 load_controlspy()
 {
@@ -14607,7 +14607,7 @@ w_metadata dxdiag dlls \
     year="2010" \
     media="download" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/dxdiag.exe"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/dxdiag.exe"
 
 load_dxdiag()
 {
@@ -14615,10 +14615,10 @@ load_dxdiag()
 
     w_call gmdls
 
-    w_try_cabextract -d "$W_TMP" -L -F dxnt.cab "$W_CACHE"/directx9/$DIRECTX_NAME
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F "dxdiag.exe" "$W_TMP/dxnt.cab"
-    mkdir -p "$W_WINDIR_UNIX/help"
-    w_try_cabextract -d "$W_WINDIR_UNIX/help" -L -F "dxdiag.chm" "$W_TMP/dxnt.cab"
+    w_try_cabextract -d "${W_TMP}" -L -F dxnt.cab "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F "dxdiag.exe" "${W_TMP}/dxnt.cab"
+    mkdir -p "${W_WINDIR_UNIX}/help"
+    w_try_cabextract -d "${W_WINDIR_UNIX}/help" -L -F "dxdiag.chm" "${W_TMP}/dxnt.cab"
     w_override_dlls native dxdiag.exe
 
     if w_workaround_wine_bug 1429; then
@@ -14648,8 +14648,8 @@ load_emu8086()
     # 2018/11/15: emu8086.com is down
     # w_download http://www.emu8086.com/files/emu8086v408r11.zip d56d6e42fe170c52df5abd6002b1e8fef0b840eb8d8807d77819fe1fc2e17afd
     w_download https://web.archive.org/web/20160206003914if_/http://emu8086.com/files/emu8086v408r11.zip d56d6e42fe170c52df5abd6002b1e8fef0b840eb8d8807d77819fe1fc2e17afd
-    w_try_unzip "$W_TMP" "$W_CACHE/$W_PACKAGE/$file1"
-    w_try "$WINE" "$W_TMP/Setup.exe" ${W_OPT_UNATTENDED:+/silent}
+    w_try_unzip "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${file1}"
+    w_try "${WINE}" "${W_TMP}/Setup.exe" ${W_OPT_UNATTENDED:+/silent}
 }
 
 #----------------------------------------------------------------
@@ -14660,7 +14660,7 @@ w_metadata ev3 apps \
     year="2014" \
     media="download" \
     file1="LMS-EV3-WIN32-ENUS-01-02-01-full-setup.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/LEGO Software/LEGO MINDSTORMS EV3 Home Edition/MindstormsEV3.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/LEGO Software/LEGO MINDSTORMS EV3 Home Edition/MindstormsEV3.exe"
 
 load_ev3()
 {
@@ -14678,8 +14678,8 @@ load_ev3()
 
     w_download http://esd.lego.com.edgesuite.net/digitaldelivery/mindstorms/6ecda7c2-1189-4816-b2dd-440e22d65814/public/LMS-EV3-WIN32-ENUS-01-02-01-full-setup.exe c47341f08242f0f6f01996530e7c93bda2d666747ada60ab93fa773a55d40a19
 
-    w_try_cd "$W_CACHE"/"$W_PACKAGE"
-    w_try "$WINE" "$file1" ${W_OPT_UNATTENDED:+/qb /AcceptLicenses yes}
+    w_try_cd "${W_CACHE}"/"${W_PACKAGE}"
+    w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+/qb /AcceptLicenses yes}
 
     if w_workaround_wine_bug 40729 "Setting override for urlmon.dll to native to avoid crash"; then
         w_override_dlls native urlmon
@@ -14694,13 +14694,13 @@ w_metadata firefox apps \
     year="2017" \
     media="download" \
     file1="FirefoxSetup51.0.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Mozilla Firefox/firefox.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Mozilla Firefox/firefox.exe"
 
 load_firefox()
 {
-    w_download "https://download.mozilla.org/?product=firefox-51.0-SSL&os=win&lang=en-US" 05fa9ae012eca560f42d593e75eb37045a54e4978b665b51f6a61e4a2d376eb8 "$file1"
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" "$file1" ${W_OPT_UNATTENDED:+ -ms}
+    w_download "https://download.mozilla.org/?product=firefox-51.0-SSL&os=win&lang=en-US" 05fa9ae012eca560f42d593e75eb37045a54e4978b665b51f6a61e4a2d376eb8 "${file1}"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+ -ms}
 }
 
 #----------------------------------------------------------------
@@ -14711,7 +14711,7 @@ w_metadata fontxplorer apps \
     year="2001" \
     media="download" \
     file1="Font_Xplorer_122_Free.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/Font Xplorer/FXplorer.exe" \
+    installed_file1="${W_PROGRAMS_X86_WIN}/Font Xplorer/FXplorer.exe" \
     homepage="http://www.moonsoftware.com/fxplorer.asp"
 
 load_fontxplorer()
@@ -14719,8 +14719,8 @@ load_fontxplorer()
     # 2011/05/15: http://www.moonsoftware.com/files/legacy/Font_Xplorer_122_Free.exe e3a53841c133e2ecfeb75c7ea277e23011317bb031f8caf423b7e9b7f92d85e0
     # 2019/06/14: http://www.moonsoftware.com/files/legacy/Font_Xplorer_122_Free.exe is dead
     w_download https://web.archive.org/web/20190217101943/http://www.moonsoftware.com/files/legacy/Font_Xplorer_122_Free.exe e3a53841c133e2ecfeb75c7ea277e23011317bb031f8caf423b7e9b7f92d85e0
-    w_try_cd "$W_CACHE/fontxplorer"
-    w_try "$WINE" Font_Xplorer_122_Free.exe ${W_OPT_UNATTENDED:+/S}
+    w_try_cd "${W_CACHE}/fontxplorer"
+    w_try "${WINE}" Font_Xplorer_122_Free.exe ${W_OPT_UNATTENDED:+/S}
     w_killall "explorer.exe"
 }
 
@@ -14732,7 +14732,7 @@ w_metadata foobar2000 apps \
     year="2018" \
     media="manual_download" \
     file1="foobar2000_v1.4.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/foobar2000/foobar2000.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/foobar2000/foobar2000.exe"
 
 load_foobar2000()
 {
@@ -14740,8 +14740,8 @@ load_foobar2000()
     # 2018/07/25: 1.4    - 7c048faecfec79f9ec2b332b2c68b25e0d0219b47a7c679fe56f2ec05686a96a
 
     w_download_manual https://www.foobar2000.org/download foobar2000_v1.4.exe 7c048faecfec79f9ec2b332b2c68b25e0d0219b47a7c679fe56f2ec05686a96a
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" "$file1" ${W_OPT_UNATTENDED:+/S}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+/S}
 }
 
 #----------------------------------------------------------------
@@ -14752,7 +14752,7 @@ w_metadata hhw apps \
     year="2000" \
     media="download" \
     file1="htmlhelp.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/HTML Help Workshop/hhw.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/HTML Help Workshop/hhw.exe"
 
 load_hhw()
 {
@@ -14771,10 +14771,10 @@ load_hhw()
     #   1. Run htmlhelp.exe to unpack its contents
     #   2. Edit htmlhelp.inf not to run hhupd.exe
     #   3. Run setup.exe
-    w_try "$WINE" "$W_CACHE/$W_PACKAGE"/htmlhelp.exe /C "/T:$W_TMP_WIN" ${W_OPT_UNATTENDED:+/q}
-    w_try_cd "$W_TMP"
+    w_try "${WINE}" "${W_CACHE}/${W_PACKAGE}"/htmlhelp.exe /C "/T:${W_TMP_WIN}" ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_TMP}"
     w_try sed -i "s/RunPostSetupCommands=HHUpdate//" htmlhelp.inf
-    w_try "$WINE" setup.exe
+    w_try "${WINE}" setup.exe
 
     if w_workaround_wine_bug 7517; then
         w_call itircl
@@ -14790,7 +14790,7 @@ w_metadata iceweasel apps \
     year="2015" \
     media="download" \
     file1="icecat-31.7.0.en-US.win32.zip" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/icecat/icecat.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/icecat/icecat.exe"
 
 load_iceweasel()
 {
@@ -14807,7 +14807,7 @@ w_metadata irfanview apps \
     year="2016" \
     media="download" \
     file1="iview444_setup.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/IrfanView/i_view32.exe" \
+    installed_file1="${W_PROGRAMS_X86_WIN}/IrfanView/i_view32.exe" \
     homepage="https://www.irfanview.com/"
 
 load_irfanview()
@@ -14817,12 +14817,12 @@ load_irfanview()
         w_call mfc42
     fi
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    if test "$W_OPT_UNATTENDED"; then
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    if test "${W_OPT_UNATTENDED}"; then
         w_ahk_do "
             SetWinDelay 200
             SetTitleMatchMode, 2
-            run $file1
+            run ${file1}
             winwait, Setup, This program will install
             winactivate, Setup, This program will install
             Sleep 900
@@ -14863,7 +14863,7 @@ load_irfanview()
             winwaitclose
         "
     else
-        w_try "$WINE" "$file1"
+        w_try "${WINE}" "${file1}"
     fi
 }
 
@@ -14886,23 +14886,23 @@ load_ie6()
 
     w_download https://web.archive.org/web/20150411022055if_/http://download.oldapps.com/Internet_Explorer/ie60.exe e34e0557d939e7e83185f5354403df99c92a3f3ff80f5ee0c75f6843eaa6efb2
 
-    w_try_cd "$W_TMP"
-    "$WINE" "$W_CACHE/$W_PACKAGE/$file1"
+    w_try_cd "${W_TMP}"
+    "${WINE}" "${W_CACHE}/${W_PACKAGE}/${file1}"
 
     # Unregister Wine IE
-    if [ ! -f "$W_SYSTEM32_DLLS"/plugin.ocx ]; then
+    if [ ! -f "${W_SYSTEM32_DLLS}"/plugin.ocx ]; then
         w_override_dlls builtin iexplore.exe
-        w_try "$WINE" iexplore -unregserver
+        w_try "${WINE}" iexplore -unregserver
     fi
 
     # Change the override to the native so we are sure we use and register them
     w_override_dlls native,builtin iexplore.exe inetcpl.cpl itircl itss jscript mlang mshtml msimtf shdoclc shdocvw shlwapi
 
     # Remove the fake DLLs, if any
-    mv "$W_PROGRAMS_UNIX/Internet Explorer/iexplore.exe" "$W_PROGRAMS_UNIX/Internet Explorer/iexplore.exe.bak"
+    mv "${W_PROGRAMS_UNIX}/Internet Explorer/iexplore.exe" "${W_PROGRAMS_UNIX}/Internet Explorer/iexplore.exe.bak"
     for dll in itircl itss jscript mlang mshtml msimtf shdoclc shdocvw shlwapi; do
-        test -f "$W_SYSTEM32_DLLS"/$dll.dll &&
-        mv "$W_SYSTEM32_DLLS"/$dll.dll "$W_SYSTEM32_DLLS"/$dll.dll.bak
+        test -f "${W_SYSTEM32_DLLS}"/${dll}.dll &&
+        mv "${W_SYSTEM32_DLLS}"/${dll}.dll "${W_SYSTEM32_DLLS}"/${dll}.dll.bak
     done
 
     # The installer doesn't want to install iexplore.exe in XP mode.
@@ -14911,22 +14911,22 @@ load_ie6()
     # Workaround https://bugs.winehq.org/show_bug.cgi?id=21009
     # FIXME: seems this didn't get migrated to Github?
     # See also https://code.google.com/p/winezeug/issues/detail?id=78
-    rm -f "$W_SYSTEM32_DLLS"/browseui.dll "$W_SYSTEM32_DLLS"/inseng.dll
+    rm -f "${W_SYSTEM32_DLLS}"/browseui.dll "${W_SYSTEM32_DLLS}"/inseng.dll
 
     # Otherwise regsvr32 crashes later
-    rm -f "$W_SYSTEM32_DLLS"/inetcpl.cpl
+    rm -f "${W_SYSTEM32_DLLS}"/inetcpl.cpl
 
     # Work around https://bugs.winehq.org/show_bug.cgi?id=25432
-    w_try_cabextract -F inseng.dll "$W_TMP/IE 6.0 Full/ACTSETUP.CAB"
-    mv inseng.dll "$W_SYSTEM32_DLLS"
+    w_try_cabextract -F inseng.dll "${W_TMP}/IE 6.0 Full/ACTSETUP.CAB"
+    mv inseng.dll "${W_SYSTEM32_DLLS}"
     w_override_dlls native inseng
 
-    w_try_cd "$W_TMP/IE 6.0 Full"
-    w_try_ms_installer "$WINE" IE6SETUP.EXE ${W_OPT_UNATTENDED:+/q:a /r:n /c:"ie6wzd /S:""#e"" /q:a /r:n"}
+    w_try_cd "${W_TMP}/IE 6.0 Full"
+    w_try_ms_installer "${WINE}" IE6SETUP.EXE ${W_OPT_UNATTENDED:+/q:a /r:n /c:"ie6wzd /S:""#e"" /q:a /r:n"}
 
     # Work around DLL registration bug until ierunonce/RunOnce/wineboot is fixed
     # FIXME: whittle down this list
-    w_try_cd "$W_SYSTEM32_DLLS"
+    w_try_cd "${W_SYSTEM32_DLLS}"
     for i in actxprxy.dll browseui.dll browsewm.dll cdfview.dll ddraw.dll \
         dispex.dll dsound.dll iedkcs32.dll iepeers.dll iesetup.dll imgutil.dll \
         inetcomm.dll inetcpl.cpl inseng.dll isetup.dll jscript.dll laprxy.dll \
@@ -14937,7 +14937,7 @@ load_ie6()
         shdocvw.dll shell32.dll vbscript.dll webcheck.dll \
         wshcon.dll wshext.dll asctrls.ocx hhctrl.ocx mscomct2.ocx \
         plugin.ocx proctexe.ocx tdc.ocx webcheck.dll wshom.ocx; do
-        "$WINE" regsvr32 /i $i > /dev/null 2>&1
+        "${WINE}" regsvr32 /i ${i} > /dev/null 2>&1
     done
 
     # Set Windows version back to the default. Leave at win2k for better rendering (is there a bug for that?)
@@ -14965,9 +14965,9 @@ load_ie7()
     w_package_unsupported_win64
 
     # Unregister Wine IE
-    if grep -q -i "wine placeholder" "$W_PROGRAMS_X86_UNIX/Internet Explorer/iexplore.exe"; then
+    if grep -q -i "wine placeholder" "${W_PROGRAMS_X86_UNIX}/Internet Explorer/iexplore.exe"; then
         w_override_dlls builtin iexplore.exe
-        w_try "$WINE" iexplore -unregserver
+        w_try "${WINE}" iexplore -unregserver
     fi
 
     # Change the override to the native so we are sure we use and register them
@@ -14980,12 +14980,12 @@ load_ie7()
     w_override_dlls builtin updspapi
 
     # Remove the fake DLLs from the existing WINEPREFIX
-    if [ -f "$W_PROGRAMS_X86_UNIX/Internet Explorer/iexplore.exe" ]; then
-        mv "$W_PROGRAMS_X86_UNIX/Internet Explorer/iexplore.exe" "$W_PROGRAMS_X86_UNIX/Internet Explorer/iexplore.exe.bak"
+    if [ -f "${W_PROGRAMS_X86_UNIX}/Internet Explorer/iexplore.exe" ]; then
+        mv "${W_PROGRAMS_X86_UNIX}/Internet Explorer/iexplore.exe" "${W_PROGRAMS_X86_UNIX}/Internet Explorer/iexplore.exe.bak"
     fi
     for dll in itircl itss jscript mshtml msimtf shdoclc shdocvw shlwapi urlmon; do
-        test -f "$W_SYSTEM32_DLLS"/$dll.dll &&
-        mv "$W_SYSTEM32_DLLS"/$dll.dll "$W_SYSTEM32_DLLS"/$dll.dll.bak
+        test -f "${W_SYSTEM32_DLLS}"/${dll}.dll &&
+        mv "${W_SYSTEM32_DLLS}"/${dll}.dll "${W_SYSTEM32_DLLS}"/${dll}.dll.bak
     done
 
     # See https://bugs.winehq.org/show_bug.cgi?id=16013
@@ -14993,15 +14993,15 @@ load_ie7()
     w_download https://github.com/Winetricks/winetricks/raw/master/files/winetest.cat 5d18ab44fc289100ccf4b51cf614cc2d36f7ca053e557e2ba973811293c97d38
 
     # Put a dummy catalog file in place
-    mkdir -p "$W_SYSTEM32_DLLS"/catroot/\{f750e6c3-38ee-11d1-85e5-00c04fc295ee\}
-    w_try cp -f "$W_CACHE"/ie7/winetest.cat "$W_SYSTEM32_DLLS"/catroot/\{f750e6c3-38ee-11d1-85e5-00c04fc295ee\}/oem0.cat
+    mkdir -p "${W_SYSTEM32_DLLS}"/catroot/\{f750e6c3-38ee-11d1-85e5-00c04fc295ee\}
+    w_try cp -f "${W_CACHE}"/ie7/winetest.cat "${W_SYSTEM32_DLLS}"/catroot/\{f750e6c3-38ee-11d1-85e5-00c04fc295ee\}/oem0.cat
 
     # KLUDGE: if / is writable (as on OS X?), having a Z: mapping to it
     # causes ie7 to put temporary directories on Z:\.
     # So hide it temporarily.  This is not very robust!
-    if [ -w / ] && [ -h "$WINEPREFIX/dosdevices/z:" ]; then
-        w_try rm -f "$WINEPREFIX/dosdevices/z:.bak_wt"
-        w_try mv "$WINEPREFIX/dosdevices/z:" "$WINEPREFIX/dosdevices/z:.bak_wt"
+    if [ -w / ] && [ -h "${WINEPREFIX}/dosdevices/z:" ]; then
+        w_try rm -f "${WINEPREFIX}/dosdevices/z:.bak_wt"
+        w_try mv "${WINEPREFIX}/dosdevices/z:" "${WINEPREFIX}/dosdevices/z:.bak_wt"
         _W_restore_z=1
     fi
 
@@ -15009,21 +15009,21 @@ load_ie7()
     # Microsoft took this down (as of 2020/08/08), but the latest snapshot on archive.org (2020/06/20) gives a different binary.
     # The snapshot just before that (2020/06/17) is fine, however:
     w_download https://web.archive.org/web/20200617171343/https://download.microsoft.com/download/3/8/8/38889DC1-848C-4BF2-8335-86C573AD86D9/IE7-WindowsXP-x86-enu.exe bf5c325bbe3f4174869b2a8ff75f92833e7f7debe64777ed0faf293c7725cbef
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
     # IE7 requies winxp to install:
     w_set_winver winxp
 
-    w_try_ms_installer "$WINE" IE7-WindowsXP-x86-enu.exe ${W_OPT_UNATTENDED:+/quiet}
+    w_try_ms_installer "${WINE}" IE7-WindowsXP-x86-enu.exe ${W_OPT_UNATTENDED:+/quiet}
 
-    if [ "$_W_restore_z" = 1 ]; then
+    if [ "${_W_restore_z}" = 1 ]; then
         # END KLUDGE: restore Z:, assuming that the user didn't kill us
-        w_try mv "$WINEPREFIX/dosdevices/z:.bak_wt" "$WINEPREFIX/dosdevices/z:"
+        w_try mv "${WINEPREFIX}/dosdevices/z:.bak_wt" "${WINEPREFIX}/dosdevices/z:"
     fi
 
     # Work around DLL registration bug until ierunonce/RunOnce/wineboot is fixed
     # FIXME: whittle down this list
-    w_try_cd "$W_SYSTEM32_DLLS"
+    w_try_cd "${W_SYSTEM32_DLLS}"
     for i in actxprxy.dll browseui.dll browsewm.dll cdfview.dll ddraw.dll \
         dispex.dll dsound.dll iedkcs32.dll iepeers.dll iesetup.dll \
         imgutil.dll inetcomm.dll inseng.dll isetup.dll jscript.dll laprxy.dll \
@@ -15034,23 +15034,23 @@ load_ie7()
         shdocvw.dll shell32.dll urlmon.dll vbscript.dll webcheck.dll \
         wshcon.dll wshext.dll asctrls.ocx hhctrl.ocx mscomct2.ocx \
         plugin.ocx proctexe.ocx tdc.ocx webcheck.dll wshom.ocx; do
-        "$WINE" regsvr32 /i $i > /dev/null 2>&1
+        "${WINE}" regsvr32 /i ${i} > /dev/null 2>&1
     done
 
     # Builtin ieproxy is in system32, but ie7's lives in Program Files. Native
     # CLSID path will get overwritten on prefix update. Setting ieproxy to
     # native doesn't help because setupapi ignores DLL overrides. To work
     # around this problem, copy native ieproxy to system32.
-    w_try cp -f "${W_PROGRAMS_X86_UNIX}/Internet Explorer/ieproxy.dll" "$W_SYSTEM32_DLLS"
+    w_try cp -f "${W_PROGRAMS_X86_UNIX}/Internet Explorer/ieproxy.dll" "${W_SYSTEM32_DLLS}"
 
     # Seeing is believing
-    case $WINETRICKS_GUI in
+    case ${WINETRICKS_GUI} in
         none)
-            w_warn "To start ie7, use the command \"$WINE\" '${W_PROGRAMS_WIN}\\\\Internet Explorer\\\\iexplore'"
+            w_warn "To start ie7, use the command \"${WINE}\" '${W_PROGRAMS_WIN}\\\\Internet Explorer\\\\iexplore'"
             ;;
         *)
-            w_warn "Starting ie7.  To start it later, use the command \"$WINE\" '${W_PROGRAMS_WIN}\\\\Internet Explorer\\\\iexplore'"
-            "$WINE" "${W_PROGRAMS_WIN}\\Internet Explorer\\iexplore" https://www.microsoft.com/windows/internet-explorer/ie7/ > /dev/null 2>&1 &
+            w_warn "Starting ie7.  To start it later, use the command \"${WINE}\" '${W_PROGRAMS_WIN}\\\\Internet Explorer\\\\iexplore'"
+            "${WINE}" "${W_PROGRAMS_WIN}\\Internet Explorer\\iexplore" https://www.microsoft.com/windows/internet-explorer/ie7/ > /dev/null 2>&1 &
             ;;
     esac
 
@@ -15077,10 +15077,10 @@ load_ie8()
     w_set_winver winxp
 
     # Unregister Wine IE
-    #if [ ! -f "$W_SYSTEM32_DLLS"/plugin.ocx ]; then
-    if grep -q -i "wine placeholder" "$W_PROGRAMS_X86_UNIX/Internet Explorer/iexplore.exe"; then
+    #if [ ! -f "${W_SYSTEM32_DLLS}"/plugin.ocx ]; then
+    if grep -q -i "wine placeholder" "${W_PROGRAMS_X86_UNIX}/Internet Explorer/iexplore.exe"; then
         w_override_dlls builtin iexplore.exe
-        w_try "$WINE" iexplore -unregserver
+        w_try "${WINE}" iexplore -unregserver
     fi
 
     w_call msls31
@@ -15095,13 +15095,13 @@ load_ie8()
     w_override_dlls builtin updspapi
 
     # Remove the fake DLLs from the existing WINEPREFIX
-    if [ -f "$W_PROGRAMS_X86_UNIX/Internet Explorer/iexplore.exe" ]; then
-        w_try mv "$W_PROGRAMS_X86_UNIX/Internet Explorer/iexplore.exe" "$W_PROGRAMS_X86_UNIX/Internet Explorer/iexplore.exe.bak"
+    if [ -f "${W_PROGRAMS_X86_UNIX}/Internet Explorer/iexplore.exe" ]; then
+        w_try mv "${W_PROGRAMS_X86_UNIX}/Internet Explorer/iexplore.exe" "${W_PROGRAMS_X86_UNIX}/Internet Explorer/iexplore.exe.bak"
     fi
 
     for dll in browseui inseng itircl itss jscript msctf mshtml shdoclc shdocvw shlwapi urlmon; do
-        test -f "$W_SYSTEM32_DLLS"/$dll.dll &&
-            w_try mv "$W_SYSTEM32_DLLS"/$dll.dll "$W_SYSTEM32_DLLS"/$dll.dll.bak
+        test -f "${W_SYSTEM32_DLLS}"/${dll}.dll &&
+            w_try mv "${W_SYSTEM32_DLLS}"/${dll}.dll "${W_SYSTEM32_DLLS}"/${dll}.dll.bak
     done
 
     # See https://bugs.winehq.org/show_bug.cgi?id=16013
@@ -15109,35 +15109,35 @@ load_ie8()
     w_download https://github.com/Winetricks/winetricks/raw/master/files/winetest.cat 5d18ab44fc289100ccf4b51cf614cc2d36f7ca053e557e2ba973811293c97d38
 
     # Put a dummy catalog file in place
-    mkdir -p "$W_SYSTEM32_DLLS"/catroot/\{f750e6c3-38ee-11d1-85e5-00c04fc295ee\}
-    w_try cp -f "$W_CACHE"/ie8/winetest.cat "$W_SYSTEM32_DLLS"/catroot/\{f750e6c3-38ee-11d1-85e5-00c04fc295ee\}/oem0.cat
+    mkdir -p "${W_SYSTEM32_DLLS}"/catroot/\{f750e6c3-38ee-11d1-85e5-00c04fc295ee\}
+    w_try cp -f "${W_CACHE}"/ie8/winetest.cat "${W_SYSTEM32_DLLS}"/catroot/\{f750e6c3-38ee-11d1-85e5-00c04fc295ee\}/oem0.cat
 
     w_download https://download.microsoft.com/download/C/C/0/CC0BD555-33DD-411E-936B-73AC6F95AE11/IE8-WindowsXP-x86-ENU.exe 5a2c6c82774bfe99b175f50a05b05bcd1fac7e9d0e54db2534049209f50cd6ef
 
     # KLUDGE: if / is writable (as on OS X?), having a Z: mapping to it
     # causes ie7 to put temporary directories on Z:\.
     # So hide it temporarily.  This is not very robust!
-    if [ -w / ] && [ -h "$WINEPREFIX/dosdevices/z:" ]; then
-        w_try rm -f "$WINEPREFIX/dosdevices/z:.bak_wt"
-        w_try mv "$WINEPREFIX/dosdevices/z:" "$WINEPREFIX/dosdevices/z:.bak_wt"
+    if [ -w / ] && [ -h "${WINEPREFIX}/dosdevices/z:" ]; then
+        w_try rm -f "${WINEPREFIX}/dosdevices/z:.bak_wt"
+        w_try mv "${WINEPREFIX}/dosdevices/z:" "${WINEPREFIX}/dosdevices/z:.bak_wt"
         _W_restore_z=1
     fi
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
     # FIXME: There's an option for /updates-noupdates to disable checking for updates, but that
     # forces the install to fail on Wine. Not sure if it's an IE8 or Wine bug...
     # FIXME: can't check status, as it always reports failure on wine?
-    "$WINE" IE8-WindowsXP-x86-ENU.exe ${W_OPT_UNATTENDED:+/quiet /forcerestart}
+    "${WINE}" IE8-WindowsXP-x86-ENU.exe ${W_OPT_UNATTENDED:+/quiet /forcerestart}
 
-    if [ "$_W_restore_z" = 1 ]; then
+    if [ "${_W_restore_z}" = 1 ]; then
         # END KLUDGE: restore Z:, assuming that the user didn't kill us
-        w_try mv "$WINEPREFIX/dosdevices/z:.bak_wt" "$WINEPREFIX/dosdevices/z:"
+        w_try mv "${WINEPREFIX}/dosdevices/z:.bak_wt" "${WINEPREFIX}/dosdevices/z:"
     fi
 
     # Work around DLL registration bug until ierunonce/RunOnce/wineboot is fixed
     # FIXME: whittle down this list
-    w_try_cd "$W_SYSTEM32_DLLS"
+    w_try_cd "${W_SYSTEM32_DLLS}"
     for i in actxprxy.dll browseui.dll browsewm.dll cdfview.dll ddraw.dll \
         dispex.dll dsound.dll iedkcs32.dll iepeers.dll iesetup.dll \
         imgutil.dll inetcomm.dll isetup.dll jscript.dll laprxy.dll \
@@ -15148,34 +15148,34 @@ load_ie8()
         shdocvw.dll shell32.dll urlmon.dll vbscript.dll webcheck.dll \
         wshcon.dll wshext.dll asctrls.ocx hhctrl.ocx mscomct2.ocx \
         plugin.ocx proctexe.ocx tdc.ocx uxtheme.dll webcheck.dll wshom.ocx; do
-        "$WINE" regsvr32 /i $i > /dev/null 2>&1
+        "${WINE}" regsvr32 /i ${i} > /dev/null 2>&1
     done
 
     if w_workaround_wine_bug 25648 "Setting TabProcGrowth=0 to avoid hang"; then
-        cat > "$W_TMP"/set-tabprocgrowth.reg <<_EOF_
+        cat > "${W_TMP}"/set-tabprocgrowth.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Microsoft\\Internet Explorer\\Main]
 "TabProcGrowth"=dword:00000000
 
 _EOF_
-        w_try_regedit "$W_TMP_WIN"\\set-tabprocgrowth.reg
+        w_try_regedit "${W_TMP_WIN}"\\set-tabprocgrowth.reg
     fi
 
     # Builtin ieproxy is in system32, but ie8's lives in Program Files. Native
     # CLSID path will get overwritten on prefix update. Setting ieproxy to
     # native doesn't help because setupapi ignores DLL overrides. To work
     # around this problem, copy native ieproxy to system32.
-    w_try cp -f "${W_PROGRAMS_X86_UNIX}/Internet Explorer/ieproxy.dll" "$W_SYSTEM32_DLLS"
+    w_try cp -f "${W_PROGRAMS_X86_UNIX}/Internet Explorer/ieproxy.dll" "${W_SYSTEM32_DLLS}"
 
     # Seeing is believing
-    case $WINETRICKS_GUI in
+    case ${WINETRICKS_GUI} in
         none)
-            w_warn "To start ie8, use the command \"$WINE\" '${W_PROGRAMS_WIN}\\\\Internet Explorer\\\\iexplore'"
+            w_warn "To start ie8, use the command \"${WINE}\" '${W_PROGRAMS_WIN}\\\\Internet Explorer\\\\iexplore'"
             ;;
         *)
-            w_warn "Starting ie8.  To start it later, use the command \"$WINE\" '${W_PROGRAMS_WIN}\\\\Internet Explorer\\\\iexplore'"
-            "$WINE" "${W_PROGRAMS_WIN}\\Internet Explorer\\iexplore" https://www.microsoft.com/windows/internet-explorer > /dev/null 2>&1 &
+            w_warn "Starting ie8.  To start it later, use the command \"${WINE}\" '${W_PROGRAMS_WIN}\\\\Internet Explorer\\\\iexplore'"
+            "${WINE}" "${W_PROGRAMS_WIN}\\Internet Explorer\\iexplore" https://www.microsoft.com/windows/internet-explorer > /dev/null 2>&1 &
             ;;
     esac
 
@@ -15192,7 +15192,7 @@ w_metadata kindle apps \
     year="2017" \
     media="download" \
     file1="KindleForPC-installer-1.16.44025.exe" \
-    installed_exe1="$W_PROGRAMS_WIN/Amazon/Kindle/Kindle.exe" \
+    installed_exe1="${W_PROGRAMS_WIN}/Amazon/Kindle/Kindle.exe" \
     homepage="https://www.amazon.com/kindle-dbs/fd/kcp"
 
 load_kindle()
@@ -15203,11 +15203,11 @@ load_kindle()
 
     # Originally at: https://s3.amazonaws.com/kindleforpc/44025/KindleForPC-installer-1.16.44025.exe
     w_download https://web.archive.org/web/20160817182927/https://s3.amazonaws.com/kindleforpc/44025/KindleForPC-installer-1.16.44025.exe 2655fa8be7b8f4659276c46ef9f3fede847135bf6e5c1de136c9de7af6cac1e2
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" "$file1" ${W_OPT_UNATTENDED:+ /S}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+ /S}
 
-    if w_workaround_wine_bug 35041 && [ -n "$W_TASKSET" ] ; then
-        w_warn "You may need to run with $W_TASKSET to avoid a libX11 crash."
+    if w_workaround_wine_bug 35041 && [ -n "${W_TASKSET}" ] ; then
+        w_warn "You may need to run with ${W_TASKSET} to avoid a libX11 crash."
     fi
 
     if w_workaround_wine_bug 29045; then
@@ -15225,14 +15225,14 @@ w_metadata kobo apps \
     year="2011" \
     media="download" \
     file1="KoboSetup.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Kobo/Kobo.exe" \
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Kobo/Kobo.exe" \
     homepage="http://www.borders.com/online/store/MediaView_ereaderapps"
 
 load_kobo()
 {
     w_download http://download.kobobooks.com/desktop/1/KoboSetup.exe 721e76c06820058422f06420400a0b1286662196d6178d70c4592fd8034704c4
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" "$file1" ${W_OPT_UNATTENDED:+ /S}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+ /S}
 }
 
 #----------------------------------------------------------------
@@ -15250,13 +15250,13 @@ load_mingw()
 {
     w_download "https://downloads.sourceforge.net/mingw/files/mingw-get-setup.exe" aab27bd5547d35dc159288f3b5b8760f21b0cfec86e8f0032b49dd0410f232bc
 
-    if test "$W_OPT_UNATTENDED"; then
+    if test "${W_OPT_UNATTENDED}"; then
         w_info "FYI: Quiet mode will install these mingw packages: 'gcc msys-base'"
     fi
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
-        run, $file1
+        run, ${file1}
         WinWait, MinGW Installation Manager Setup Tool
         if ( w_opt_unattended > 0 ) {
             WinActivate
@@ -15282,8 +15282,8 @@ load_mingw()
     "
 
     w_append_path 'C:\MinGW\bin'
-    w_try "$WINE" mingw-get update
-    w_try "$WINE" mingw-get install gcc msys-base
+    w_try "${WINE}" mingw-get update
+    w_try "${WINE}" mingw-get install gcc msys-base
 }
 
 #----------------------------------------------------------------
@@ -15300,8 +15300,8 @@ w_metadata mozillabuild apps \
 load_mozillabuild()
 {
     w_download https://ftp.mozilla.org/pub/mozilla.org/mozilla/libraries/win32/MozillaBuildSetup-2.0.0.exe d5ffe52fe634fb7ed02e61041cc183c3af92039ee74e794f7ae83a408e4cf3f5
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" MozillaBuildSetup-2.0.0.exe ${W_OPT_UNATTENDED:+/S}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" MozillaBuildSetup-2.0.0.exe ${W_OPT_UNATTENDED:+/S}
 }
 
 #----------------------------------------------------------------
@@ -15312,14 +15312,14 @@ w_metadata mpc apps \
     year="2014" \
     media="download" \
     file1="MPC-HC.1.7.5.x86.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/MPC-HC/mpc-hc.exe" \
+    installed_file1="${W_PROGRAMS_X86_WIN}/MPC-HC/mpc-hc.exe" \
     homepage="https://mpc-hc.sourceforge.io/"
 
 load_mpc()
 {
     w_download https://downloads.sourceforge.net/project/mpc-hc/MPC%20HomeCinema%20-%20Win32/MPC-HC_v1.7.5_x86/MPC-HC.1.7.5.x86.exe 1d690da5b330f723aea4a294d478828395d321b59fc680f2b971e8b16b8bd33d
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" MPC-HC.1.7.5.x86.exe ${W_OPT_UNATTENDED:+ /VERYSILENT}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" MPC-HC.1.7.5.x86.exe ${W_OPT_UNATTENDED:+ /VERYSILENT}
 }
 
 #----------------------------------------------------------------
@@ -15341,8 +15341,8 @@ load_mspaint()
     # Originally at: https://download.microsoft.com/download/0/A/4/0A40DF5C-2BAE-4C63-802A-84C33B34AC98/WindowsXP-KB978706-x86-ENU.exe
     # Mirror list: http://www.filewatcher.com/_/?q=WindowsXP-KB978706-x86-ENU.exe
     w_download http://download.windowsupdate.com/msdownload/update/software/secu/2010/01/windowsxp-kb978706-x86-enu_f4e076b3867c2f08b6d258316aa0e11d6822b8d7.exe 93ed34ab6c0d01a323ce10992d1c1ca27d1996fef82f0864d83e7f5ac6f9b24b
-    w_try "$WINE" "${W_CACHE}/${W_PACKAGE}/${file1}" /q /x:"${W_TMP}/${file1}"
-    w_try cp -f "${W_TMP}/${file1}/SP3GDR/mspaint.exe" "$W_WINDIR_UNIX"/mspaint.exe
+    w_try "${WINE}" "${W_CACHE}/${W_PACKAGE}/${file1}" /q /x:"${W_TMP}/${file1}"
+    w_try cp -f "${W_TMP}/${file1}/SP3GDR/mspaint.exe" "${W_WINDIR_UNIX}"/mspaint.exe
 }
 
 #----------------------------------------------------------------
@@ -15366,7 +15366,7 @@ load_mt4()
     export WINEDLLOVERRIDES
 
     # No documented silent install option, unfortunately.
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         Run, ${file1}
         SetTitleMatchMode, RegEx
@@ -15390,17 +15390,17 @@ w_metadata njcwp_trial apps \
     year="2015" \
     media="download" \
     file1="njcwp610sw15918.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/NJStar Chinese WP6/NJStar.exe" \
+    installed_exe1="${W_PROGRAMS_X86_WIN}/NJStar Chinese WP6/NJStar.exe" \
     homepage="https://www.njstar.com/cms/njstar-chinese-word-processor"
 
 load_njcwp_trial()
 {
     w_download http://ftp.njstar.com/sw/njcwp610sw15918.exe 7afa6dfc431f058d1397ac7100d5650b97347e1f37f81a2e2d2ee5dfdff4660b
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    if test "$W_OPT_UNATTENDED"; then
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    if test "${W_OPT_UNATTENDED}"; then
         w_ahk_do "
         SetTitleMatchMode, 2
-        run $file1
+        run ${file1}
         WinWait, Setup, Welcome
         ControlClick Button2 ; next
         WinWait, Setup, License
@@ -15413,7 +15413,7 @@ load_njcwp_trial()
         WinWaitClose
         "
     else
-        w_try "$WINE" "$file1"
+        w_try "${WINE}" "${file1}"
     fi
 }
 
@@ -15425,17 +15425,17 @@ w_metadata njjwp_trial apps \
     year="2009" \
     media="download" \
     file1="njjwp610sw15918.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/NJStar Japanese WP6/NJStarJ.exe" \
+    installed_exe1="${W_PROGRAMS_X86_WIN}/NJStar Japanese WP6/NJStarJ.exe" \
     homepage="https://www.njstar.com/cms/njstar-japanese-word-processor"
 
 load_njjwp_trial()
 {
     w_download http://ftp.njstar.com/sw/njjwp610sw15918.exe 7f36138c3d19539cb73d757cd42a6f7afebdaf9cfed0cf9bc483c33e519e2a26
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    if test "$W_OPT_UNATTENDED"; then
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    if test "${W_OPT_UNATTENDED}"; then
         w_ahk_do "
         SetTitleMatchMode, 2
-        run $file1
+        run ${file1}
         WinWait, Setup, Welcome
         ControlClick Button2 ; next
         WinWait, Setup, License
@@ -15448,7 +15448,7 @@ load_njjwp_trial()
         WinWaitClose
         "
     else
-        w_try "$WINE" "$file1"
+        w_try "${WINE}" "${file1}"
     fi
 }
 
@@ -15460,7 +15460,7 @@ w_metadata nook apps \
     year="2011" \
     media="download" \
     file1="bndr2_setup_latest.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Barnes & Noble/BNDesktopReader/BNDReader.exe" \
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Barnes & Noble/BNDesktopReader/BNDReader.exe" \
     homepage="https://www.barnesandnoble.com/h/nook/apps"
 
 load_nook()
@@ -15468,15 +15468,15 @@ load_nook()
     # Dates from curl --head
     # 2012/03/07: sha256sum 436616d99f0e2351909ab53d910b505c7a3fca248876ebb835fd7bce4aad9720
     w_download http://images.barnesandnoble.com/PResources/download/eReader2/bndr2_setup_latest.exe 436616d99f0e2351909ab53d910b505c7a3fca248876ebb835fd7bce4aad9720
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
     # Exits with 199 for some reason..
-    "$WINE" "$file1" ${W_OPT_UNATTENDED:+ /S}
+    "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+ /S}
 
     status=$?
-    case $status in
-        0|199) echo "Successfully installed $W_PACKAGE" ;;
-        *) w_die "Failed to install $W_PACKAGE" ;;
+    case ${status} in
+        0|199) echo "Successfully installed ${W_PACKAGE}" ;;
+        *) w_die "Failed to install ${W_PACKAGE}" ;;
     esac
 }
 
@@ -15488,13 +15488,13 @@ w_metadata npp apps \
     year="2019" \
     media="download" \
     file1="npp.7.7.1.Installer.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Notepad++/notepad++.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Notepad++/notepad++.exe"
 
 load_npp()
 {
     w_download https://notepad-plus-plus.org/repository/7.x/7.7.1/npp.7.7.1.Installer.exe 6787c524b0ac30a698237ffb035f932d7132343671b8fe8f0388ed380d19a51c
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" "${file1}" ${W_OPT_UNATTENDED:+/S}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+/S}
 }
 
 #----------------------------------------------------------------
@@ -15505,7 +15505,7 @@ w_metadata office2003pro apps \
     year="2002" \
     media="cd" \
     file1="setup.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Microsoft Office/Office11/WINWORD.EXE"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Microsoft Office/Office11/WINWORD.EXE"
 
 load_office2003pro()
 {
@@ -15514,7 +15514,7 @@ load_office2003pro()
 
     w_ahk_do "
         if ( w_opt_unattended > 0 ) {
-            run ${W_ISO_MOUNT_LETTER}:setup.exe /EULA_ACCEPT=YES /PIDKEY=$W_KEY
+            run ${W_ISO_MOUNT_LETTER}:setup.exe /EULA_ACCEPT=YES /PIDKEY=${W_KEY}
         } else {
             run ${W_ISO_MOUNT_LETTER}:setup.exe
         }
@@ -15556,7 +15556,7 @@ w_metadata office2007pro apps \
     year="2006" \
     media="cd" \
     file1="setup.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/Microsoft Office/Office12/WINWORD.EXE"
+    installed_file1="${W_PROGRAMS_X86_WIN}/Microsoft Office/Office12/WINWORD.EXE"
 
 load_office2007pro()
 {
@@ -15573,33 +15573,33 @@ load_office2007pro()
     w_mount OFFICE12
     w_read_key
 
-    if [ -n "$W_OPT_UNATTENDED" ]; then
+    if [ -n "${W_OPT_UNATTENDED}" ]; then
         # See
         # https://blogs.technet.microsoft.com/office_resource_kit/2009/01/29/configure-a-silent-install-of-the-2007-office-system-with-config-xml/
         # https://www.symantec.com/connect/articles/office-2007-silent-installation-lessons-learned
-        cat > "$W_TMP"/config.xml <<__EOF__
+        cat > "${W_TMP}"/config.xml <<__EOF__
 <Configuration Product="ProPlus">
 <Display Level="none" CompletionNotice="no" SuppressModal="yes" AcceptEula="yes" />
-<PIDKEY Value="$W_KEY" />
+<PIDKEY Value="${W_KEY}" />
 </Configuration>
 __EOF__
-        "$WINE" ${W_ISO_MOUNT_LETTER}:setup.exe /config "$W_TMP_WIN"\\config.xml
+        "${WINE}" ${W_ISO_MOUNT_LETTER}:setup.exe /config "${W_TMP_WIN}"\\config.xml
 
         status=$?
-        case $status in
+        case ${status} in
             0|43) ;;
             78)
-                w_die "Installing $W_PACKAGE failed, product key $W_KEY \
+                w_die "Installing ${W_PACKAGE} failed, product key ${W_KEY} \
     might be wrong. Try again without -q, or put correct key in \
-    $W_CACHE/$W_PACKAGE/key.txt and rerun."
+    ${W_CACHE}/${W_PACKAGE}/key.txt and rerun."
                 ;;
             *)
-                w_die "Installing $W_PACKAGE failed."
+                w_die "Installing ${W_PACKAGE} failed."
                 ;;
         esac
 
     else
-        w_try "$WINE" ${W_ISO_MOUNT_LETTER}:setup.exe
+        w_try "${WINE}" ${W_ISO_MOUNT_LETTER}:setup.exe
     fi
 }
 
@@ -15611,7 +15611,7 @@ w_metadata office2013pro apps \
     year="2013" \
     media="download" \
     file1="setup.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/Microsoft Office/Office15/WINWORD.EXE"
+    installed_file1="${W_PROGRAMS_X86_WIN}/Microsoft Office/Office15/WINWORD.EXE"
 
 load_office2013pro()
 {
@@ -15637,27 +15637,27 @@ load_office2013pro()
     fi
 
     if w_workaround_wine_bug 38648 "DirectX < 11 has problems with black window after installation" ,3.0; then
-        cat > "$W_TMP"/MaxVersionGL.reg <<_EOF_
+        cat > "${W_TMP}"/MaxVersionGL.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\Direct3D]
 "MaxVersionGL"=dword:00030002
 
 _EOF_
-        w_try_regedit "$W_TMP_WIN"\\MaxVersionGL.reg
+        w_try_regedit "${W_TMP_WIN}"\\MaxVersionGL.reg
     fi
 
-    case "$WINETRICKS_ISO_MOUNT" in
+    case "${WINETRICKS_ISO_MOUNT}" in
         # archivemount > 0.8.8: works
         # archivemount <= 0.8.8: cannot finish installation due to path issue
         archivemount)
             _W_last_bad_ver=0.8.8
             _W_tool_ver="$(archivemount --version 2>&1 | head -n 1 | cut -d ' ' -f3)"
             _W_pos_am_ver="$(printf "%s\\n%s" "${_W_tool_ver}" "${_W_last_bad_ver}" | sort -t. -k 1,1n -k 2,2n -k 3,3n | grep -n "^${_W_tool_ver}\$" | cut -d : -f1 | head -n 1)"
-            if test "$_W_pos_am_ver" = "2"; then
+            if test "${_W_pos_am_ver}" = "2"; then
                 W_USE_USERMOUNT=1
             else
-                w_warn "archivemount <= $_W_last_bad_ver has path issue and cannot be used."
+                w_warn "archivemount <= ${_W_last_bad_ver} has path issue and cannot be used."
             fi
             unset _W_last_bad_ver _W_tool_ver _W_pos_am_ver
             ;;
@@ -15667,15 +15667,15 @@ _EOF_
     esac
     w_mount OFFICE15
 
-    if [ -n "$W_OPT_UNATTENDED" ]; then
-        cat > "$W_TMP"/config.xml <<_EOF_
+    if [ -n "${W_OPT_UNATTENDED}" ]; then
+        cat > "${W_TMP}"/config.xml <<_EOF_
 <Configuration Product="ProPlus">
 <Display Level="none" CompletionNotice="no" SuppressModal="yes" AcceptEula="yes" />
 </Configuration>
 _EOF_
-        w_try "$WINE" "${W_ISO_MOUNT_LETTER}:${file1}" /config "$W_TMP_WIN"\\config.xml
+        w_try "${WINE}" "${W_ISO_MOUNT_LETTER}:${file1}" /config "${W_TMP_WIN}"\\config.xml
     else
-        w_try "$WINE" "${W_ISO_MOUNT_LETTER}:${file1}"
+        w_try "${WINE}" "${W_ISO_MOUNT_LETTER}:${file1}"
     fi
 
     w_wineserver -w
@@ -15701,7 +15701,7 @@ load_ollydbg110()
     w_call corefonts
 
     w_download http://www.ollydbg.de/odbg110.zip 73b1770f28893dab22196eb58d45ede8ddf5444009960ccc0107d09881a7cd1e
-    w_try_unzip "$W_DRIVE_C/ollydbg110" "$W_CACHE/$W_PACKAGE"/odbg110.zip
+    w_try_unzip "${W_DRIVE_C}/ollydbg110" "${W_CACHE}/${W_PACKAGE}"/odbg110.zip
 }
 
 #----------------------------------------------------------------
@@ -15721,7 +15721,7 @@ load_ollydbg200()
     w_call corefonts
 
     w_download http://www.ollydbg.de/odbg200.zip 93dfd6348323db33f2005fc1fb8ff795256ae91d464dd186adc29c4314ed647c
-    w_try_unzip "$W_DRIVE_C/ollydbg200" "$W_CACHE/$W_PACKAGE"/odbg200.zip
+    w_try_unzip "${W_DRIVE_C}/ollydbg200" "${W_CACHE}/${W_PACKAGE}"/odbg200.zip
 }
 
 #----------------------------------------------------------------
@@ -15741,7 +15741,7 @@ load_ollydbg201()
     w_call corefonts
 
     w_download http://www.ollydbg.de/odbg201.zip 29244e551be31f347db00503c512058086f55b43c93c1ae93729b15ce6e087a5
-    w_try_unzip "$W_DRIVE_C/ollydbg201" "$W_CACHE/$W_PACKAGE"/odbg201.zip
+    w_try_unzip "${W_DRIVE_C}/ollydbg201" "${W_CACHE}/${W_PACKAGE}"/odbg201.zip
 
     # ollydbg201 is affected by Wine bug 36012 if debug symbols are available.
     # As a workaround native 'dbghelp' can be installed. We don't do this automatically
@@ -15770,18 +15770,18 @@ load_openwatcom()
         # Options documented at http://bugzilla.openwatcom.org/show_bug.cgi?id=898
         # But they don't seem to work on Wine, so jam them into setup.inf
         # Pick smallest installation that supports 16-bit C and C++
-        w_try_cd "$W_TMP"
-        cp "$W_CACHE/${W_PACKAGE}/${file1}" .
+        w_try_cd "${W_TMP}"
+        cp "${W_CACHE}/${W_PACKAGE}/${file1}" .
         w_try_unzip . "${file1}" setup.inf
         sed -i 's/tools16=.*/tools16=true/' setup.inf
         w_try zip -f "${file1}"
-        w_try "$WINE" "${file1}" -s
+        w_try "${WINE}" "${file1}" -s
     else
-        w_try_cd "$W_CACHE/$W_PACKAGE"
-        w_try "$WINE" "${file1}"
+        w_try_cd "${W_CACHE}/${W_PACKAGE}"
+        w_try "${WINE}" "${file1}"
     fi
 
-    if test ! -f "$W_DRIVE_C"/WATCOM/binnt/wcc.exe; then
+    if test ! -f "${W_DRIVE_C}"/WATCOM/binnt/wcc.exe; then
         w_warn "c:/watcom/binnt/wcc.exe not found; you probably didn't select 16-bit tools, and won't be able to build win16test."
     fi
 }
@@ -15794,12 +15794,12 @@ w_metadata protectionid apps \
     year="2016" \
     media="manual_download" \
     file1="ProtectionId.685.December.2016.rar" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/protection_id.exe"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/protection_id.exe"
 
 load_protectionid()
 {
     w_download "https://web.archive.org/web/20181209123344/https://pid.wiretarget.com/?f=ProtectionId.685.December.2016.rar" 27a84d740c9fb96cc866438a2b5cd4afc350affc8b7a0122c28c651af3559aea ProtectionId.685.December.2016.rar
-    w_try_cd "$W_SYSTEM32_DLLS"
+    w_try_cd "${W_SYSTEM32_DLLS}"
     w_try_unrar "${W_CACHE}/${W_PACKAGE}/${file1}"
 
     # ProtectionId.685.December.2016 has a different executable name than usual, this may need to be disabled on next update:
@@ -15814,7 +15814,7 @@ w_metadata psdk2003 apps \
     year="2003" \
     media="download" \
     file1="5.2.3790.1830.15.PlatformSDK_Svr2003SP1_rtm.img" \
-    installed_file1="$W_PROGRAMS_X86_WIN/Microsoft Platform SDK/SetEnv.Cmd"
+    installed_file1="${W_PROGRAMS_X86_WIN}/Microsoft Platform SDK/SetEnv.Cmd"
 
 load_psdk2003()
 {
@@ -15828,15 +15828,15 @@ load_psdk2003()
     # Unpack ISO (how handy that 7z can do this!)
     # Only the Windows version of 7z can handle .img files?
     WINETRICKS_OPT_SHAREDPREFIX=1 w_call 7zip
-    w_try_cd "$W_PROGRAMS_X86_UNIX"/7-Zip
-    w_try "$WINE" 7z.exe x -y -o"$W_TMP_WIN" "$W_CACHE_WIN\\psdk2003\\5.2.3790.1830.15.PlatformSDK_Svr2003SP1_rtm.img"
+    w_try_cd "${W_PROGRAMS_X86_UNIX}"/7-Zip
+    w_try "${WINE}" 7z.exe x -y -o"${W_TMP_WIN}" "${W_CACHE_WIN}\\psdk2003\\5.2.3790.1830.15.PlatformSDK_Svr2003SP1_rtm.img"
 
-    w_try_cd "$W_TMP/Setup"
+    w_try_cd "${W_TMP}/Setup"
 
     # Sanity check...
     w_verify_sha256sum d2605ae6f35a7fcc209e1d8dfbdfdb42afcb61e7d173f58fd608ae31db4ab1e7 PSDK-x86.msi
 
-    w_try "$WINE" msiexec /i PSDK-x86.msi ${W_OPT_UNATTENDED:+/qb}
+    w_try "${WINE}" msiexec /i PSDK-x86.msi ${W_OPT_UNATTENDED:+/qb}
 }
 
 #----------------------------------------------------------------
@@ -15858,15 +15858,15 @@ load_psdkwin7()
     # do an AutoHotKey script until Microsoft gets its act together:
     # https://social.msdn.microsoft.com/Forums/windowsdesktop/en-US/c053b616-7d5b-405d-9841-ec465a8e21d5/
     w_download https://download.microsoft.com/download/7/A/B/7ABD2203-C472-4036-8BA0-E505528CCCB7/winsdk_web.exe bb0e3b5d8feb750b3164b657a046f76ff086887719e418f57ce88ada5e8990d5
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     if w_workaround_wine_bug 21596; then
         w_warn "When given a choice, select only C++ compilers and headers, the other options don't work yet.  See https://bugs.winehq.org/show_bug.cgi?id=21596"
     fi
-    w_try "$WINE" winsdk_web.exe
+    w_try "${WINE}" winsdk_web.exe
 
     if w_workaround_wine_bug 21362; then
         # Assume user installed in default location
-        cat > "$W_TMP"/set-psdk7.reg <<_EOF_
+        cat > "${W_TMP}"/set-psdk7.reg <<_EOF_
 REGEDIT4
 
 [HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Microsoft SDKs]
@@ -15880,7 +15880,7 @@ REGEDIT4
 "ProductVersion"="7.0.7600.16385.40715"
 "ProductName"="Microsoft Windows SDK for Windows 7 (7.0.7600.16385.40715)"
 _EOF_
-        w_try_regedit "$W_TMP_WIN"\\set-psdk7.reg
+        w_try_regedit "${W_TMP_WIN}"\\set-psdk7.reg
     fi
 }
 
@@ -15909,12 +15909,12 @@ load_psdkwin71()
     # don't have a working unattended recipe.  Maybe we'll have to
     # do an AutoHotKey script until Microsoft gets its act together:
     # https://social.msdn.microsoft.com/Forums/windowsdesktop/en-US/c053b616-7d5b-405d-9841-ec465a8e21d5/
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" winsdk_web.exe
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" winsdk_web.exe
 
     if w_workaround_wine_bug 21362; then
         # Assume user installed in default location
-        cat > "$W_TMP"/set-psdk71.reg <<_EOF_
+        cat > "${W_TMP}"/set-psdk71.reg <<_EOF_
 REGEDIT4
 
 [HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Microsoft SDKs]
@@ -15943,7 +15943,7 @@ REGEDIT4
 "InstallationFolder"="C:\\\\Program Files\\\\Microsoft SDKs\\\\Windows\\\\v7.1\\\\bin\\\\"
 "ProductVersion"="7.0.7600.0.30514"
 _EOF_
-        w_try_regedit "$W_TMP_WIN"\\set-psdk71.reg
+        w_try_regedit "${W_TMP_WIN}"\\set-psdk71.reg
     fi
 }
 
@@ -15956,7 +15956,7 @@ w_metadata qq apps \
     media="download" \
     file1="QQ8.9.6.exe" \
     file2="QQ.tar.gz"\
-    installed_exe1="$W_PROGRAMS_X86_WIN/Tencent/QQ/Bin/QQScLauncher.exe" \
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Tencent/QQ/Bin/QQScLauncher.exe" \
     homepage="https://www.qq.com/" \
     unattended="no"
 
@@ -15976,16 +15976,16 @@ load_qq()
     w_call mfc42
 
     if w_workaround_wine_bug 38171 "Installing desktop file to work around bug"; then
-        w_try_cd "$W_TMP/"
-        tar -zxf "$W_CACHE/qq/QQ.tar.gz"
-        mkdir -p "$HOME/.local/share/applications/wine/Programs/腾讯软件/QQ"
-        mkdir -p "$HOME/.local/share/icons/hicolor/48x48/apps"
-        mkdir -p "$HOME/.local/share/icons/hicolor/256x256/apps"
+        w_try_cd "${W_TMP}/"
+        tar -zxf "${W_CACHE}/qq/QQ.tar.gz"
+        mkdir -p "${HOME}/.local/share/applications/wine/Programs/腾讯软件/QQ"
+        mkdir -p "${HOME}/.local/share/icons/hicolor/48x48/apps"
+        mkdir -p "${HOME}/.local/share/icons/hicolor/256x256/apps"
         w_try mv QQ/腾讯QQ.desktop ~/.local/share/applications/wine/Programs/腾讯软件/QQ
         w_try mv QQ/48x48/QQ.png ~/.local/share/icons/hicolor/48x48/apps
         w_try mv QQ/256x256/QQ.png ~/.local/share/icons/hicolor/256x256/apps
         # shellcheck disable=SC1001
-        echo Exec=env WINEPREFIX="$WINEPREFIX" "$WINE" \""$W_PROGRAMS_X86_WIN"/Tencent/QQ/bin/QQScLauncher.exe\" >> "$HOME/.local/share/applications/wine/Programs/腾讯软件/QQ/腾讯QQ.desktop"
+        echo Exec=env WINEPREFIX="${WINEPREFIX}" "${WINE}" \""${W_PROGRAMS_X86_WIN}"/Tencent/QQ/bin/QQScLauncher.exe\" >> "${HOME}/.local/share/applications/wine/Programs/腾讯软件/QQ/腾讯QQ.desktop"
     fi
 
     if w_workaround_wine_bug 39657 "Disable ntoskrnl.exe to work around can't be started bug"; then
@@ -15999,8 +15999,8 @@ load_qq()
     # Disable update, stay on the version.
     w_override_dlls disabled txupd.exe
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" "$file1"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" "${file1}"
 }
 
 #----------------------------------------------------------------
@@ -16011,7 +16011,7 @@ w_metadata qqintl apps \
     year="2014" \
     media="download" \
     file1="QQIntl2.11.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Tencent/QQIntl/Bin/QQ.exe" \
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Tencent/QQIntl/Bin/QQ.exe" \
     homepage="https://www.imqq.com/" \
     unattended="no"
 
@@ -16037,8 +16037,8 @@ load_qqintl()
     # wants mfc80u.dll
     w_call vcrun2005
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" "$file1"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" "${file1}"
 }
 
 #----------------------------------------------------------------
@@ -16049,18 +16049,18 @@ w_metadata safari apps \
     year="2010" \
     media="download" \
     file1="SafariSetup.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Safari/Safari.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Safari/Safari.exe"
 
 load_safari()
 {
     w_download http://appldnld.apple.com.edgesuite.net/content.info.apple.com/Safari5/061-7138.20100607.Y7U87/SafariSetup.exe a5b44032fe9cd0ede8571023912c91b1dcca106ad6a65a822be9ebd405510939
 
-    if [ -n "$W_OPT_UNATTENDED" ]; then
+    if [ -n "${W_OPT_UNATTENDED}" ]; then
         w_warn "Safari's silent install is broken under Wine. See https://bugs.winehq.org/show_bug.cgi?id=23493. You should do a regular install if you want to use Safari."
     fi
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE_MULTI" SafariSetup.exe ${W_OPT_UNATTENDED:+/qn}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE_MULTI}" SafariSetup.exe ${W_OPT_UNATTENDED:+/qn}
 }
 
 #----------------------------------------------------------------
@@ -16071,13 +16071,13 @@ w_metadata sketchup apps \
     year="2012" \
     media="download" \
     file1="GoogleSketchUpWEN.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Google/Google SketchUp 8/SketchUp.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Google/Google SketchUp 8/SketchUp.exe"
 
 load_sketchup()
 {
     w_download https://dl.google.com/sketchup/GoogleSketchUpWEN.exe e50c1b36131d72437eb32a124a5208fad22dc22b843683cfb520e1ef172b8352
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetTitleMatchMode, 2
         run GoogleSketchUpWEN.exe
@@ -16114,26 +16114,26 @@ w_metadata steam apps \
     year="2010" \
     media="download" \
     file1="SteamInstall.msi" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Steam/Steam.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Steam/Steam.exe"
 
 load_steam()
 {
     # 2016/10/28: 029f918a29b2b311711788e8a477c8de529c11d7dba3caf99cbbde5a983efdad
     # 2018/06/01: 3bc6942fe09f10ed3447bccdcf4a70ed369366fef6b2c7f43b541f1a3c5d1c51
     w_download http://media.steampowered.com/client/installer/SteamSetup.exe 3bc6942fe09f10ed3447bccdcf4a70ed369366fef6b2c7f43b541f1a3c5d1c51
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
     # Should be fixed in newer steam versions, since 2012. Commenting out for a while before removing in case users need to revert locally
     #
     # Install corefonts first, so if the user doesn't have cabextract/Wine with cab support, we abort before installing Steam.
     # FIXME: support using Wine's cab support
-    #if ! test -f "$W_FONTSDIR_UNIX/Times.TTF" && \
+    #if ! test -f "${W_FONTSDIR_UNIX}/Times.TTF" && \
     #    w_workaround_wine_bug 22751 "Installing corefonts to prevent a Steam crash"
     #then
     #    w_call corefonts
     #fi
 
-    if [ -n "$W_OPT_UNATTENDED" ]; then
+    if [ -n "${W_OPT_UNATTENDED}" ]; then
             w_ahk_do "
             run, SteamSetup.exe
             SetTitleMatchMode, 2
@@ -16154,7 +16154,7 @@ load_steam()
             WinWaitClose
             "
     else
-            w_try "$WINE" SteamSetup.exe
+            w_try "${WINE}" SteamSetup.exe
     fi
 
     # Not all users need this disabled, but let's play it safe for now
@@ -16171,16 +16171,16 @@ w_metadata uplay apps \
     year="2013" \
     media="download" \
     file1="UplayInstaller.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Ubisoft/Ubisoft Game Launcher/Uplay.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Ubisoft/Ubisoft Game Launcher/Uplay.exe"
 
 load_uplay()
 {
     # Changes too frequently, don't check anymore
     w_download https://static3.cdn.ubi.com/orbit/launcher_installer/UplayInstaller.exe
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
     # NSIS installer
-    w_try "$WINE" UplayInstaller.exe ${W_OPT_UNATTENDED:+ /S}
+    w_try "${WINE}" UplayInstaller.exe ${W_OPT_UNATTENDED:+ /S}
 }
 
 #----------------------------------------------------------------
@@ -16199,7 +16199,7 @@ load_utorrent()
     # 2012/03/07: sha256sum ec2c086ff784b06e4ff05243164ddb768b81ee32096afed6d5e574ff350b619e
     w_download_manual "https://www.oldapps.com/utorrent.php?old_utorrent=38" utorrent_2.2.1.exe ec2c086ff784b06e4ff05243164ddb768b81ee32096afed6d5e574ff350b619e
 
-    w_try cp -f "$W_CACHE/utorrent/$file1" "$W_WINDIR_UNIX"/utorrent.exe
+    w_try cp -f "${W_CACHE}/utorrent/${file1}" "${W_WINDIR_UNIX}"/utorrent.exe
 }
 
 #----------------------------------------------------------------
@@ -16210,23 +16210,23 @@ w_metadata utorrent3 apps \
     year="2011" \
     media="download" \
     file1="uTorrent.exe" \
-    installed_exe1="c:/users/$LOGNAME/Application Data/uTorrent/uTorrent.exe"
+    installed_exe1="c:/users/${LOGNAME}/Application Data/uTorrent/uTorrent.exe"
 
 load_utorrent3()
 {
     # 2017/03/26: sha256sum 482cfc0759f484ad4e6547cc160ef3f08057cb05969242efd75a51525ab9bd92
     w_download https://download-new.utorrent.com/endpoint/utorrent/os/windows/track/stable/ 482cfc0759f484ad4e6547cc160ef3f08057cb05969242efd75a51525ab9bd92 uTorrent.exe
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     # If you don't use /PERFORMINSTALL, it just runs µTorrent
     # FIXME: That's no longer a quiet option, though..
-    "$WINE" "$file1" /PERFORMINSTALL /NORUN
+    "${WINE}" "${file1}" /PERFORMINSTALL /NORUN
 
     # dang installer exits with status 1 on success
     status=$?
-    case $status in
+    case ${status} in
         0|1) ;;
-        *) w_die "Note: utorrent installer returned status '$status'.  Aborting." ;;
+        *) w_die "Note: utorrent installer returned status '${status}'.  Aborting." ;;
     esac
 }
 
@@ -16238,7 +16238,7 @@ w_metadata vc2005express apps \
     year="2005" \
     media="download" \
     file1="VC.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Microsoft Visual Studio 8/Common7/IDE/VCExpress.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Microsoft Visual Studio 8/Common7/IDE/VCExpress.exe"
 
 load_vc2005express()
 {
@@ -16251,17 +16251,17 @@ load_vc2005express()
     w_download https://download.microsoft.com/download/A/9/1/A91D6B2B-A798-47DF-9C7E-A97854B7DD18/VC.iso 5ae700d0285d94ec6df23828c7dc9f5634cd250363bed72e486916af22ff9545
 
     # Unpack ISO (how handy that 7z can do this!)
-    w_try_7z "$W_TMP" "$W_CACHE"/vc2005express/VC.iso
+    w_try_7z "${W_TMP}" "${W_CACHE}"/vc2005express/VC.iso
 
-    w_try_cd "$W_TMP"
+    w_try_cd "${W_TMP}"
     if [ -n "${W_OPT_UNATTENDED}" ]; then
         chmod +x Ixpvc.exe
         # Add /qn after ReallySuppress for a really silent install (but then you won't see any errors)
 
-        w_try "$WINE" Ixpvc.exe /t:"$W_TMP_WIN" /q:a /c:"msiexec /i vcsetup.msi VSEXTUI=1 ADDLOCAL=ALL REBOOT=ReallySuppress"
+        w_try "${WINE}" Ixpvc.exe /t:"${W_TMP_WIN}" /q:a /c:"msiexec /i vcsetup.msi VSEXTUI=1 ADDLOCAL=ALL REBOOT=ReallySuppress"
 
     else
-        w_try "$WINE" setup.exe
+        w_try "${WINE}" setup.exe
         w_ahk_do "
             SetTitleMatchMode, 2
             WinWait, Visual C++ 2005 Express Edition Setup
@@ -16288,7 +16288,7 @@ load_vc2005expresssp1()
             w_warn "Installer currently fails"
     fi
     w_download https://download.microsoft.com/download/7/7/3/7737290f-98e8-45bf-9075-85cc6ae34bf1/VS80sp1-KB926748-X86-INTL.exe a959d1ea52674b5338473be32a1370f9ec80df84629a2ed3471aa911b42d9e50
-    w_try $WINE "$W_CACHE"/vc2005expresssp1/VS80sp1-KB926748-X86-INTL.exe
+    w_try ${WINE} "${W_CACHE}"/vc2005expresssp1/VS80sp1-KB926748-X86-INTL.exe
 }
 
 #----------------------------------------------------------------
@@ -16299,7 +16299,7 @@ w_metadata vc2005trial apps \
     year="2005" \
     media="download" \
     file1="En_vs_2005_vsts_180_Trial.img" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Microsoft Visual Studio 8/Common7/IDE/devenv.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Microsoft Visual Studio 8/Common7/IDE/devenv.exe"
 
 load_vc2005trial()
 {
@@ -16313,10 +16313,10 @@ load_vc2005trial()
     # Unpack ISO (how handy that 7z can do this!)
     # Only the Windows version of 7z can handle .img files?
     WINETRICKS_OPT_SHAREDPREFIX=1 w_call 7zip
-    w_try_cd "$W_PROGRAMS_X86_UNIX"/7-Zip
-    w_try "$WINE" 7z.exe x -y -o"$W_TMP_WIN" "$W_CACHE_WIN\\vc2005trial\\En_vs_2005_vsts_180_Trial.img"
+    w_try_cd "${W_PROGRAMS_X86_UNIX}"/7-Zip
+    w_try "${WINE}" 7z.exe x -y -o"${W_TMP_WIN}" "${W_CACHE_WIN}\\vc2005trial\\En_vs_2005_vsts_180_Trial.img"
 
-    w_try_cd "$W_TMP"
+    w_try_cd "${W_TMP}"
 
     # Sanity check...
     w_verify_sha256sum e1d5ddd4bad46c2efe8105f8d73bd62857f6218942d3b9ac5da0e1a6a0a217e0 vs/wcu/runmsi.exe
@@ -16360,7 +16360,7 @@ w_metadata vc2008express apps \
     year="2008" \
     media="download" \
     file1="VS2008ExpressENUX1397868.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Microsoft Visual Studio 9.0/Common7/IDE/VCExpress.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Microsoft Visual Studio 9.0/Common7/IDE/VCExpress.exe"
 
 load_vc2008express()
 {
@@ -16372,11 +16372,11 @@ load_vc2008express()
     w_download https://download.microsoft.com/download/8/B/5/8B5804AD-4990-40D0-A6AA-CE894CBBB3DC/VS2008ExpressENUX1397868.iso 632318ef0df5bad58fcb99852bd251243610e7a4d84213c45b4f693605a13ead
 
     # Unpack ISO
-    w_try_7z "$W_TMP" "$W_CACHE"/vc2008express/VS2008ExpressENUX1397868.iso
+    w_try_7z "${W_TMP}" "${W_CACHE}"/vc2008express/VS2008ExpressENUX1397868.iso
 
     # See also https://blogs.msdn.microsoft.com/astebner/2008/04/25/a-simpler-way-to-silently-install-visual-studio-2008-express-editions-with-a-caveat/
-    w_try_cd "$W_TMP"/VCExpress
-    w_try "$WINE" setup.exe ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_TMP}"/VCExpress
+    w_try "${WINE}" setup.exe ${W_OPT_UNATTENDED:+/q}
 }
 
 #----------------------------------------------------------------
@@ -16387,7 +16387,7 @@ w_metadata vc2010express apps \
     year="2010" \
     media="download" \
     file1="VS2010Express1.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Microsoft Visual Studio 10.0/Common7/IDE/VCExpress.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Microsoft Visual Studio 10.0/Common7/IDE/VCExpress.exe"
 
 load_vc2010express()
 {
@@ -16397,8 +16397,8 @@ load_vc2010express()
     w_download https://debian.fmi.uni-sofia.bg/~aangelov/VS2010Express1.iso a9d5dcdf55e539a06547a8ebbc63d55dc167113e09ee9e42096ab9098313039b
 
     # Unpack ISO
-    w_try_7z "$W_TMP" "$W_CACHE"/vc2010express/VS2010Express1.iso
-    w_try_cd "$W_TMP"/VCExpress
+    w_try_7z "${W_TMP}" "${W_CACHE}"/vc2010express/VS2010Express1.iso
+    w_try_cd "${W_TMP}"/VCExpress
 
     # Uninstall wine-mono, installer doesn't attempt to install native .Net if mono is installed,
     # Then the installer throws an exception and fails
@@ -16406,7 +16406,7 @@ load_vc2010express()
     w_call remove_mono
 
     # dotnet40 leaves winver at win2k, which causes vc2010 to abort on
-    # start because it looks for c:\users\$LOGNAME\Application Data
+    # start because it looks for c:\users\${LOGNAME}\Application Data
     w_set_winver winxp
 
     if w_workaround_wine_bug 12501 "Installing mspatcha to work around bug in SQL Server install"; then
@@ -16417,7 +16417,7 @@ load_vc2010express()
         w_call vcrun2005
     fi
 
-    w_try $WINE setup.exe ${W_OPT_UNATTENDED:+/q}
+    w_try ${WINE} setup.exe ${W_OPT_UNATTENDED:+/q}
 }
 
 #----------------------------------------------------------------
@@ -16428,14 +16428,14 @@ w_metadata vlc apps \
     year="2015" \
     media="download" \
     file1="vlc-2.2.1-win32.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/VideoLAN/VLC/vlc.exe" \
+    installed_file1="${W_PROGRAMS_X86_WIN}/VideoLAN/VLC/vlc.exe" \
     homepage="https://www.videolan.org/vlc/"
 
 load_vlc()
 {
     w_download https://get.videolan.org/vlc/2.2.1/win32/vlc-2.2.1-win32.exe 2eaa3881b01a2464d2a155ad49cc78162571dececcef555400666c719a60794d
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" "$file1" ${W_OPT_UNATTENDED:+ /S}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+ /S}
 }
 
 #----------------------------------------------------------------
@@ -16446,7 +16446,7 @@ w_metadata winamp apps \
     year="2013" \
     media="download" \
     file1="winamp5666_full_all_redux.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Winamp/winamp.exe" \
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Winamp/winamp.exe" \
     homepage="https://www.winamp.com/"
 
 load_winamp()
@@ -16455,12 +16455,12 @@ load_winamp()
 
     # 2019/12/11: previously at https://winampplugins.co.uk/Winamp/winamp5666_full_all_redux.exe
     w_download http://www.meggamusic.co.uk/winamp/winamp5666_full_all_redux.exe ea9a6ba81475d49876d0b8b300d93f28f7959b8e99ce4372dbde746567e14002
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    if [ -n "$W_OPT_UNATTENDED" ]; then
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    if [ -n "${W_OPT_UNATTENDED}" ]; then
         w_ahk_do "
             SetWinDelay 500
             SetTitleMatchMode, 2
-            Run $file1
+            Run ${file1}
             WinWait, Installer Language, Please select
             Sleep 500
             ControlClick, Button1 ; OK
@@ -16493,7 +16493,7 @@ load_winamp()
             WinWaitClose
         "
     else
-        w_try "$WINE" "$file1"
+        w_try "${WINE}" "${file1}"
     fi
 }
 
@@ -16505,7 +16505,7 @@ w_metadata wme9 apps \
     year="2002" \
     media="download" \
     file1="WMEncoder.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/Windows Media Components/Encoder/wmenc.exe"
+    installed_file1="${W_PROGRAMS_X86_WIN}/Windows Media Components/Encoder/wmenc.exe"
 
 load_wme9()
 {
@@ -16516,8 +16516,8 @@ load_wme9()
     # Mirror list: http://www.filewatcher.com/_/?q=WMEncoder.exe
     w_download https://people.ok.ubc.ca/mberger/MiscSW/WMEncoder.exe 19d1610d12b51c969f64703c4d3a76aae30dee526bae715381b5f3369f717d76
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" WMEncoder.exe ${W_OPT_UNATTENDED:+/q}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" WMEncoder.exe ${W_OPT_UNATTENDED:+/q}
 }
 
 #----------------------------------------------------------------
@@ -16531,9 +16531,9 @@ load_wm9codecs()
     # Used by direct calls from load_wmp9, so we have to specify cache directory.
     # http://birds.camden.rutgers.edu/
     w_download_to wm9codecs http://birds.camden.rutgers.edu/WM9Codecs9x.exe f25adf6529745a772c4fdd955505e7fcdc598b8a031bb0ce7e5856da5e5fcc95
-    w_try_cd "$W_CACHE/wm9codecs"
+    w_try_cd "${W_CACHE}/wm9codecs"
     w_set_winver win2k
-    w_try "$WINE" WM9Codecs9x.exe ${W_OPT_UNATTENDED:+/q}
+    w_try "${WINE}" WM9Codecs9x.exe ${W_OPT_UNATTENDED:+/q}
 }
 
 w_metadata wmp9 dlls \
@@ -16542,7 +16542,7 @@ w_metadata wmp9 dlls \
     year="2003" \
     media="download" \
     file1="MPSetup.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN"/l3codeca.acm
+    installed_file1="${W_SYSTEM32_DLLS_WIN}"/l3codeca.acm
 
 load_wmp9()
 {
@@ -16561,8 +16561,8 @@ load_wmp9()
     w_download https://web.archive.org/web/20180404022333if_/download.microsoft.com/download/1/b/c/1bc0b1a3-c839-4b36-8f3c-19847ba09299/MPSetup.exe 678c102847c18a92abf13c3fae404c3473a0770c871a046b45efe623c9938fc0
 
     # remove builtin placeholders to allow update
-    rm -f "$W_SYSTEM32_DLLS"/wmvcore.dll "$W_SYSTEM32_DLLS"/wmp.dll
-    rm -f "$W_PROGRAMS_X86_UNIX/Windows Media Player/wmplayer.exe"
+    rm -f "${W_SYSTEM32_DLLS}"/wmvcore.dll "${W_SYSTEM32_DLLS}"/wmp.dll
+    rm -f "${W_PROGRAMS_X86_UNIX}/Windows Media Player/wmplayer.exe"
     # need native overrides to allow update and later checks to succeed
     w_override_dlls native l3codeca.acm wmp wmplayer.exe wmvcore
 
@@ -16571,14 +16571,14 @@ load_wmp9()
     # Wine's pidgen is too stubby, crashes, see Wine bug 31111
     w_override_app_dlls MPSetup.exe native pidgen
 
-    w_try_cd "$W_CACHE"/"$W_PACKAGE"
-    if [ "$W_ARCH" = "win64" ]; then
-      w_try cabextract -d "$W_TMP" ./MPSetup.exe
-      w_try_cd "$W_TMP"
+    w_try_cd "${W_CACHE}"/"${W_PACKAGE}"
+    if [ "${W_ARCH}" = "win64" ]; then
+      w_try cabextract -d "${W_TMP}" ./MPSetup.exe
+      w_try_cd "${W_TMP}"
       w_try sed -i 's/IsWow64Process/IsNow64Process/' setup_wm.exe
-      w_try "$WINE" setup_wm.exe ${W_OPT_UNATTENDED:+/Quiet}
+      w_try "${WINE}" setup_wm.exe ${W_OPT_UNATTENDED:+/Quiet}
     else
-      w_try "$WINE" MPSetup.exe ${W_OPT_UNATTENDED:+/q}
+      w_try "${WINE}" MPSetup.exe ${W_OPT_UNATTENDED:+/q}
     fi
     load_wm9codecs
 
@@ -16593,7 +16593,7 @@ w_metadata wmp10 dlls \
     year="2006" \
     media="download" \
     file1="MP10Setup.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/l3codecp.acm"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/l3codecp.acm"
 
 load_wmp10()
 {
@@ -16611,16 +16611,16 @@ load_wmp10()
     w_set_winver winxp
 
     # remove builtin placeholders to allow update
-    rm -f "$W_SYSTEM32_DLLS"/wmvcore.dll "$W_SYSTEM32_DLLS"/wmp.dll
-    rm -f "$W_PROGRAMS_X86_UNIX/Windows Media Player/wmplayer.exe"
+    rm -f "${W_SYSTEM32_DLLS}"/wmvcore.dll "${W_SYSTEM32_DLLS}"/wmp.dll
+    rm -f "${W_PROGRAMS_X86_UNIX}/Windows Media Player/wmplayer.exe"
     # need native overrides to allow update and later checks to succeed
     w_override_dlls native l3codeca.acm wmp wmplayer.exe wmvcore
 
     # Crashes on exit, but otherwise ok; see https://bugs.winehq.org/show_bug.cgi?id=12633
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try cabextract -d "$W_TMP" ./MP10Setup.exe
-    w_try_cd "$W_TMP"
-    "$WINE" setup_wm.exe ${W_OPT_UNATTENDED:+/Quiet}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try cabextract -d "${W_TMP}" ./MP10Setup.exe
+    w_try_cd "${W_TMP}"
+    "${WINE}" setup_wm.exe ${W_OPT_UNATTENDED:+/Quiet}
 
     # Disable WMP's services, since they depend on unimplemented stuff, they trigger the GUI debugger several times
     w_try_regedit /D "HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Services\\Cdr4_2K"
@@ -16639,7 +16639,7 @@ w_metadata wmp11 dlls \
     year="2007" \
     media="download" \
     file1="wmp11-windowsxp-x86-enu.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/Windows Media Player/wmplayer.exe"
+    installed_file1="${W_PROGRAMS_X86_WIN}/Windows Media Player/wmplayer.exe"
 
 load_wmp11()
 {
@@ -16647,13 +16647,13 @@ load_wmp11()
     w_call wsh57
     w_call gdiplus
 
-    if [ "$W_ARCH" = "win32" ]; then
+    if [ "${W_ARCH}" = "win32" ]; then
       # https://appdb.winehq.org/objectManager.php?sClass=version&iId=8150
       w_download https://web.archive.org/web/20170628063001/http://download.microsoft.com/download/0/9/5/0953e553-3bb6-44b1-8973-106f1b7e5049/wmp11-windowsxp-x86-enu.exe ffd321a441a67001a893f3bde4bb1afba07d4d2c9659bfdb0fbb057e7945d970
       installer_exe=wmp11-windowsxp-x86-enu.exe
       wmf_exe=wmfdist11.exe
       wmf_exe=wmp11.exe
-    elif [ "$W_ARCH" = "win64" ]; then
+    elif [ "${W_ARCH}" = "win64" ]; then
       # https://appdb.winehq.org/objectManager.php?sClass=version&iId=32057
       w_download https://web.archive.org/web/20190512112704/https://download.microsoft.com/download/3/0/8/3080C52C-2517-43DE-BDB4-B7EAFD88F084/wmp11-windowsxp-x64-enu.exe 5af407cf336849aff435044ec28f066dd523bbdc22d1ce7aaddb5263084f5526
       installer_exe=wmp11-windowsxp-x64-enu.exe
@@ -16664,12 +16664,12 @@ load_wmp11()
     w_set_winver winxp
 
     # remove builtin placeholders to allow update
-    w_try rm -f "$W_PROGRAMS_UNIX/Windows Media Player/wmplayer.exe" "$W_SYSTEM64_DLLS"/wmp.dll "$W_SYSTEM64_DLLS"/wmvcore.dll
+    w_try rm -f "${W_PROGRAMS_UNIX}/Windows Media Player/wmplayer.exe" "${W_SYSTEM64_DLLS}"/wmp.dll "${W_SYSTEM64_DLLS}"/wmvcore.dll
 
     # need native overrides to allow update and later checks to succeed
     w_override_dlls native l3codeca.acm wmp wmplayer.exe wmvcore wmpnssci
 
-    w_try_cd "$W_TMP"
+    w_try_cd "${W_TMP}"
 
     # https://bugs.winehq.org/show_bug.cgi?id=10219#c1
     w_try_cabextract "${W_CACHE}/${W_PACKAGE}/${installer_exe}"
@@ -16693,17 +16693,17 @@ w_metadata 3dmark2000 benchmarks \
     year="2000" \
     media="download" \
     file1="3dmark2000_v11_100308.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/MadOnion.com/3DMark2000/3DMark2000.exe"
+    installed_file1="${W_PROGRAMS_X86_WIN}/MadOnion.com/3DMark2000/3DMark2000.exe"
 
 load_3dmark2000()
 {
     # https://www.futuremark.com/download/3dmark2000/
-    if ! test -f "$W_CACHE/$W_PACKAGE/3dmark2000_v11_100308.exe"; then
+    if ! test -f "${W_CACHE}/${W_PACKAGE}/3dmark2000_v11_100308.exe"; then
         w_download http://www.ocinside.de/download/3dmark2000_v11_100308.exe 1b392776fd377de8cc6db7c1d8b1565485e20816d1b053de3f16a743e629048d
     fi
 
-    w_try_unzip "$W_TMP/$W_PACKAGE" "$W_CACHE/$W_PACKAGE"/3dmark2000_v11_100308.exe
-    w_try_cd "$W_TMP/$W_PACKAGE"
+    w_try_unzip "${W_TMP}/${W_PACKAGE}" "${W_CACHE}/${W_PACKAGE}"/3dmark2000_v11_100308.exe
+    w_try_cd "${W_TMP}/${W_PACKAGE}"
     w_ahk_do "
         SetTitleMatchMode, 2
         run Setup.exe
@@ -16744,16 +16744,16 @@ w_metadata 3dmark2001 benchmarks \
     year="2001" \
     media="download" \
     file1="3dmark2001se_330_100308.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/MadOnion.com/3DMark2001 SE/3DMark2001SE.exe"
+    installed_file1="${W_PROGRAMS_X86_WIN}/MadOnion.com/3DMark2001 SE/3DMark2001SE.exe"
 
 load_3dmark2001()
 {
     # https://www.futuremark.com/download/3dmark2001/
-    if ! test -f "$W_CACHE/$W_PACKAGE"/3dmark2001se_330_100308.exe; then
+    if ! test -f "${W_CACHE}/${W_PACKAGE}"/3dmark2001se_330_100308.exe; then
         w_download http://www.ocinside.de/download/3dmark2001se_330_100308.exe e34dfd32ef8fe8018a6f41f33fc3ab6dba45f2e90881688ac75a18b97dcd8813
     fi
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetWinDelay 1000
         SetTitleMatchMode, 2
@@ -16788,16 +16788,16 @@ w_metadata 3dmark03 benchmarks \
     year="2003" \
     media="manual_download" \
     file1="3DMark03_v360_1901.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Futuremark/3DMark03/3DMark03.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Futuremark/3DMark03/3DMark03.exe"
 
 load_3dmark03()
 {
     # https://www.futuremark.com/benchmarks/3dmark03/download/
-    if ! test -f "$W_CACHE/$W_PACKAGE/3DMark03_v360_1901.exe"; then
+    if ! test -f "${W_CACHE}/${W_PACKAGE}/3DMark03_v360_1901.exe"; then
         w_download_manual https://www.futuremark.com/download/3dmark03/ 3DMark03_v360_1901.exe 86d7f73747944c553e47e6ab5a74138e8bbca07fab8216ae70a61ac7f9a1c468
     fi
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_warn "Don't use mouse while this installer is running.  Sorry..."
     # This old installer doesn't seem to be scriptable the usual way, so spray and pray.
     w_ahk_do "
@@ -16846,16 +16846,16 @@ w_metadata 3dmark05 benchmarks \
     year="2005" \
     media="download" \
     file1="3dmark05_v130_1901.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Futuremark/3DMark05/3DMark05.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Futuremark/3DMark05/3DMark05.exe"
 
 load_3dmark05()
 {
     # https://www.futuremark.com/download/3dmark05/
-    if ! test -f "$W_CACHE/$W_PACKAGE/3DMark05_v130_1901.exe"; then
+    if ! test -f "${W_CACHE}/${W_PACKAGE}/3DMark05_v130_1901.exe"; then
         w_download http://www.ocinside.de/download/3dmark05_v130_1901.exe af97f20665090985ee8a4ba83d137e796bfe12e0dfb7fe285712fae198b34334
     fi
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         run 3DMark05_v130_1901.exe
         WinWait ahk_class #32770, Welcome
@@ -16891,15 +16891,15 @@ w_metadata 3dmark06 benchmarks \
     year="2006" \
     media="manual_download" \
     file1="3DMark06_v121_installer.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Futuremark/3DMark06/3DMark06.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Futuremark/3DMark06/3DMark06.exe"
 
 load_3dmark06()
 {
     w_download_manual https://www.futuremark.com/support/downloads 3DMark06_v121_installer.exe 362ebafd2b9c89a59a233e4328596438b74a32827feb65fe2837154c60a37da3
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
-        run $file1
+        run ${file1}
         WinWait ahk_class #32770, Welcome
         if ( w_opt_unattended > 0 ) {
             Send {Enter}
@@ -16942,7 +16942,7 @@ w_metadata stalker_pripyat_bench benchmarks \
     year="2009" \
     media="manual_download" \
     file1="stkcop-bench-setup.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Call Of Pripyat Benchmark/Benchmark.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Call Of Pripyat Benchmark/Benchmark.exe"
 
 load_stalker_pripyat_bench()
 {
@@ -16950,12 +16950,12 @@ load_stalker_pripyat_bench()
     w_download_manual http://www.bigdownload.com/games/stalker-call-of-pripyat/pc/stalker-call-of-pripyat-benchmark stkcop-bench-setup.exe 8c810fba1bbb9c58fc01f4f602479886680c9f4b491dd0afe935e27083f54845
     #w_download https://files.gsc-game.com/st/bench/stkcop-bench-setup.exe 8c810fba1bbb9c58fc01f4f602479886680c9f4b491dd0afe935e27083f54845
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
     # FIXME: a bit fragile, if you're browsing the web while installing, it sometimes gets stuck.
     w_ahk_do "
         SetTitleMatchMode, 2
-        run $file1
+        run ${file1}
         WinWait,Setup - Call Of Pripyat Benchmark
         if ( w_opt_unattended > 0 ) {
             sleep 1000
@@ -17007,11 +17007,11 @@ load_unigine_heaven()
 {
     w_download_manual "https://www.fileplanet.com/212489/210000/fileinfo/Unigine-'Heaven'-Benchmark-2.1-%28Windows%29" 47113b285253a1ebce04527a31d734c0dfce5724e8d2643c6c1b822a940e7073
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetWinDelay 1000
         SetTitleMatchMode, 2
-        run msiexec /i $file1
+        run msiexec /i ${file1}
         if ( w_opt_unattended > 0 ) {
             WinWait ahk_class MsiDialogCloseClass
             Send {Enter}
@@ -17047,14 +17047,14 @@ w_metadata wglgears benchmarks \
     year="2005" \
     media="download" \
     file1="wglgears.exe" \
-    installed_exe1="$W_SYSTEM32_DLLS_WIN/wglgears.exe"
+    installed_exe1="${W_SYSTEM32_DLLS_WIN}/wglgears.exe"
 
 load_wglgears()
 {
     # Original site http://www2.cs.uidaho.edu/~jeffery/win32/wglgears.exe is 403 as of 2019/04/07
     w_download https://web.archive.org/web/20091001002702/http://www2.cs.uidaho.edu/~jeffery/win32/wglgears.exe 858ba95ea3c9af4ded1f4100e59b6e8e57024f3efef56304dbd48106e8f2f6f7
-    cp "$W_CACHE"/wglgears/wglgears.exe "$W_SYSTEM32_DLLS"
-    chmod +x "$W_SYSTEM32_DLLS/wglgears.exe"
+    cp "${W_CACHE}"/wglgears/wglgears.exe "${W_SYSTEM32_DLLS}"
+    chmod +x "${W_SYSTEM32_DLLS}/wglgears.exe"
 }
 
 #----------------------------------------------------------------
@@ -17067,13 +17067,13 @@ w_metadata algodoo_demo games \
     year="2009" \
     media="download" \
     file1="Algodoo_1_7_1-Win32.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Algodoo/Algodoo.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Algodoo/Algodoo.exe"
 
 load_algodoo_demo()
 {
     w_download http://www.algodoo.com/download/Algodoo_1_7_1-Win32.exe 99d3704ac35028fbc74fdf7c59df3f6caf636009bba19bcddf4f7e7797c14d71
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         ; This one's funny... on Wine, keyboard works once you click manually, but until then, only ControlClick seems to work.
         run, Algodoo_1_7_1-Win32.exe
@@ -17115,13 +17115,13 @@ w_metadata amnesia_tdd_demo games \
     year="2010" \
     media="manual_download" \
     file1="amnesia_tdd_demo_1.0.1.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Amnesia - The Dark Descent Demo/redist/Amnesia.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Amnesia - The Dark Descent Demo/redist/Amnesia.exe"
 
 load_amnesia_tdd_demo()
 {
     w_download_manual https://download.cnet.com/Amnesia-The-Dark-Descent-Demo/3000-2097_4-75312743.html amnesia_tdd_demo_1.0.1.exe ee4c07b40bfa59b506d2cee258c5c7a16028e11fc3a2bd243258c6bec8532dbc
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
     w_ahk_do "
         SetTitleMatchMode, 2
@@ -17159,14 +17159,14 @@ w_metadata aoe3_demo games \
     year="2005" \
     media="download" \
     file1="aoe3trial.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Microsoft Games/Age of Empires III Trial/age3.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Microsoft Games/Age of Empires III Trial/age3.exe"
 
 load_aoe3_demo()
 {
 
     w_download https://http.download.nvidia.com/downloads/nZone/demos/aoe3trial.exe 4ef69289dfa0817ec14942d85ef597835a9d2b09e1506c60b9938b20daa274ad
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
     w_ahk_do "
         SetTitleMatchMode, 2
@@ -17207,7 +17207,7 @@ w_metadata acreedbro games \
     year="2011" \
     media="dvd" \
     file1="ACB.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Ubisoft/Assassin's Creed Brotherhood/AssassinsCreedBrotherhood.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Ubisoft/Assassin's Creed Brotherhood/AssassinsCreedBrotherhood.exe"
 
 load_acreedbro()
 {
@@ -17252,9 +17252,9 @@ load_acreedbro()
         sleep 10
     fi
 
-    w_info "Applying patch $W_CACHE/$W_PACKAGE/ac_brotherhood_1.01_ww.exe..."
+    w_info "Applying patch ${W_CACHE}/${W_PACKAGE}/ac_brotherhood_1.01_ww.exe..."
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetWinDelay 1000
         SetTitleMatchMode, 2
@@ -17286,7 +17286,7 @@ w_metadata avatar_demo games \
     year="2009" \
     media="manual_download" \
     file1="Avatar_The_Game_Demo.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Ubisoft/Demo/James Cameron's AVATAR - THE GAME (Demo)/bin/AvatarDemo.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Ubisoft/Demo/James Cameron's AVATAR - THE GAME (Demo)/bin/AvatarDemo.exe"
 
 load_avatar_demo()
 {
@@ -17296,14 +17296,14 @@ load_avatar_demo()
         w_call vcrun2005
     fi
 
-    w_try_cd "$W_TMP"
-    w_try_unrar "$W_CACHE/$W_PACKAGE/Avatar_The_Game_Demo.exe"
+    w_try_cd "${W_TMP}"
+    w_try_unrar "${W_CACHE}/${W_PACKAGE}/Avatar_The_Game_Demo.exe"
     w_ahk_do "
         SetTitleMatchMode, 2
         SetWinDelay 500
         run, setup.exe
         winwait, Language
-        u = $W_OPT_UNATTENDED
+        u = ${W_OPT_UNATTENDED}
         if ( u > 0 ) {
             WinActivate
             controlclick, Button1
@@ -17345,13 +17345,13 @@ w_metadata bttf101 games \
     year="2011" \
     media="manual_download" \
     file1="bttf_101_setup.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Telltale Games/Back to the Future The Game/Episode 1/BackToTheFuture101.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Telltale Games/Back to the Future The Game/Episode 1/BackToTheFuture101.exe"
 
 load_bttf101()
 {
     w_download_manual "https://www.fileplanet.com/220151/220000/fileinfo/Back-to-the-Future:-The-Game---Episode-1-Client-%28Free-Game%29" bttf_101_setup.exe 8ad05063c5dae096697665ac36578f885937829ec7dac6a3a3644c76820e999c
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetWinDelay 1000
         SetTitleMatchMode, 2
@@ -17384,15 +17384,15 @@ w_metadata bioshock_demo games \
     year="2007" \
     media="download" \
     file1="nzd_BioShockPC.zip" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/2K Games/BioShock Demo/Builds/Release/Bioshock.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/2K Games/BioShock Demo/Builds/Release/Bioshock.exe"
 
 load_bioshock_demo()
 {
     w_download https://us.download.nvidia.com/downloads/nZone/demos/nzd_BioShockPC.zip 36f73251c0c1c6f4b6a83af9b6e44c642b4fce127c2c28cb6d2b25bc95baa934
 
     w_info "Unzipping demo, installer will start in about 30 seconds."
-    w_try unzip "$W_CACHE/$W_PACKAGE/nzd_BioShockPC.zip" -d "$W_TMP/$W_PACKAGE"
-    w_try_cd "$W_TMP/$W_PACKAGE/BioShock PC Demo"
+    w_try unzip "${W_CACHE}/${W_PACKAGE}/nzd_BioShockPC.zip" -d "${W_TMP}/${W_PACKAGE}"
+    w_try_cd "${W_TMP}/${W_PACKAGE}/BioShock PC Demo"
 
     w_ahk_do "
         SetTitleMatchMode, 2
@@ -17436,8 +17436,8 @@ w_metadata bioshock2 games \
     year="2010" \
     media="dvd" \
     file1="BIOSHOCK_2.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/2K Games/BioShock 2/SP/Builds/Binaries/Bioshock2Launcher.exe" \
-    installed_exe2="$W_PROGRAMS_X86_WIN/2K Games/BioShock 2/MP/Builds/Binaries/Bioshock2Launcher.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/2K Games/BioShock 2/SP/Builds/Binaries/Bioshock2Launcher.exe" \
+    installed_exe2="${W_PROGRAMS_X86_WIN}/2K Games/BioShock 2/MP/Builds/Binaries/Bioshock2Launcher.exe"
 
 load_bioshock2()
 {
@@ -17490,7 +17490,7 @@ load_bfbc2()
         ControlClick, Next, Bad Company
         winwait, Bad Company, Registration Code
         sleep 500
-        send {RAW}$W_KEY
+        send {RAW}${W_KEY}
         ControlClick, Next, Bad Company, Registration Code
         winwait, Bad Company, Setup Wizard will install
         sleep 500
@@ -17522,7 +17522,7 @@ load_bfbc2()
 
     w_warn "Patching to latest version..."
 
-    w_try_cd "$W_PROGRAMS_X86_UNIX/Electronic Arts/Battlefield Bad Company 2"
+    w_try_cd "${W_PROGRAMS_X86_UNIX}/Electronic Arts/Battlefield Bad Company 2"
     w_ahk_do "
         SetTitleMatchMode, 2
         run, BFBC2Updater.exe
@@ -17536,7 +17536,7 @@ load_bfbc2()
 
     if w_workaround_wine_bug 22762; then
         # FIXME: does this directory name change in Windows 7?
-        w_try_cd "$W_DRIVE_C/users/$LOGNAME/My Documents"
+        w_try_cd "${W_DRIVE_C}/users/${LOGNAME}/My Documents"
         if test -f BFBC2/settings.ini; then
             mv BFBC2/settings.ini BFBC2/oldsettings.ini
             sed 's,DxVersion=auto,DxVersion=9,;
@@ -17562,13 +17562,13 @@ w_metadata cnc3_demo games \
     year="2007" \
     media="download" \
     file1="CnC3Demo.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Electronic Arts/Command & Conquer 3 Tiberium Wars Demo/CNC3Demo.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Electronic Arts/Command & Conquer 3 Tiberium Wars Demo/CNC3Demo.exe"
 
 load_cnc3_demo()
 {
     w_download "https://files.cncnz.com/cc3_tiberium_wars/demo/CnC3Demo.exe" 1e2499f441ef1fc3cbe447ac16361ad4247a02b9b8ec05f504161e7b5b1254e5
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetTitleMatchMode, 2
         run, CnC3Demo.exe
@@ -17605,20 +17605,20 @@ w_metadata cnc_redalert3_demo games \
     year="2008" \
     media="manual_download" \
     file1="RedAlert3Demo.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Electronic Arts/Red Alert 3 Demo/RA3Demo.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Electronic Arts/Red Alert 3 Demo/RA3Demo.exe"
 
 load_cnc_redalert3_demo()
 {
     w_download_manual 'https://www.fileplanet.com/194888/190000/fileinfo/Command-&-Conquer:-Red-Alert-3-Demo' RedAlert3Demo.exe 9c2fb15076830f0e11d89be1847f4777262d8e6ee3d51ae765535f812a8a8cb2
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    if test ! "$W_OPT_UNATTENDED"; then
-        w_try "$WINE" "$file1"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    if test ! "${W_OPT_UNATTENDED}"; then
+        w_try "${WINE}" "${file1}"
     else
         w_ahk_do "
             SetWinDelay 1000
             SetTitleMatchMode, 2
-            run $file1
+            run ${file1}
             winwait, Demo, readme
             send {enter}                           ; Install button
             winwait, Demo, Agreement
@@ -17657,7 +17657,7 @@ w_metadata blobby_volley games \
 load_blobby_volley()
 {
     w_download_manual https://www.chip.de/downloads/Blobby-Volley_12990993.html blobby.zip ef7d2e61fabe5ac6a556fa7c254edc667df5a6659ea262ee2bc97ed61abc3f64
-    w_try_unzip "$W_DRIVE_C/BlobbyVolley" "$W_CACHE/$W_PACKAGE"/blobby.zip
+    w_try_unzip "${W_DRIVE_C}/BlobbyVolley" "${W_CACHE}/${W_PACKAGE}"/blobby.zip
 }
 
 #----------------------------------------------------------------
@@ -17668,15 +17668,15 @@ w_metadata cim_demo games \
     year="2010" \
     media="manual_download" \
     file1="cim-demo-1-0-8.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Cities In Motion Demo/Cities In Motion.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Cities In Motion Demo/Cities In Motion.exe"
 
 load_cim_demo()
 {
     # 29 Mar 2011 cf02066f496637c24f95cf0c4ddfae376951330802500fb11bd74cc6c8872995, Inno Setup installer
     #w_download https://www.pcgamestore.com/games/cities-in-motion-nbsp/trial/cim-demo-1-0-8.exe cf02066f496637c24f95cf0c4ddfae376951330802500fb11bd74cc6c8872995
     w_download_manual https://www.fileplanet.com/218762/210000/fileinfo/Cities-in-Motion-Demo cim-demo-1-0-8.exe cf02066f496637c24f95cf0c4ddfae376951330802500fb11bd74cc6c8872995
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" cim-demo-1-0-8.exe ${W_OPT_UNATTENDED:+ /sp- /silent /norestart}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" cim-demo-1-0-8.exe ${W_OPT_UNATTENDED:+ /sp- /silent /norestart}
 }
 
 #----------------------------------------------------------------
@@ -17687,13 +17687,13 @@ w_metadata cod_demo games \
     year="2003" \
     media="manual_download" \
     file1="call_of_duty_demo.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Call of Duty Single Player Demo/CoDSP.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Call of Duty Single Player Demo/CoDSP.exe"
 
 load_cod_demo()
 {
     w_download_manual https://www.gamefront.com/files/968870/call_of_duty_demo_exe Call_Of_Duty_Demo.exe a7773f1ddb0c9928f738a2be34614d52bc07ecc42c0fe704ab5a596da5421b08
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetTitleMatchMode, 2
         run Call_Of_Duty_Demo.exe
@@ -17757,7 +17757,7 @@ load_cod1()
         run ${W_ISO_MOUNT_LETTER}:setup.exe
         WinWait, w_try_cd Key, enter
         if ( w_opt_unattended > 0 ) {
-            send {Raw}$W_KEY
+            send {Raw}${W_KEY}
             ControlClick Button1
             WinWait, w_try_cd Key, valid
             ControlClick Button1
@@ -17777,7 +17777,7 @@ load_cod1()
         WinWait, Insert CD, Please insert the Call of Duty cd 2
         "
 
-    "$WINE" eject ${W_ISO_MOUNT_LETTER}:
+    "${WINE}" eject ${W_ISO_MOUNT_LETTER}:
     w_mount CoD2
 
     w_ahk_do "
@@ -17788,7 +17788,7 @@ load_cod1()
         WinWait, Insert CD, Please insert the Call of Duty cd 1
     "
 
-    "$WINE" eject ${W_ISO_MOUNT_LETTER}:
+    "${WINE}" eject ${W_ISO_MOUNT_LETTER}:
     w_mount CoD1
 
     w_ahk_do "
@@ -17810,7 +17810,7 @@ load_cod1()
         }
         WinWaitClose
     "
-    "$WINE" eject ${W_ISO_MOUNT_LETTER}:
+    "${WINE}" eject ${W_ISO_MOUNT_LETTER}:
 
     if w_workaround_wine_bug 21558; then
         # Work around a buffer overflow - not really Wine's fault
@@ -17827,14 +17827,14 @@ w_metadata cod4mw_demo games \
     year="2007" \
     media="manual_download" \
     file1="CoD4MWDemoSetup_v2.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Activision/Call of Duty 4 - Modern Warfare Demo/iw3sp.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Activision/Call of Duty 4 - Modern Warfare Demo/iw3sp.exe"
 
 load_cod4mw_demo()
 {
     # 2017/03/28: Also at https://www.fileplanet.com/213663/210000/fileinfo/LEGO-Harry-Potter:-Years-1-4-Demo
     w_download_manual https://download.cnet.com/Call-of-Duty-4-Modern-Warfare/3000-7441_4-11277584.html CoD4MWDemoSetup_v2.exe 715710678394e9b0edda5dd3a560c9711557297aa2849c83e5c109db9830fbbb
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetTitleMatchMode, 2
         run, CoD4MWDemoSetup_v2.exe
@@ -17879,7 +17879,7 @@ w_metadata cod5_waw games \
     year="2008" \
     media="dvd" \
     file1="5330161c7960f0770e6b05f498ab9fd13be4cfad.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Activision/Call of Duty - World at War/CoDWaW.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Activision/Call of Duty - World at War/CoDWaW.exe"
 
 load_cod5_waw()
 {
@@ -17892,7 +17892,7 @@ load_cod5_waw()
         run, ${W_ISO_MOUNT_LETTER}:setup.exe
         winwait, Call of Duty, Key Code
         sleep 1000
-        Send $W_KEY
+        Send ${W_KEY}
         sleep 1000
         ControlClick, Button1, Call of Duty, Key Code
         winwait, Key Code Check
@@ -17943,14 +17943,14 @@ w_metadata civ4_demo games \
     year="2005" \
     media="manual_download" \
     file1="Civilization4_Demo.zip" \
-    installed_file1="$W_PROGRAMS_X86_WIN/Firaxis Games/Sid Meier's Civilization 4 Demo/Civilization4.exe"
+    installed_file1="${W_PROGRAMS_X86_WIN}/Firaxis Games/Sid Meier's Civilization 4 Demo/Civilization4.exe"
 
 load_civ4_demo()
 {
     w_download_manual https://download.cnet.com/Civilization-IV-demo/3000-7489_4-10465206.html Civilization4_Demo.zip aaafc7fcbf0fc16c9b28c2422400721a40818b867e9291268877c5d3841122a2
 
-    w_try_unzip "$W_TMP" "$W_CACHE/$W_PACKAGE"/Civilization4_Demo.zip
-    w_try_cd "$W_TMP/$W_PACKAGE"
+    w_try_unzip "${W_TMP}" "${W_CACHE}/${W_PACKAGE}"/Civilization4_Demo.zip
+    w_try_cd "${W_TMP}/${W_PACKAGE}"
     chmod +x setup.exe
     w_ahk_do "
         SetTitleMatchMode, 2
@@ -17983,14 +17983,14 @@ w_metadata crayonphysics_demo games \
     year="2011" \
     media="download" \
     file1="crayon_release52demo.exe" \
-    installed_exe1="$W_PROGRAMS_WIN/Crayon Physics Deluxe Demo/crayon.exe" \
+    installed_exe1="${W_PROGRAMS_WIN}/Crayon Physics Deluxe Demo/crayon.exe" \
     homepage="http://crayonphysics.com"
 
 load_crayonphysics_demo()
 {
     w_download https://crayonphysicsdeluxe.s3.amazonaws.com/crayon_release52demo.exe 3c221f4c4283d89c180337071b5d3f8b88b68cea0558e6f72abcb34ef954b923
     # Inno Setup installer
-    w_try "$WINE" "$W_CACHE/$W_PACKAGE/$file1" ${W_OPT_UNATTENDED:+ /sp- /silent /norestart}
+    w_try "${WINE}" "${W_CACHE}/${W_PACKAGE}/${file1}" ${W_OPT_UNATTENDED:+ /sp- /silent /norestart}
 }
 
 #----------------------------------------------------------------
@@ -18001,7 +18001,7 @@ w_metadata crysis2 games \
     year="2011" \
     media="dvd" \
     file1="Crysis2.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/Electronic Arts/Crytek/Crysis 2/bin32/Crysis2.exe"
+    installed_file1="${W_PROGRAMS_X86_WIN}/Electronic Arts/Crytek/Crysis 2/bin32/Crysis2.exe"
 
 load_crysis2()
 {
@@ -18064,13 +18064,13 @@ w_metadata csi6_demo games \
     year="2010" \
     media="manual_download" \
     file1="CSI6_PC_Demo_05.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Ubisoft/Telltale Games/CSI - Fatal Conspiracy Demo/CSI6Demo.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Ubisoft/Telltale Games/CSI - Fatal Conspiracy Demo/CSI6Demo.exe"
 
 load_csi6_demo()
 {
     w_download_manual https://www.fileplanet.com/217175/download/CSI:-Fatal-Conspiracy-Demo CSI6_PC_Demo_05.exe dd80e8e2ad2716a49ae292da99c4d069e2193d64ee62ca2941ce93fd7ee3b015
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetWinDelay 1000
         SetTitleMatchMode, 2
@@ -18103,13 +18103,13 @@ w_metadata darknesswithin2_demo games \
     year="2010" \
     media="manual_download" \
     file1="DarknessWithin2Demo.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Iceberg Interactive/Darkness Within 2 Demo/DarkLineage.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Iceberg Interactive/Darkness Within 2 Demo/DarkLineage.exe"
 
 load_darknesswithin2_demo()
 {
     w_download_manual http://www.bigdownload.com/games/darkness-within-2-the-dark-lineage/pc/darkness-within-2-the-dark-lineage-demo DarknessWithin2Demo.exe
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetTitleMatchMode, 2
         run, DarknessWithin2Demo.exe
@@ -18154,7 +18154,7 @@ w_metadata darkspore games \
     year="2011" \
     media="dvd" \
     file1="DARKSPORE.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Electronic Arts/Darkspore/DarksporeBin/Darkspore.exe" \
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Electronic Arts/Darkspore/DarksporeBin/Darkspore.exe" \
     homepage="http://darkspore.com/"
 
 load_darkspore()
@@ -18205,7 +18205,7 @@ w_metadata dcuo games \
     media="dvd" \
     file1="DCUO - Disc 1.iso" \
     file2="DCUO - Disc 2.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Sony Online Entertainment/Installed Games/DC Universe Online Live/LaunchPad.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Sony Online Entertainment/Installed Games/DC Universe Online Live/LaunchPad.exe"
 
 load_dcuo()
 {
@@ -18294,7 +18294,7 @@ w_metadata deadspace games \
     year="2008" \
     media="dvd" \
     file1="DEADSPACE.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Electronic Arts/Dead Space/Dead Space.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Electronic Arts/Dead Space/Dead Space.exe"
 
 load_deadspace()
 {
@@ -18318,10 +18318,10 @@ load_deadspace()
         winwait, Dead
         send {Enter}
         winwait, Dead, Registration Code
-        send {RAW}$W_KEY
+        send {RAW}${W_KEY}
         Sleep 1000
         controlclick, Button2
-        $msvcrun_me_harder
+        ${msvcrun_me_harder}
         winwait, Setup, License
         Sleep 1000
         controlclick, Button1
@@ -18354,7 +18354,7 @@ w_metadata deadspace2 games \
     media="dvd" \
     file1="Disc1.iso" \
     file2="Disc2.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/EA Games/Dead Space 2/deadspace2.exe" \
+    installed_exe1="${W_PROGRAMS_X86_WIN}/EA Games/Dead Space 2/deadspace2.exe" \
 
 load_deadspace2()
 {
@@ -18366,26 +18366,26 @@ load_deadspace2()
     #
     # Work around bug 25963 (fails to switch discs)
     w_warn "Copying discs to hard drive.  This will take a few minutes."
-    w_try_cd "$W_TMP"
+    w_try_cd "${W_TMP}"
     # Copy takes a LONG time, so offer a way to avoid copy while debugging verb
     # You'll need to comment out the five "rm -rf"'s, too.
     if test ! -f easetup.exe; then
-        w_try cp -R "$W_ISO_MOUNT_ROOT"/* .
+        w_try cp -R "${W_ISO_MOUNT_ROOT}"/* .
         # Make the directories writable, else 2nd disc copy will fail.
         w_try chmod -R +w .
         w_mount Disc2
         # On Linux, use symlinks for disc 2.  (On Cygwin, we'd have to copy.)
-        w_try ln -s "$W_ISO_MOUNT_ROOT"/*.dat .
+        w_try ln -s "${W_ISO_MOUNT_ROOT}"/*.dat .
         mkdir -p movies/en movies/fr
-        w_try ln -s "$W_ISO_MOUNT_ROOT"/movies/en/* movies/en/
-        w_try ln -s "$W_ISO_MOUNT_ROOT"/movies/fr/* movies/fr/
+        w_try ln -s "${W_ISO_MOUNT_ROOT}"/movies/en/* movies/en/
+        w_try ln -s "${W_ISO_MOUNT_ROOT}"/movies/fr/* movies/fr/
         # Make the files writable, otherwise you'll get errors when trying to remove the temp directory.
         chmod -R +w .
     fi
 
     # Install takes a long time, so offer a way to skip installation
     # and go straight to activation while debugging that
-    if ! test -f "$W_PROGRAMS_X86_UNIX/EA Games/Dead Space 2/deadspace2.exe"; then
+    if ! test -f "${W_PROGRAMS_X86_UNIX}/EA Games/Dead Space 2/deadspace2.exe"; then
       w_ahk_do "
         run easetup.exe
         if ( w_opt_unattended > 0 ) {
@@ -18438,7 +18438,7 @@ load_deadspace2()
     fi
 
     # Activate the game
-    w_try_cd "$W_PROGRAMS_X86/EA Games/Dead Space 2"
+    w_try_cd "${W_PROGRAMS_X86}/EA Games/Dead Space 2"
     w_ahk_do "
         run activation.exe
         if ( w_opt_unattended > 0 ) {
@@ -18448,7 +18448,7 @@ load_deadspace2()
             controlclick TBitBtn2  ; Next
             WinWait, Product activation, Serial
             sleep 500
-            send $W_KEY
+            send ${W_KEY}
             controlclick TBitBtn3  ; Next
             WinWait, Information
             sleep 4000             ; let user see what happened
@@ -18466,14 +18466,14 @@ w_metadata deusex2_demo games \
     year="2003" \
     media="manual_download" \
     file1="dxiw_demo.zip" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Deus Ex - Invisible War Demo/System/DX2.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Deus Ex - Invisible War Demo/System/DX2.exe"
 
 load_deusex2_demo()
 {
     w_download_manual https://www.fileplanet.com/133479/130000/fileinfo/Deus-Ex:-INVISIBLE-WAR-Demo dxiw_demo.zip cd3804a03301afd582c9c9374a670944b8cc1470ad1c2e5f3cd602c60d70244f
 
-    w_try unzip "$W_CACHE/$W_PACKAGE/dxiw_demo.zip" -d "$W_TMP"
-    w_try_cd "$W_TMP"
+    w_try unzip "${W_CACHE}/${W_PACKAGE}/dxiw_demo.zip" -d "${W_TMP}"
+    w_try_cd "${W_TMP}"
     w_ahk_do "
         SetTitleMatchMode 2
         SetWinDelay 500
@@ -18512,7 +18512,7 @@ w_metadata diablo2 games \
     file1="INSTALL.iso" \
     file2="PLAYDISC.iso" \
     file3="CINEMATICS.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Diablo II/Diablo II.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Diablo II/Diablo II.exe"
 
 load_diablo2()
 {
@@ -18529,8 +18529,8 @@ load_diablo2()
         winwait, Choose Installation Size
         send {u}
         send {Enter}
-        send {Raw}$LOGNAME
-        send {Tab}{Raw}$W_KEY
+        send {Raw}${LOGNAME}
+        send {Tab}{Raw}${W_KEY}
         send {Enter}
         winwait, Diablo II - choose install directory
         send {Enter}
@@ -18539,7 +18539,7 @@ load_diablo2()
         winwait, Insert Disc"
     w_mount PLAYDISC
     # Needed by patch 1.13c to avoid disc swapping
-    cp "$W_ISO_MOUNT_ROOT"/d2music.mpq "$W_PROGRAMS_UNIX/Diablo II/"
+    cp "${W_ISO_MOUNT_ROOT}"/d2music.mpq "${W_PROGRAMS_UNIX}/Diablo II/"
     w_ahk_do "
         send, {Enter}
         Sleep 1000
@@ -18561,8 +18561,8 @@ load_diablo2()
         ControlClick &Cancel, Diablo II Setup - Video Test
         winclose, Diablo II Setup"
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" D2Patch_113c.exe
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" D2Patch_113c.exe
     w_ahk_do "
         winwait, Blizzard Updater v2.72, has completed
         Sleep 1000
@@ -18580,15 +18580,15 @@ w_metadata digitanks_demo games \
     year="2011" \
     media="download" \
     file1="digitanks.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Digitanks/digitanksdemo.exe" \
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Digitanks/digitanksdemo.exe" \
     homepage="http://www.digitanks.com"
 
 load_digitanks_demo()
 {
     # 2011/11/11: bc98de67680e907a30ee1ab5d062e098c07a87292e3fb82ae62ad2d7175e94ff
     w_download "http://static.digitanks.com/files/digitanks.exe" bc98de67680e907a30ee1ab5d062e098c07a87292e3fb82ae62ad2d7175e94ff
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_try "$WINE" "$file1" ${W_OPT_UNATTENDED:+ /S}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+ /S}
     if w_workaround_wine_bug 8060 "installing corefonts"; then
         w_call corefonts
     fi
@@ -18600,13 +18600,13 @@ w_metadata dirt2_demo games \
     year="2009" \
     media="manual_download" \
     file1="Dirt2Demo.zip" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Codemasters/DiRT2 Demo/dirt2.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Codemasters/DiRT2 Demo/dirt2.exe"
 
 load_dirt2_demo()
 {
     w_download_manual https://www.fileplanet.com/207823/200000/fileinfo/DiRT-2-Demo Dirt2Demo.zip fbae62d04e3e33790fe78803577efc8ef9ff7e552220c944023b53315e0db9de
 
-    w_try_unzip "$W_TMP/$W_PACKAGE" "$W_CACHE/$W_PACKAGE/Dirt2Demo.zip"
+    w_try_unzip "${W_TMP}/${W_PACKAGE}" "${W_CACHE}/${W_PACKAGE}/Dirt2Demo.zip"
 
     if w_workaround_wine_bug 23532; then
         w_call gfw
@@ -18616,7 +18616,7 @@ load_dirt2_demo()
         w_call d3dx9_36
     fi
 
-    w_try_cd "$W_TMP/$W_PACKAGE"
+    w_try_cd "${W_TMP}/${W_PACKAGE}"
 
     w_ahk_do "
         Run, Setup.exe
@@ -18659,13 +18659,13 @@ w_metadata demolition_company_demo games \
     year="2010" \
     media="manual_download" \
     file1="DemolitionCompanyDemoENv2.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Demolition Company Demo/DemolitionCompany.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Demolition Company Demo/DemolitionCompany.exe"
 
 load_demolition_company_demo()
 {
     w_download_manual https://www.demolitioncompany-thegame.com/demo.php DemolitionCompanyDemoENv2.exe
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetTitleMatchMode, 2
         run, DemolitionCompanyDemoENv2.exe
@@ -18700,7 +18700,7 @@ w_metadata dragonage games \
     year="2009" \
     media="dvd" \
     file1="DragonAge.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Dragon Age/bin_ship/daorigins.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Dragon Age/bin_ship/daorigins.exe"
 
 load_dragonage()
 {
@@ -18728,7 +18728,7 @@ load_dragonage()
             send {Enter} ; continue
             SetTitleMatchMode, 1
             winwait, Dragon Age: Origins, Registration
-            send $W_KEY
+            send ${W_KEY}
             send {Enter}
         }
         winwait, Dragon Age: Origins Setup, Install Type
@@ -18738,24 +18738,24 @@ load_dragonage()
     "
     # Since the installer explodes on exit, just wait for the
     # last file it's known to create
-    while ! test -f "$W_PROGRAMS_X86_UNIX/Dragon Age/bin_ship/DAOriginsLauncher-MCE.png"; do
+    while ! test -f "${W_PROGRAMS_X86_UNIX}/Dragon Age/bin_ship/DAOriginsLauncher-MCE.png"; do
         w_info "Waiting for installer to finish..."
         sleep 1
     done
 
     # FIXME: does this directory name change in Windows 7?
-    ini="$W_DRIVE_C/users/$LOGNAME/My Documents/BioWare/Dragon Age/Settings/DragonAge.ini"
-    if ! test -f "$ini"; then
-        w_warn "$ini not found?"
+    ini="${W_DRIVE_C}/users/${LOGNAME}/My Documents/BioWare/Dragon Age/Settings/DragonAge.ini"
+    if ! test -f "${ini}"; then
+        w_warn "${ini} not found?"
     else
-        cp -f "$ini" "$ini.old"
+        cp -f "${ini}" "${ini}.old"
     fi
     if w_workaround_wine_bug 22383 "use strictdrawordering to avoid video problems"; then
         w_call strictdrawordering=enabled
     fi
     if w_workaround_wine_bug 22557 "Setting UseVSync=0 to avoid black menu"; then
-        sed 's,UseVSync=1,UseVSync=0,' < "$ini" > "$ini.new"
-        mv -f "$ini.new" "$ini"
+        sed 's,UseVSync=1,UseVSync=0,' < "${ini}" > "${ini}.new"
+        mv -f "${ini}.new" "${ini}"
     fi
 }
 
@@ -18795,7 +18795,7 @@ load_dragonage_ue()
             winwait, Dragon Age: Origins, Registration
             controlclick, Edit1
             sleep 1000
-            send $W_KEY
+            send ${W_KEY}
             send {Enter}
             winwait, Dragon Age: Origins Setup, Install Type
             controlclick, Button2, Dragon Age: Origins Setup, Install Type
@@ -18845,13 +18845,13 @@ w_metadata dragonage2_demo games \
     year="2011" \
     media="download" \
     file1="DragonAge2Demo_F93M2qCj_EnEsItPlRu.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Dragon Age 2 Demo/bin_ship/DragonAge2Demo.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Dragon Age 2 Demo/bin_ship/DragonAge2Demo.exe"
 
 load_dragonage2_demo()
 {
     w_download https://lvlt.bioware.cdn.ea.com/bioware/u/f/eagames/bioware/dragonage2/demo/DragonAge2Demo_F93M2qCj_EnEsItPlRu.exe 615c014deed9b97de5662774fe25074862a7873c430d5d3650d07c7ce2727e9d
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetWinDelay 500
         SetTitleMatchMode, 2
@@ -18892,13 +18892,13 @@ load_eve()
     # https://community.eveonline.com/support/download/
     w_download https://binaries.eveonline.com/EveLauncher-1104888.exe d1d66ea0a0e4a476a926307dcdb3d7b5e777d7cff7feb172ce7779dac9fdae8f
 
-    if test "$W_OPT_UNATTENDED"; then
+    if test "${W_OPT_UNATTENDED}"; then
         w_warn "Quiet mode doesn't work with latest eve update, button names don't appear in AHK."
     fi
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
-        run, $file1
+        run, ${file1}
         WinWait, EVE Online
         if ( w_opt_unattended > 0 ) {
             WinActivate
@@ -18931,7 +18931,7 @@ w_metadata fable_tlc games \
     file2="FABLE DISC 2.iso" \
     file3="FABLE DISC 3.iso" \
     file4="FABLE DISC 4.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Microsoft Games/Fable - The Lost Chapters/Fable.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Microsoft Games/Fable - The Lost Chapters/Fable.exe"
 
 load_fable_tlc()
 {
@@ -18954,7 +18954,7 @@ load_fable_tlc()
             ControlClick Button4 ; Next
             WinWait,Fable,Product Key
             Sleep 500
-            Send $W_KEY
+            Send ${W_KEY}
             Send {Enter}
         }
         WinWait,Fable,Disk 2
@@ -18995,24 +18995,24 @@ load_fable_tlc()
 
     # Now tell game what the real disc is so user can insert disc 1 and run the game!
     # FIXME: don't guess it's D:
-    cat > "$W_TMP/${W_PACKAGE}.reg" <<_EOF_
+    cat > "${W_TMP}/${W_PACKAGE}.reg" <<_EOF_
 REGEDIT4
 
 [HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Installer\\UserData\\S-1-5-18\\Products\\D3BE9C3CAF4226447B48E06CAACF2DDD\\InstallProperties]
 "InstallSource"="D:\\"
 
 _EOF_
-    try_regedit "$W_TMP_WIN\\${W_PACKAGE}.reg"
+    try_regedit "${W_TMP_WIN}\\${W_PACKAGE}.reg"
 
     # Also accept EULA
-    cat > "$W_TMP/${W_PACKAGE}.reg" <<_EOF_
+    cat > "${W_TMP}/${W_PACKAGE}.reg" <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Microsoft\\Microsoft Games\\Fable TLC]
 "FIRSTRUN"=dword:00000001
 
 _EOF_
-    try_regedit "$W_TMP_WIN\\${W_PACKAGE}.reg"
+    try_regedit "${W_TMP_WIN}\\${W_PACKAGE}.reg"
 
     if w_workaround_wine_bug 24912; then
         # kill off lingering installer
@@ -19043,15 +19043,15 @@ w_metadata fifa11_demo games \
     year="2010" \
     media="download" \
     file1="fifa11_pc_demo_NA.zip" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/EA Sports/FIFA 11 Demo/Game/fifa.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/EA Sports/FIFA 11 Demo/Game/fifa.exe"
 
 load_fifa11_demo()
 {
     # From https://www.ea.com/uk/football/news/fifa11-download-2
     w_download "http://static.cdn.ea.com/fifa/u/f/fifa11_pc_demo_NA.zip" 8b51b5d7b017c4a198fdfae1c348666f99cd60271835d608357f2ad893e5be43
 
-    w_try unzip -d "$W_TMP" "$W_CACHE/$W_PACKAGE/fifa11_pc_demo_NA.zip"
-    w_try_cd "$W_TMP"
+    w_try unzip -d "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/fifa11_pc_demo_NA.zip"
+    w_try_cd "${W_TMP}"
 
     w_ahk_do "
         SetTitleMatchMode, 2
@@ -19105,7 +19105,7 @@ w_metadata hon games \
     year="2018" \
     media="download" \
     file1="HoNClient.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Heroes of Newerth/hon.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Heroes of Newerth/hon.exe"
 
 load_hon()
 {
@@ -19113,10 +19113,10 @@ load_hon()
     # 2018/06/03: d4c82a3c5fdaee193675838e2fe6ade6b9fcdc4bdaf57848300c0eb09e71a945
     w_download http://dl.heroesofnewerth.com/installers/win32/HoNClient.exe d4c82a3c5fdaee193675838e2fe6ade6b9fcdc4bdaf57848300c0eb09e71a945
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetTitleMatchMode, 2
-        run, $file1
+        run, ${file1}
         winwait, Installer Language
         if ( w_opt_unattended > 0 ) {
             send {Enter}
@@ -19148,13 +19148,13 @@ w_metadata hordesoforcs2_demo games \
     year="2010" \
     media="manual_download" \
     file1="HoO2Demo.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Hordes of Orcs 2 Demo/HoO2.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Hordes of Orcs 2 Demo/HoO2.exe"
 
 load_hordesoforcs2_demo()
 {
     w_download_manual https://www.fileplanet.com/216619/download/Hordes-of-Orcs-2-Demo HoO2Demo.exe 9c26e420c56268ca14e5cfa6552a9034fc2ea974714b5bfd427e611dfde197be
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetTitleMatchMode, 2
         SetWinDelay 500
@@ -19194,7 +19194,7 @@ w_metadata mfsxde games \
     media="dvd" \
     file1="FSX DISK 1.iso" \
     file2="FSX DISK 2.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Microsoft Games/Microsoft Flight Simulator X/fsx.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Microsoft Games/Microsoft Flight Simulator X/fsx.exe"
 
 load_mfsxde()
 {
@@ -19205,12 +19205,12 @@ load_mfsxde()
     w_mount "FSX DISK 1"
 
     if w_workaround_wine_bug 25558 "Copying disc to hard drive.  This will take a few minutes."; then
-        w_try_cd "$W_CACHE/$W_PACKAGE"
+        w_try_cd "${W_CACHE}/${W_PACKAGE}"
         # Copy takes a LONG time, so offer a way to avoid copy while debugging verb
         if test ! -f bothdiscs/setup.exe; then
             mkdir bothdiscs
             w_try_cd bothdiscs
-            w_try cp -R "$W_ISO_MOUNT_ROOT"/* .
+            w_try cp -R "${W_ISO_MOUNT_ROOT}"/* .
 
             # A few files are on both DVDs. Remove them manually so cp doesn't complain.
             rm -f DVDCheck.exe autorun.inf fsx.ico vcredist_x86.exe
@@ -19221,7 +19221,7 @@ load_mfsxde()
             w_mount "FSX DISK 2"
 
             # On Linux, use symlinks for disc 2.  (On Cygwin, we'd have to copy.)
-            w_try ln -s "$W_ISO_MOUNT_ROOT"/* .
+            w_try ln -s "${W_ISO_MOUNT_ROOT}"/* .
 
             # Make the files writable, otherwise you'll get errors when trying to remove bothdiscs.
             chmod -R +w .
@@ -19267,7 +19267,7 @@ w_metadata mfsx_demo games \
     year="2006" \
     media="download" \
     file1="FSXDemo.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Microsoft Games/Microsoft Flight Simulator X Demo/fsx.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Microsoft Games/Microsoft Flight Simulator X Demo/fsx.exe"
 
 load_mfsx_demo()
 {
@@ -19277,8 +19277,8 @@ load_mfsx_demo()
 
     # 2017/03/28: also available at http://www.gamewatcher.com/downloads/flight-simulator-x-download/flight-simulator-x-final-demo
     w_download_manual "https://www.fileplanet.com/166127/160000/fileinfo/Microsoft-Flight-Simulator-X-Demo-[Final]" fsxdemo.exe 0d616d8fb6315c15e9919a29968f98b1feda14a2a284721dad114395154e58be
-    w_try_cd "$W_TMP"
-    unzip "$W_CACHE/$W_PACKAGE"/FSXDemo.exe
+    w_try_cd "${W_TMP}"
+    unzip "${W_CACHE}/${W_PACKAGE}"/FSXDemo.exe
     w_ahk_do "
         SetWinDelay 1000
         SetTitleMatchMode, 2
@@ -19311,7 +19311,7 @@ w_metadata gta_vc games \
     media="cd" \
     file1="GTA_VICE_CITY.iso" \
     file2="VICE_CITY_PLAY.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Rockstar Games/Grand Theft Auto Vice City/gta-vc.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Rockstar Games/Grand Theft Auto Vice City/gta-vc.exe"
 
 load_gta_vc()
 {
@@ -19330,7 +19330,7 @@ load_gta_vc()
             send {enter}
             winwait, Grand Theft Auto Vice City, Customer Information
             controlclick, edit1
-            send $LOGNAME
+            send ${LOGNAME}
             send {tab}
             send company ; installer won't proceed without something here
             send {enter}
@@ -19362,11 +19362,11 @@ load_gta_vc()
         w_call vd=800x600
     fi
 
-    myexec="Exec=env WINEPREFIX=\"$WINEPREFIX\" wine cmd /c 'C:\\\\\\\\Run-gta_vc.bat'"
-    mymenu="$XDG_DATA_HOME/applications/wine/Programs/Rockstar Games/Grand Theft Auto Vice City/Play GTA Vice City.desktop"
-    if test -f "$mymenu" && w_workaround_wine_bug 26304 "Fixing system menu"; then
+    myexec="Exec=env WINEPREFIX=\"${WINEPREFIX}\" wine cmd /c 'C:\\\\\\\\Run-gta_vc.bat'"
+    mymenu="${XDG_DATA_HOME}/applications/wine/Programs/Rockstar Games/Grand Theft Auto Vice City/Play GTA Vice City.desktop"
+    if test -f "${mymenu}" && w_workaround_wine_bug 26304 "Fixing system menu"; then
         # this is a hack, hopefully the wine bug will be fixed soon
-        sed -i "s,Exec=.*,$myexec," "$mymenu"
+        sed -i "s,Exec=.*,${myexec}," "${mymenu}"
     fi
 }
 
@@ -19381,7 +19381,7 @@ w_metadata kotor1 games \
     file2="KOTOR_2.iso" \
     file3="KOTOR_3.iso" \
     file4="KOTOR_4.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/LucasArts/SWKotOR/swkotor.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/LucasArts/SWKotOR/swkotor.exe"
 
 load_kotor1()
 {
@@ -19460,13 +19460,13 @@ w_metadata losthorizon_demo games \
     year="2010" \
     media="manual_download" \
     file1="Lost_Horizon_Demo_EN.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Deep Silver/Lost Horizon Demo/fsasgame.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Deep Silver/Lost Horizon Demo/fsasgame.exe"
 
 load_losthorizon_demo()
 {
     w_download_manual https://www.fileplanet.com/215704/download/Lost-Horizon-Demo Lost_Horizon_Demo_EN.exe
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
     w_ahk_do "
         SetTitleMatchMode, 2
@@ -19519,11 +19519,11 @@ w_metadata lhp_demo games \
     year="2010" \
     media="manual_download" \
     file1="LEGOHarryPotterDEMO.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/WB Games/LEGO_Harry_Potter_DEMO/LEGOHarryPotterDEMO.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/WB Games/LEGO_Harry_Potter_DEMO/LEGOHarryPotterDEMO.exe"
 
 load_lhp_demo()
 {
-    case "$LANG" in
+    case "${LANG}" in
         *UTF-8*|*utf8*) ;;
         *)
             w_warn "This installer fails in non-utf-8 locales. Doing 'export LANG=en_US.UTF-8' is a workaround."
@@ -19532,12 +19532,12 @@ load_lhp_demo()
             ;;
     esac
 
-    w_download_manual "https://www.fileplanet.com/213663/210000/fileinfo/LEGO-Harry-Potter:-Years-1-4-Demo" "$file1" 01d8e88511d71f5dd1492034ea4b00eacdbbf891ef23cffa31413d232eee3647
+    w_download_manual "https://www.fileplanet.com/213663/210000/fileinfo/LEGO-Harry-Potter:-Years-1-4-Demo" "${file1}" 01d8e88511d71f5dd1492034ea4b00eacdbbf891ef23cffa31413d232eee3647
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetTitleMatchMode, 2
-        run, $file1
+        run, ${file1}
         winwait, LEGO, language
         if ( w_opt_unattended > 0 ) {
             controlclick, Button1
@@ -19556,7 +19556,7 @@ load_lhp_demo()
 
     # Work around locale issues by symlinking the app's directory to not have a funny char
     # Won't really work on Cygwin, but that's ok.
-    w_try_cd "$W_PROGRAMS_X86_UNIX/WB Games"
+    w_try_cd "${W_PROGRAMS_X86_UNIX}/WB Games"
     ln -s LEGO*Harry\ Potter*DEMO LEGO_Harry_Potter_DEMO
 }
 
@@ -19568,7 +19568,7 @@ w_metadata lswcs games \
     year="2009" \
     media="dvd" \
     file1="LEGOSAGA.iso" \
-    installed_file1="$W_PROGRAMS_X86_WIN/LucasArts/LEGO Star Wars - The Complete Saga/LEGOStarWarsSaga.exe"
+    installed_file1="${W_PROGRAMS_X86_WIN}/LucasArts/LEGO Star Wars - The Complete Saga/LEGOStarWarsSaga.exe"
 
 load_lswcs()
 {
@@ -19657,7 +19657,7 @@ w_metadata luxor_ar games \
     year="2006" \
     media="cd" \
     file1="LUXOR_AMUNRISING.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/MumboJumbo/Luxor Amun Rising/Luxor AR.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/MumboJumbo/Luxor Amun Rising/Luxor AR.exe"
 
 load_luxor_ar()
 {
@@ -19693,7 +19693,7 @@ w_metadata masseffect2 games \
     media="dvd" \
     file1="MassEffect2.iso" \
     file2="ME2_Disc2.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Mass Effect 2/Binaries/MassEffect2.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Mass Effect 2/Binaries/MassEffect2.exe"
 
 load_masseffect2()
 {
@@ -19712,7 +19712,7 @@ load_masseffect2()
             ControlClick, Button4
             ControlClick, Button2
             winwait, Mass Effect, Registration Code
-            send $W_KEY
+            send ${W_KEY}
             ControlClick, Button2
             winwait, Mass Effect, Install Type
             ControlClick, Button2
@@ -19758,21 +19758,21 @@ w_metadata masseffect2_demo games \
     year="2010" \
     media="download" \
     file1="MassEffect2DemoEN.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Mass Effect 2 Demo/Binaries/MassEffect2.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Mass Effect 2 Demo/Binaries/MassEffect2.exe"
 
 load_masseffect2_demo()
 {
     w_download http://static.cdn.ea.com/bioware/u/f/eagames/bioware/masseffect2/ME2_DEMO/MassEffect2DemoEN.exe 4ec5ce1dc90c10512324d24cba2b5b9ba1e1872ed4c23e3ede0fc0accc7d2ff2
 
-    # Don't let self-extractor write into $W_CACHE
-    case "$W_PLATFORM" in
+    # Don't let self-extractor write into ${W_CACHE}
+    case "${W_PLATFORM}" in
         windows_cmd|wine_cmd)
-            cp "$W_CACHE/$W_PACKAGE/MassEffect2DemoEN.exe" "$W_TMP"
-            chmod +x "$W_TMP"/MassEffect2DemoEN.exe ;;
+            cp "${W_CACHE}/${W_PACKAGE}/MassEffect2DemoEN.exe" "${W_TMP}"
+            chmod +x "${W_TMP}"/MassEffect2DemoEN.exe ;;
         *)
-            ln -sf "$W_CACHE/$W_PACKAGE/MassEffect2DemoEN.exe" "$W_TMP" ;;
+            ln -sf "${W_CACHE}/${W_PACKAGE}/MassEffect2DemoEN.exe" "${W_TMP}" ;;
     esac
-    w_try_cd "$W_TMP"
+    w_try_cd "${W_TMP}"
     w_ahk_do "
         SetWinDelay 1000
         SetTitleMatchMode, 2
@@ -19817,15 +19817,15 @@ w_metadata maxmagicmarker_demo games \
     year="2010" \
     media="download" \
     file1="max_demo_pc.zip" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/maxmagicmarker_demo/max and the magic markerdemo pc.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/maxmagicmarker_demo/max and the magic markerdemo pc.exe"
 
 load_maxmagicmarker_demo()
 {
     w_download https://www.maxandthemagicmarker.com/maxdemo/max_demo_pc.zip 6e2abd0cbd0ad04bfea9663402d7e9f24864d3f1c32df69eebf92dfc469fe6dd
 
-    w_try_unzip "$W_PROGRAMS_X86_UNIX/$W_PACKAGE" "$W_CACHE/$W_PACKAGE"/max_demo_pc.zip
+    w_try_unzip "${W_PROGRAMS_X86_UNIX}/${W_PACKAGE}" "${W_CACHE}/${W_PACKAGE}"/max_demo_pc.zip
     # Work around bug in game?!
-    w_try_cd "$W_PROGRAMS_X86_UNIX/$W_PACKAGE"
+    w_try_cd "${W_PROGRAMS_X86_UNIX}/${W_PACKAGE}"
     mv "max and the magic markerdemo pc" "max and the magic markerdemo pc"_Data
 }
 
@@ -19847,7 +19847,7 @@ load_mdk()
     w_download http://www.falconfly.de/downloads/patch-mdk3dfx.zip 9b9413609ed147944fa44bb5f51b35cf6baa7657e7e1a9891ad68d858275e00b
 
     w_mount MDK
-    w_try_cd "$W_ISO_MOUNT_ROOT"
+    w_try_cd "${W_ISO_MOUNT_ROOT}"
     w_ahk_do "
         SetTitleMatchMode, 2
         SetTitleMatchMode, slow
@@ -19887,8 +19887,8 @@ load_mdk()
         }
         WinWaitClose
     "
-    w_try_cd "$W_DRIVE_C/SHINY/MDK"
-    w_try_unzip . "$W_CACHE/$W_PACKAGE"/patch-mdk3dfx.zip
+    w_try_cd "${W_DRIVE_C}/SHINY/MDK"
+    w_try_unzip . "${W_CACHE}/${W_PACKAGE}"/patch-mdk3dfx.zip
 
     # TODO: Wine fails to install menu items, add a workaround for that
 }
@@ -19901,13 +19901,13 @@ w_metadata menofwar games \
     year="2009" \
     media="dvd" \
     file1="Men of War.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Aspyr/Men of War/mow.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Aspyr/Men of War/mow.exe"
 
 load_menofwar()
 {
     w_mount "Men of War"
 
-    w_try_cd "$W_ISO_MOUNT_ROOT"
+    w_try_cd "${W_ISO_MOUNT_ROOT}"
     w_ahk_do "
         SetTitleMatchMode, 2
         SetTitleMatchMode, slow
@@ -19942,7 +19942,7 @@ w_metadata myth2_demo games \
     year="2011" \
     media="download" \
     file1="Myth2_Demo_180.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Myth II Demo/Myth II Demo.exe" \
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Myth II Demo/Myth II Demo.exe" \
     homepage="https://projectmagma.net/"
 
 load_myth2_demo()
@@ -19959,7 +19959,7 @@ load_myth2_demo()
     w_ahk_do "
         SetTitleMatchMode, 2
         SetWinDelay 500
-        run, $file1
+        run, ${file1}
         winwait, Setup, Welcome
         if ( w_opt_unattended > 0 ) {
             winactivate
@@ -19986,20 +19986,20 @@ w_metadata nfsshift_demo games \
     year="2009" \
     media="download" \
     file1="NFSSHIFTPCDEMO.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Electronic Arts/Need for Speed SHIFT Demo/shiftdemo.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Electronic Arts/Need for Speed SHIFT Demo/shiftdemo.exe"
 
 load_nfsshift_demo()
 {
     #w_download http://cdn.needforspeed.com/data/downloads/shift/NFSSHIFTPCDEMO.exe 5ad011e7dd42e3404e3191009cd81c05b891e7c138d61f958fce9506ff8c9de3
     w_download http://www.legendaryreviews.com/download-center/demos/NFSSHIFTPCDEMO.exe 5ad011e7dd42e3404e3191009cd81c05b891e7c138d61f958fce9506ff8c9de3
 
-    w_try cp "$W_CACHE/$W_PACKAGE/$file1" "$W_TMP"
+    w_try cp "${W_CACHE}/${W_PACKAGE}/${file1}" "${W_TMP}"
 
-    w_try_cd "$W_TMP"
+    w_try_cd "${W_TMP}"
     w_ahk_do "
         SetTitleMatchMode, 2
         SetTitleMatchMode, slow
-        run, $file1
+        run, ${file1}
         winwait, WinRAR
         if ( w_opt_unattended > 0 ) {
             ControlClick, Button2
@@ -20054,13 +20054,13 @@ w_metadata oblivion games \
     year="2006" \
     media="dvd" \
     file1="Oblivion.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Bethesda Softworks/Oblivion/Oblivion.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Bethesda Softworks/Oblivion/Oblivion.exe"
 
 load_oblivion()
 {
     w_mount "Oblivion"
 
-    w_try_cd "$W_ISO_MOUNT_ROOT"
+    w_try_cd "${W_ISO_MOUNT_ROOT}"
     w_ahk_do "
         SetTitleMatchMode, 2
         run, Setup.exe
@@ -20103,15 +20103,15 @@ w_metadata penpenxmas games \
     year="2007" \
     media="download" \
     file1="PenPenXmasOlympics100.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/PPO/PPO.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/PPO/PPO.exe"
 
 load_penpenxmas()
 {
     W_BROWSERAGENT=1 \
     w_download http://retrospec.sgn.net/download/files/PenPenXmasOlympics100.exe c35c5c6a9a3fa62d6b099713e72390d0490320534dba958b57b94f0a6ab458db
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    "$WINE" PenPenXmasOlympics100.exe ${W_OPT_UNATTENDED:+/S}
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    "${WINE}" PenPenXmasOlympics100.exe ${W_OPT_UNATTENDED:+/S}
 }
 
 #----------------------------------------------------------------
@@ -20122,7 +20122,7 @@ w_metadata popfs games \
     year="2010" \
     media="dvd" \
     file1="PoP_TFS.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Ubisoft/Prince of Persia The Forgotten Sands/Prince of Persia.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Ubisoft/Prince of Persia The Forgotten Sands/Prince of Persia.exe"
 
 load_popfs()
 {
@@ -20176,7 +20176,7 @@ w_metadata rct3deluxe games \
     year="2004" \
     media="cd" \
     file1="RCT3.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Atari/RollerCoaster Tycoon 3/RCT3.EXE"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Atari/RollerCoaster Tycoon 3/RCT3.EXE"
 
 load_rct3deluxe()
 {
@@ -20235,13 +20235,13 @@ w_metadata riseofnations_demo games \
     year="2003" \
     media="manual_download" \
     file1="RiseOfNationsTrial.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Microsoft Games/Rise of Nations Trial/nations.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Microsoft Games/Rise of Nations Trial/nations.exe"
 
 load_riseofnations_demo()
 {
     w_download_manual https://download.cnet.com/Rise-of-Nations-Trial-Version/3000-7562_4-10730812.html RiseOfNationsTrial.exe f0bd8be3999164e669aad33583e372ca0f530b1a2ac0194a4c13b265e9cdf744
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
     w_ahk_do "
         SetTitleMatchMode, 2
@@ -20270,17 +20270,17 @@ w_metadata secondlife games \
     year="2003-2011" \
     media="download" \
     file1="Second_Life_3-2-8-248931_Setup.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/SecondLifeViewer/SecondLife.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/SecondLifeViewer/SecondLife.exe"
 
 load_secondlife()
 {
     w_download http://download.cloud.secondlife.com/Viewer-3/Second_Life_3-2-8-248931_Setup.exe d155366f16bfe23f33a6b6d63f366691be2d0554429916da875ea78d0e0de8a6
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetTitleMatchMode, 2
         SetWinDelay 500
-        run, $file1
+        run, ${file1}
         if ( w_opt_unattended > 0 ) {
             winwait, Installer Language
             send {Enter}
@@ -20303,7 +20303,7 @@ w_metadata sims3 games \
     year="2009" \
     media="dvd" \
     file1="Sims3.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Electronic Arts/The Sims 3/Game/Bin/TS3.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Electronic Arts/The Sims 3/Game/Bin/TS3.exe"
 
 load_sims3()
 {
@@ -20325,7 +20325,7 @@ load_sims3()
             sleep 1000
             send a{Enter}
             sleep 1000
-            send {Raw}$W_KEY
+            send {Raw}${W_KEY}
             send {Enter}
             winwait, - InstallShield Wizard, Setup Type
             send {Enter}
@@ -20348,7 +20348,7 @@ load_sims3()
     # FIXME: download appropriate one rather than just US version.
     w_download http://akamai.cdn.ea.com/eadownloads/u/f/sims/sims3/patches/TS3_1.19.44.010001_Update.exe 9428b32638108e51e63455b60f3cfd5b5aca07b55ce58a200087631a02b5336c
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         run TS3_1.19.44.010001_Update.exe
         SetTitleMatchMode, 2
@@ -20368,7 +20368,7 @@ w_metadata simsmed games \
     year="2011" \
     media="dvd" \
     file1="TSimsM.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Electronic Arts/The Sims Medieval/Game/Bin/TSM.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Electronic Arts/The Sims Medieval/Game/Bin/TSM.exe"
 
 load_simsmed()
 {
@@ -20393,7 +20393,7 @@ load_simsmed()
             sleep 1000
             ControlClick Button1   ; Next
             sleep 1000
-            send {Raw}$W_KEY
+            send {Raw}${W_KEY}
             send {Enter}
             winwait, - InstallShield Wizard, Setup Type
             ControlClick &Complete    ; was not defaulting to complete?
@@ -20439,7 +20439,7 @@ load_simsmed()
     # FIXME: download appropriate one rather than just US version.
     w_download http://akamai.cdn.ea.com/eadownloads/u/f/sims/sims/patches/TheSimsMedievalPatch_1.1.10.00001_Update.exe 01c0f9e3394d93869f67f1319b80a1257fe421bbdf911a15c8c7ab43f2e73683
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetTitleMatchMode, 2
         SetWinDelay 500
@@ -20466,11 +20466,11 @@ w_metadata sims3_gen games \
     year="2011" \
     media="dvd" \
     file1="Sims3EP04.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Electronic Arts/The Sims 3 Generations/Game/Bin/TS3EP04.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Electronic Arts/The Sims 3 Generations/Game/Bin/TS3EP04.exe"
 
 load_sims3_gen()
 {
-    if [ ! -f "$W_PROGRAMS_X86_WIN/Electronic Arts/The Sims 3/Game/Bin/TS3.exe" ]; then
+    if [ ! -f "${W_PROGRAMS_X86_WIN}/Electronic Arts/The Sims 3/Game/Bin/TS3.exe" ]; then
         w_die "You must have sims3 installed to install sims3_gen!"
     fi
 
@@ -20511,7 +20511,7 @@ load_sims3_gen()
             }
             winwait, Sims, Please enter the entire Registration Code
             sleep 1000
-            send {Raw}$W_KEY
+            send {Raw}${W_KEY}
             send {Enter}
             winwait, - InstallShield Wizard, Setup Type
             ControlClick &Complete    ; was not defaulting to complete?
@@ -20542,7 +20542,7 @@ w_metadata splitsecond games \
     year="2010" \
     media="dvd" \
     file1="SplitSecond.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Disney Interactive Studios/Split Second/SplitSecond.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Disney Interactive Studios/Split Second/SplitSecond.exe"
 
 load_splitsecond()
 {
@@ -20550,7 +20550,7 @@ load_splitsecond()
     w_mount SplitSecond
 
     # Aborts with dialog about FirewallInstallHelper.dll if that's not on the path (e.g. in current dir)
-    w_try_cd "$W_ISO_MOUNT_ROOT"
+    w_try_cd "${W_ISO_MOUNT_ROOT}"
     w_ahk_do "
         SetTitleMatchMode, 2
         run setup.exe
@@ -20595,7 +20595,7 @@ w_metadata spore games \
     year="2008" \
     media="dvd" \
     file1="SPORE.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Electronic Arts/SPORE/Sporebin/SporeApp.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Electronic Arts/SPORE/Sporebin/SporeApp.exe"
 
 load_spore()
 {
@@ -20619,7 +20619,7 @@ load_spore()
             sleep 500
             controlclick, Button1
             winwait, SPORE, Registration Code
-            send {RAW}$W_KEY
+            send {RAW}${W_KEY}
             sleep 500
             controlclick, Button2
             winwait, SPORE, Setup Type
@@ -20657,7 +20657,7 @@ w_metadata spore_cc_demo games \
     year="2008" \
     media="download" \
     file1="792248d6ad421d577132c2b648bbed45_scc_trial_na.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Electronic Arts/SPORE/Sporebin/SporeCreatureCreator.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Electronic Arts/SPORE/Sporebin/SporeCreatureCreator.exe"
 
 load_spore_cc_demo()
 {
@@ -20665,12 +20665,12 @@ load_spore_cc_demo()
 
     w_info "The installer runs on for about a minute after it's done."
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    if test "$W_OPT_UNATTENDED"; then
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    if test "${W_OPT_UNATTENDED}"; then
         w_ahk_do "
             SetWinDelay 1000
             SetTitleMatchMode, 2
-            run $file1
+            run ${file1}
             winwait, Wizard, Welcome to the SPORE
             send N
             winwait, Wizard, Please read the following
@@ -20689,12 +20689,12 @@ load_spore_cc_demo()
             send {SPACE}{DOWN}{SPACE}{ENTER}
             winwaitclose
         "
-        while pgrep -f "$file1" > /dev/null; do
+        while pgrep -f "${file1}" > /dev/null; do
             w_info "Waiting for installer to finish."
             sleep 2
         done
     else
-        w_try "$WINE" "$file1"
+        w_try "${WINE}" "${file1}"
     fi
 }
 
@@ -20706,14 +20706,14 @@ w_metadata starcraft2_demo games \
     year="2010" \
     media="manual_download" \
     file1="SC2-WingsOfLiberty-enUS-Demo-Installer.zip" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/StarCraft II Demo/StarCraft II.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/StarCraft II Demo/StarCraft II.exe"
 
 load_starcraft2_demo()
 {
     w_download_manual https://www.fileplanet.com/217982/210000/fileinfo/Starcraft-2-Demo SC2-WingsOfLiberty-enUS-Demo-Installer.zip 6ba192a726fc8b58031a7de961ad9392f60df05cfb206342f02f7a80b57c0784
 
-    w_try_cd "$W_TMP"
-    w_try_unzip . "$W_CACHE/$W_PACKAGE"/SC2-WingsOfLiberty-enUS-Demo-Installer.zip
+    w_try_cd "${W_TMP}"
+    w_try_unzip . "${W_CACHE}/${W_PACKAGE}"/SC2-WingsOfLiberty-enUS-Demo-Installer.zip
 
     w_ahk_do "
         SetTitleMatchMode, 2
@@ -20773,13 +20773,13 @@ w_metadata theundergarden_demo games \
     year="2010" \
     media="manual_download" \
     file1="TheUnderGarden_PC_B34_SRTB.30_28OCT10.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/The UnderGarden/TheUndergarden.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/The UnderGarden/TheUndergarden.exe"
 
 load_theundergarden_demo()
 {
     w_download_manual http://www.bigdownload.com/games/the-undergarden/pc/the-undergarden-demo TheUnderGarden_PC_B34_SRTB.30_28OCT10.exe acf90c422ac2f2f242100f39bedfe7df0c95f7a
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
     w_ahk_do "
         SetTitleMatchMode, 2
@@ -20851,14 +20851,14 @@ w_metadata tmnationsforever games \
     year="2009" \
     media="download" \
     file1="tmnationsforever_setup.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/TmNationsForever/TmForever.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/TmNationsForever/TmForever.exe"
 
 load_tmnationsforever()
 {
     # 2011/03/29: 2f659138ed4409da404970841e18f03d29921beaf6a424824c8312ddb20f6355
     w_download "http://files.trackmaniaforever.com/tmnationsforever_setup.exe" 2f659138ed4409da404970841e18f03d29921beaf6a424824c8312ddb20f6355
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
     w_ahk_do "
         SetTitleMatchMode, 2
@@ -20908,7 +20908,7 @@ w_metadata trainztcc_2004 games \
     year="2008" \
     media="dvd" \
     file1="TRS2006DVD.iso" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Auran/TRS2004/TRS2004.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Auran/TRS2004/TRS2004.exe"
 
 load_trainztcc_2004()
 {
@@ -20980,13 +20980,13 @@ w_metadata sammax301_demo games \
     year="2010" \
     media="manual_download" \
     file1="SamMax301_PC_Setup.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Telltale Games/Sam and Max - The Devil's Playhouse/The Penal Zone/SamMax301.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Telltale Games/Sam and Max - The Devil's Playhouse/The Penal Zone/SamMax301.exe"
 
 load_sammax301_demo()
 {
     w_download_manual "https://www.fileplanet.com/211314/210000/fileinfo/Sam-&-Max:-Devil's-Playhouse---Episode-One-Demo" SamMax301_PC_Setup.exe bed2c16c0254881e7770743f936b8926fa202b91d281bb8c2dd34305d0c0a84a
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetTitleMatchMode, 2
         SetWinDelay 500
@@ -21018,16 +21018,16 @@ w_metadata sammax304_demo games \
     year="2010" \
     media="manual_download" \
     file1="SamMax304_PC_setup.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Telltale Games/Sam and Max - The Devil's Playhouse/Beyond the Alley of the Dolls/SamMax304.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Telltale Games/Sam and Max - The Devil's Playhouse/Beyond the Alley of the Dolls/SamMax304.exe"
 
 load_sammax304_demo()
 {
     w_download_manual "https://www.fileplanet.com/214770/210000/fileinfo/Sam-&-Max:-The-Devi's-Playhouse---Beyond-the-Alley-of-the-Dolls-Demo" SamMax304_PC_setup.exe 51c85e98857d15c59d9bb808ee16794cc0caf39799c50545bffdf359eac4c70a
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetTitleMatchMode, 2
-        Run, $file1
+        Run, ${file1}
         WinWait,Sam and Max Beyond the Alley of the Dolls Setup
         if ( w_opt_unattended > 0 ) {
             ControlClick Button2 ; Next
@@ -21053,13 +21053,13 @@ w_metadata tropico3_demo games \
     year="2009" \
     media="manual_download" \
     file1="Tropico3Demo.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Kalypso/Tropico 3 Demo/Tropico3 Demo.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Kalypso/Tropico 3 Demo/Tropico3 Demo.exe"
 
 load_tropico3_demo()
 {
     w_download_manual https://www.fileplanet.com/204947/200000/fileinfo/Tropico-3-Demo Tropico3Demo.exe c4c06858cb1e0b9ff29dc8de6ecb8eb9cf699ce31609fbfa848d5dbc83c9d3e0
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
     w_ahk_do "
         SetWinDelay 1000
@@ -21107,7 +21107,7 @@ load_singularity()
             sleep 1000
             winwait, Singularity(TM), Keycode Check
             sleep 1000
-            Send $W_KEY
+            Send ${W_KEY}
             sleep 1000
             Send {Enter}
             ; Well this is annoying...
@@ -21146,7 +21146,7 @@ load_singularity()
         "
 
     # Clean up crap left over in c:\ when the installer runs the vc 2008 redistributable installer
-    w_try_cd "$W_DRIVE_C"
+    w_try_cd "${W_DRIVE_C}"
     rm -f VC_RED.* eula.*.txt globdata.ini install.exe install.ini install.res.*.dll vcredist.bmp
 }
 
@@ -21210,7 +21210,7 @@ load_twfc()
             controlclick, Button1, Activision, Select the language for the installation
             winwait, Transformers, Press NEXT to verify your key
             sleep 1000
-            send $W_KEY
+            send ${W_KEY}
             send {Enter}
             winwait, Keycode Check, The Keycode you entered appears to be valid
             sleep 1000
@@ -21248,7 +21248,7 @@ load_twfc()
     "
 
     # Clean up crap left over in c:\ when the installer runs the vc 2008 redistributable installer
-    w_try_cd "$W_DRIVE_C"
+    w_try_cd "${W_DRIVE_C}"
     rm -f VC_RED.* eula.*.txt globdata.ini install.exe install.ini install.res.*.dll vcredist.bmp
 }
 
@@ -21260,13 +21260,13 @@ w_metadata typingofthedead_demo games \
     year="1999" \
     media="manual_download" \
     file1="Tod_e_demo.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/SEGA/TOD-Demo/Tod_e_demo.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/SEGA/TOD-Demo/Tod_e_demo.exe"
 
 load_typingofthedead_demo()
 {
     w_download_manual "https://www.fileplanet.com/54947/50000/fileinfo/The-Typing-of-the-Dead-Demo" tod-demo.zip feb0888b6cf1d51af2bf3d752e1727b5d248c2704ca053561f384b55e86267ea
-    w_try_cd "$W_TMP"
-    w_try_unzip . "$W_CACHE/$W_PACKAGE/tod-demo.zip"
+    w_try_cd "${W_TMP}"
+    w_try_unzip . "${W_CACHE}/${W_PACKAGE}/tod-demo.zip"
     w_ahk_do "
         SetTitleMatchMode, 2
         run SETUP.EXE
@@ -21292,7 +21292,7 @@ w_metadata ut3 games \
     media="dvd" \
     file1="UT3_RC7.iso" \
     file2="UT3Patch5.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Unreal Tournament 3/Binaries/UT3.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Unreal Tournament 3/Binaries/UT3.exe"
 
 load_ut3()
 {
@@ -21328,7 +21328,7 @@ load_ut3()
         WinWaitClose
     "
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
     w_ahk_do "
         SetTitleMatchMode, 2
@@ -21357,21 +21357,21 @@ w_metadata wog games \
     year="2008" \
     media="download" \
     file1="WorldOfGooDemo.1.0.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/WorldOfGooDemo/WorldOfGoo.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/WorldOfGooDemo/WorldOfGoo.exe"
 
 load_wog()
 {
-    if ! test -f "$W_CACHE/wog/WorldOfGooDemo.1.0.exe"; then
+    if ! test -f "${W_CACHE}/wog/WorldOfGooDemo.1.0.exe"; then
         # Get temporary download location
         w_download "https://www.worldofgoo.com/dl2.php?lk=demo&filename=WorldOfGooDemo.1.0.exe"
-        URL=$(grep WorldOfGooDemo.1.0.exe "$W_CACHE/wog/dl2.php?lk=demo&filename=WorldOfGooDemo.1.0.exe" \
+        URL=$(grep WorldOfGooDemo.1.0.exe "${W_CACHE}/wog/dl2.php?lk=demo&filename=WorldOfGooDemo.1.0.exe" \
             | sed 's,.*http,http,;s,".*,,')
-        w_try rm "$W_CACHE/wog/dl2.php?lk=demo&filename=WorldOfGooDemo.1.0.exe"
+        w_try rm "${W_CACHE}/wog/dl2.php?lk=demo&filename=WorldOfGooDemo.1.0.exe"
 
-        w_download "$URL" 07892e927e0c403a178717b67928d3b4126dd0ed4f82afa20a4bd2496706c5e9
+        w_download "${URL}" 07892e927e0c403a178717b67928d3b4126dd0ed4f82afa20a4bd2496706c5e9
     fi
 
-    w_try_cd "$W_CACHE/$W_PACKAGE"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_ahk_do "
         SetWinDelay 500
         run WorldOfGooDemo.1.0.exe
@@ -21401,7 +21401,7 @@ w_metadata alienswarm_steam games \
     publisher="Valve" \
     year="2010" \
     media="download" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Steam/steamapps/common/alien swarm/swarm.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Steam/steamapps/common/alien swarm/swarm.exe"
 
 load_alienswarm_steam()
 {
@@ -21415,7 +21415,7 @@ w_metadata bioshock2_steam games \
     publisher="2k" \
     year="2010" \
     media="download" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Steam/steamapps/common/bioshock2/blort.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Steam/steamapps/common/bioshock2/blort.exe"
 
 load_bioshock2_steam()
 {
@@ -21429,7 +21429,7 @@ w_metadata borderlands_steam games \
     publisher="2K Games" \
     year="2009" \
     media="download" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Steam/steamapps/common/borderlands/Binaries/Borderlands.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Steam/steamapps/common/borderlands/Binaries/Borderlands.exe"
 
 load_borderlands_steam()
 {
@@ -21443,7 +21443,7 @@ w_metadata civ5_demo_steam games \
     publisher="2K Games" \
     year="2010" \
     media="download" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Steam/steamapps/common/sid meier's civilization v - demo/CivilizationV.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Steam/steamapps/common/sid meier's civilization v - demo/CivilizationV.exe"
 
 load_civ5_demo_steam()
 {
@@ -21472,7 +21472,7 @@ load_civ5_demo_steam()
         # finds the dialog it's looking for, clicks, and exits.
         w_info "If you already own the full Civ 5 game on Steam, the installer won't even appear."
     w_steam_install_game 65900 "Sid Meier's Civilization V - Demo"
-    kill -s HUP "$_job"   # just in case
+    kill -s HUP "${_job}"   # just in case
 }
 
 #----------------------------------------------------------------
@@ -21482,7 +21482,7 @@ w_metadata ruse_demo_steam games \
     publisher="Ubisoft" \
     year="2010" \
     media="download" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Steam/steamapps/common/r.u.s.e. demo/Ruse.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Steam/steamapps/common/r.u.s.e. demo/Ruse.exe"
 
 load_ruse_demo_steam()
 {
@@ -21496,7 +21496,7 @@ w_metadata supermeatboy_steam games \
     publisher="Independent" \
     year="2010" \
     media="download" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Steam/steamapps/common/super meat boy/SuperMeatBoy.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Steam/steamapps/common/super meat boy/SuperMeatBoy.exe"
 
 load_supermeatboy_steam()
 {
@@ -21510,7 +21510,7 @@ w_metadata trine_steam games \
     publisher="Frozenbyte" \
     year="2009" \
     media="download" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Steam/steamapps/common/trine/trine_launcher.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Steam/steamapps/common/trine/trine_launcher.exe"
 
 load_trine_steam()
 {
@@ -21524,7 +21524,7 @@ w_metadata trine_demo_steam games \
     publisher="Frozenbyte" \
     year="2009" \
     media="download" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Steam/steamapps/common/trine demo/trine_launcher.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Steam/steamapps/common/trine demo/trine_launcher.exe"
 
 load_trine_demo_steam()
 {
@@ -21538,7 +21538,7 @@ w_metadata wormsreloaded_demo_steam games \
     publisher="Team17" \
     year="2010" \
     media="download" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Steam/steamapps/common/worms reloaded/WormsReloaded.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Steam/steamapps/common/worms reloaded/WormsReloaded.exe"
 
 load_wormsreloaded_demo_steam()
 {
@@ -21576,15 +21576,15 @@ load_mwo()
     *) w_die "illegal value $1 for MouseWarpOverride";;
     esac
 
-    echo "Setting MouseWarpOverride to $arg"
-    cat > "$W_TMP"/set-mwo.reg <<_EOF_
+    echo "Setting MouseWarpOverride to ${arg}"
+    cat > "${W_TMP}"/set-mwo.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\DirectInput]
-"MouseWarpOverride"="$arg"
+"MouseWarpOverride"="${arg}"
 
 _EOF_
-    w_try_regedit "$W_TMP"/set-mwo.reg
+    w_try_regedit "${W_TMP}"/set-mwo.reg
 }
 
 #----------------------------------------------------------------
@@ -21636,17 +21636,17 @@ load_fontsmooth()
 
     echo "Setting font smoothing to $1"
 
-    cat > "$W_TMP"/fontsmooth.reg <<_EOF_
+    cat > "${W_TMP}"/fontsmooth.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Control Panel\\Desktop]
-"FontSmoothing"="$FontSmoothing"
+"FontSmoothing"="${FontSmoothing}"
 "FontSmoothingGamma"=dword:00000578
-"FontSmoothingOrientation"=dword:0000000$FontSmoothingOrientation
-"FontSmoothingType"=dword:0000000$FontSmoothingType
+"FontSmoothingOrientation"=dword:0000000${FontSmoothingOrientation}
+"FontSmoothingType"=dword:0000000${FontSmoothingType}
 
 _EOF_
-    w_try_regedit "$W_TMP_WIN"\\fontsmooth.reg
+    w_try_regedit "${W_TMP_WIN}"\\fontsmooth.reg
 }
 
 #----------------------------------------------------------------
@@ -21661,15 +21661,15 @@ w_metadata macdriver=x11 settings \
 
 load_macdriver()
 {
-    echo "Setting MacDriver to $arg"
-    cat > "$W_TMP"/set-mac.reg <<_EOF_
+    echo "Setting MacDriver to ${arg}"
+    cat > "${W_TMP}"/set-mac.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\Drivers]
-"Graphics"="$arg"
+"Graphics"="${arg}"
 
 _EOF_
-    w_try_regedit "$W_TMP"/set-mac.reg
+    w_try_regedit "${W_TMP}"/set-mac.reg
 }
 
 #----------------------------------------------------------------
@@ -21690,18 +21690,18 @@ load_mackeyremap()
         *) w_die "illegal value $1 for MacKeyRemap";;
     esac
 
-    echo "Setting MacKeyRemap to $arg"
-    cat > "$W_TMP"/set-mackeyremap.reg <<_EOF_
+    echo "Setting MacKeyRemap to ${arg}"
+    cat > "${W_TMP}"/set-mackeyremap.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver]
-"LeftCommandIsCtrl"="$_W_arg_l"
-"LeftOptionIsAlt"="$_W_arg_l"
-"RightCommandIsCtrl"="$_W_arg_r"
-"RightOptionIsAlt"="$_W_arg_r"
+"LeftCommandIsCtrl"="${_W_arg_l}"
+"LeftOptionIsAlt"="${_W_arg_l}"
+"RightCommandIsCtrl"="${_W_arg_r}"
+"RightOptionIsAlt"="${_W_arg_r}"
 
 _EOF_
-    w_try_regedit "$W_TMP"/set-mackeyremap.reg
+    w_try_regedit "${W_TMP}"/set-mackeyremap.reg
 
     unset _W_arg_l _W_arg_r
 }
@@ -21723,15 +21723,15 @@ load_grabfullscreen()
         *) w_die "illegal value $1 for GrabFullscreen";;
     esac
 
-    echo "Setting GrabFullscreen to $arg"
-    cat > "$W_TMP"/set-gfs.reg <<_EOF_
+    echo "Setting GrabFullscreen to ${arg}"
+    cat > "${W_TMP}"/set-gfs.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\X11 Driver]
-"GrabFullscreen"="$arg"
+"GrabFullscreen"="${arg}"
 
 _EOF_
-    w_try_regedit "$W_TMP"/set-gfs.reg
+    w_try_regedit "${W_TMP}"/set-gfs.reg
 }
 
 w_metadata windowmanagerdecorated=y settings \
@@ -21764,15 +21764,15 @@ load_usetakefocus()
         *) w_die "illegal value $1 for UseTakeFocus";;
     esac
 
-    echo "Setting UseTakeFocus to $arg"
-    cat > "$W_TMP"/set-gfs.reg <<_EOF_
+    echo "Setting UseTakeFocus to ${arg}"
+    cat > "${W_TMP}"/set-gfs.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\X11 Driver]
-"UseTakeFocus"="$arg"
+"UseTakeFocus"="${arg}"
 
 _EOF_
-    w_try_regedit "$W_TMP"/set-gfs.reg
+    w_try_regedit "${W_TMP}"/set-gfs.reg
 }
 
 #----------------------------------------------------------------
@@ -21784,15 +21784,15 @@ load_windowmanagerdecorated()
         *) w_die "illegal value $1 for Decorated";;
     esac
 
-    echo "Setting Decorated to $arg"
-    cat > "$W_TMP"/set-wmd.reg <<_EOF_
+    echo "Setting Decorated to ${arg}"
+    cat > "${W_TMP}"/set-wmd.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\X11 Driver]
-"Decorated"="$arg"
+"Decorated"="${arg}"
 
 _EOF_
-    w_try_regedit "$W_TMP"/set-wmd.reg
+    w_try_regedit "${W_TMP}"/set-wmd.reg
 }
 
 w_metadata windowmanagermanaged=y settings \
@@ -21811,15 +21811,15 @@ load_windowmanagermanaged()
         *) w_die "illegal value $1 for Managed";;
     esac
 
-    echo "Setting Managed to $arg"
-    cat > "$W_TMP"/set-wmm.reg <<_EOF_
+    echo "Setting Managed to ${arg}"
+    cat > "${W_TMP}"/set-wmm.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\X11 Driver]
-"Managed"="$arg"
+"Managed"="${arg}"
 
 _EOF_
-    w_try_regedit "$W_TMP"/set-wmm.reg
+    w_try_regedit "${W_TMP}"/set-wmm.reg
 }
 
 #----------------------------------------------------------------
@@ -21846,9 +21846,9 @@ w_metadata vd=1440x900 settings \
 load_vd()
 {
     size="$1"
-    case $size in
+    case ${size} in
         off|disabled)
-        cat > "$W_TMP"/vd.reg <<_EOF_
+        cat > "${W_TMP}"/vd.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\Explorer]
@@ -21859,21 +21859,21 @@ REGEDIT4
 _EOF_
         ;;
         [1-9]*x[1-9]*)
-        cat > "$W_TMP"/vd.reg <<_EOF_
+        cat > "${W_TMP}"/vd.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\Explorer]
 "Desktop"="Default"
 [HKEY_CURRENT_USER\\Software\\Wine\\Explorer\\Desktops]
-"Default"="$size"
+"Default"="${size}"
 
 _EOF_
         ;;
         *)
-        w_die "you want a virtual desktop of $size? I don't understand."
+        w_die "you want a virtual desktop of ${size}? I don't understand."
         ;;
     esac
-    w_try_regedit "$W_TMP_WIN"/vd.reg
+    w_try_regedit "${W_TMP_WIN}"/vd.reg
 }
 
 #----------------------------------------------------------------
@@ -21892,15 +21892,15 @@ load_mimeassoc()
         *) w_die "illegal value $1 for mimeassoc";;
     esac
 
-    echo "Setting mimeassoc to $arg"
-    cat > "$W_TMP"/set-mimeassoc.reg <<_EOF_
+    echo "Setting mimeassoc to ${arg}"
+    cat > "${W_TMP}"/set-mimeassoc.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\FileOpenAssociations]
-"Enable"="$arg"
+"Enable"="${arg}"
 
 _EOF_
-    w_try_regedit "$W_TMP"/set-mimeassoc.reg
+    w_try_regedit "${W_TMP}"/set-mimeassoc.reg
 }
 
 ####
@@ -21922,15 +21922,15 @@ winetricks_set_wined3d_var()
         *) w_die "illegal value $2 for $1";;
     esac
 
-    echo "Setting Direct3D/$1 to $arg"
-    cat > "$W_TMP"/set-wined3d.reg <<_EOF_
+    echo "Setting Direct3D/$1 to ${arg}"
+    cat > "${W_TMP}"/set-wined3d.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\Direct3D]
-"$1"="$arg"
+"$1"="${arg}"
 
 _EOF_
-    w_try_regedit "$W_TMP_WIN"\\set-wined3d.reg
+    w_try_regedit "${W_TMP_WIN}"\\set-wined3d.reg
 }
 
 #----------------------------------------------------------------
@@ -21980,15 +21980,15 @@ load_csmt()
         *) w_die "illegal value $1 for csmt";;
     esac
 
-    echo "Setting csmt to $arg"
-    cat > "$W_TMP"/set-csmt.reg <<_EOF_
+    echo "Setting csmt to ${arg}"
+    cat > "${W_TMP}"/set-csmt.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\Direct3D]
-"csmt"=dword:$arg
+"csmt"=dword:${arg}
 
 _EOF_
-    w_try_regedit "$W_TMP"/set-csmt.reg
+    w_try_regedit "${W_TMP}"/set-csmt.reg
 }
 
 #----------------------------------------------------------------
@@ -22160,12 +22160,12 @@ w_metadata videomemorysize=2048 settings \
 load_videomemorysize()
 {
     size="$1"
-    echo "Setting video memory size to $size"
+    echo "Setting video memory size to ${size}"
 
-    case $size in
+    case ${size} in
         default)
 
-    cat > "$W_TMP"/set-video.reg <<_EOF_
+    cat > "${W_TMP}"/set-video.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\Direct3D]
@@ -22174,16 +22174,16 @@ REGEDIT4
 _EOF_
     ;;
         *)
-    cat > "$W_TMP"/set-video.reg <<_EOF_
+    cat > "${W_TMP}"/set-video.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\Direct3D]
-"VideoMemorySize"="$size"
+"VideoMemorySize"="${size}"
 
 _EOF_
     ;;
     esac
-    w_try_regedit "$W_TMP_WIN"\\set-video.reg
+    w_try_regedit "${W_TMP_WIN}"\\set-video.reg
 }
 
 #----------------------------------------------------------------
@@ -22218,23 +22218,23 @@ w_metadata autostart_winedbg=disabled settings \
 
 load_autostart_winedbg()
 {
-    case "$arg" in
+    case "${arg}" in
         # accidentally commited as enable/disable, so accept that, but prefer enabled/disabled
         enable|enabled) _W_debugger_value="winedbg --auto %ld %ld";;
         disable|disabled) _W_debugger_value="false";;
-        *) w_die "Unexpected argument '$arg'. Should be enable/disable";;
+        *) w_die "Unexpected argument '${arg}'. Should be enable/disable";;
     esac
 
-    echo "Setting HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug\\Debugger to '$arg'"
-    cat > "$W_TMP"/autostart_winedbg.reg <<_EOF_
+    echo "Setting HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug\\Debugger to '${arg}'"
+    cat > "${W_TMP}"/autostart_winedbg.reg <<_EOF_
 REGEDIT4
 
 [HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug]
 "Debugger"="${_W_debugger_value}"
 _EOF_
 
-    w_try_regedit "$W_TMP_WIN"\\autostart_winedbg.reg
-    w_backup_reg_file "$W_TMP"/autostart_winedbg.reg
+    w_try_regedit "${W_TMP_WIN}"\\autostart_winedbg.reg
+    w_backup_reg_file "${W_TMP}"/autostart_winedbg.reg
 
     unset _W_debugger_value
 }
@@ -22247,14 +22247,14 @@ w_metadata heapcheck settings \
 
 load_heapcheck()
 {
-    cat > "$W_TMP"/heapcheck.reg <<_EOF_
+    cat > "${W_TMP}"/heapcheck.reg <<_EOF_
 REGEDIT4
 
 [HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\Session Manager]
 "GlobalFlag"=dword:00200030
 
 _EOF_
-    w_try_regedit "$W_TMP_WIN"\\heapcheck.reg
+    w_try_regedit "${W_TMP_WIN}"\\heapcheck.reg
 }
 
 #----------------------------------------------------------------
@@ -22266,14 +22266,14 @@ w_metadata nocrashdialog settings \
 load_nocrashdialog()
 {
     echo "Disabling graphical crash dialog"
-    cat > "$W_TMP"/crashdialog.reg <<_EOF_
+    cat > "${W_TMP}"/crashdialog.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\WineDbg]
 "ShowCrashDialog"=dword:00000000
 
 _EOF_
-    w_try_cd "$W_TMP"
+    w_try_cd "${W_TMP}"
     w_try_regedit crashdialog.reg
 }
 
@@ -22302,7 +22302,7 @@ w_metadata bad settings \
 
 load_bad()
 {
-    w_die "$W_PACKAGE failed!"
+    w_die "${W_PACKAGE} failed!"
 }
 
 #----------------------------------------------------------------
@@ -22324,7 +22324,7 @@ w_metadata good settings \
 
 load_good()
 {
-    w_info "$W_PACKAGE succeeded!"
+    w_info "${W_PACKAGE} succeeded!"
 }
 
 #----------------------------------------------------------------
@@ -22343,24 +22343,24 @@ load_hidewineexports()
     #
     # Hiding these Wine exports is only available in wine-staging.
     # See https://bugs.winehq.org/show_bug.cgi?id=38656
-    case $arg in
+    case ${arg} in
         enable)
             _W_registry_value="\"Y\""
             ;;
         disable)
             _W_registry_value="-"
             ;;
-        *) w_die "Unexpected argument, $arg";;
+        *) w_die "Unexpected argument, ${arg}";;
     esac
 
-    cat > "$W_TMP"/set-wineexports.reg <<_EOF_
+    cat > "${W_TMP}"/set-wineexports.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine]
-"HideWineExports"=$_W_registry_value
+"HideWineExports"=${_W_registry_value}
 
 _EOF_
-    w_try_regedit "$W_TMP"/set-wineexports.reg
+    w_try_regedit "${W_TMP}"/set-wineexports.reg
 }
 
 #----------------------------------------------------------------
@@ -22379,36 +22379,36 @@ load_hosts()
     # See https://bugs.winehq.org/show_bug.cgi?id=12076
 
     # It's in system32 for both win32/win64
-    mkdir -p "$W_WINDIR_UNIX"/system32/drivers/etc
-    touch "$W_WINDIR_UNIX"/system32/drivers/etc/hosts
-    touch "$W_WINDIR_UNIX"/system32/drivers/etc/services
+    mkdir -p "${W_WINDIR_UNIX}"/system32/drivers/etc
+    touch "${W_WINDIR_UNIX}"/system32/drivers/etc/hosts
+    touch "${W_WINDIR_UNIX}"/system32/drivers/etc/services
 }
 
 #----------------------------------------------------------------
 
 w_metadata isolate_home settings \
-    title_uk="Видалити посилання на вино преміум на \$HOME" \
-    title="Remove wineprefix links to \$HOME"
+    title_uk="Видалити посилання на вино преміум на \${HOME}" \
+    title="Remove wineprefix links to \${HOME}"
 
 load_isolate_home()
 {
     w_skip_windows isolate_home && return
 
     _olddir="$(pwd)"
-    w_try_cd "$WINEPREFIX/drive_c/users/$USER"
+    w_try_cd "${WINEPREFIX}/drive_c/users/${USER}"
     for x in *; do
-        if test -h "$x" && test -d "$x"; then
-            rm -f "$x"
-            mkdir -p "$x"
+        if test -h "${x}" && test -d "${x}"; then
+            rm -f "${x}"
+            mkdir -p "${x}"
         fi
     done
-    w_try_cd "$_olddir"
+    w_try_cd "${_olddir}"
     unset _olddir
 
     # Workaround for:
     # https://bugs.winehq.org/show_bug.cgi?id=22450 (sandbox verb)
     # https://bugs.winehq.org/show_bug.cgi?id=22974 (isolate_home, sandbox verbs)
-    echo disable > "$WINEPREFIX/.update-timestamp"
+    echo disable > "${WINEPREFIX}/.update-timestamp"
 }
 
 #----------------------------------------------------------------
@@ -22462,9 +22462,9 @@ load_remove_mono()
     # So, we uninstall anything that has 'Wine Mono' in the name to handle both cases.
     # If wine uninstaller can't find the application it will return 0 anyway.
     mono_uuid="$("${WINE_ARCH}" uninstaller --list | grep 'Wine Mono' | cut -f1 -d\|)"
-    if test "$mono_uuid"; then
-        for uuid in $mono_uuid; do
-            "${WINE_ARCH}" uninstaller --remove "$uuid"
+    if test "${mono_uuid}"; then
+        for uuid in ${mono_uuid}; do
+            "${WINE_ARCH}" uninstaller --remove "${uuid}"
         done
     else
         # Bail out if mono isn't installed, so we don't break .Net setups
@@ -22480,9 +22480,9 @@ load_remove_mono()
     "${WINE_ARCH}" reg delete "HKLM\\Software\\Microsoft\\NET Framework Setup\\NDP\\v3.5" /f || true
     "${WINE_ARCH}" reg delete "HKLM\\Software\\Microsoft\\NET Framework Setup\\NDP\\v4" /f || true
 
-    w_try rm -f "$W_WINDIR_UNIX/system32/mscoree.dll"
-    if [ "$W_ARCH" = "win64" ]; then
-        w_try rm -f "$W_WINDIR_UNIX/syswow64/mscoree.dll"
+    w_try rm -f "${W_WINDIR_UNIX}/system32/mscoree.dll"
+    if [ "${W_ARCH}" = "win64" ]; then
+        w_try rm -f "${W_WINDIR_UNIX}/syswow64/mscoree.dll"
     fi
 }
 
@@ -22491,14 +22491,14 @@ load_remove_mono()
 
 w_metadata sandbox settings \
     title_uk="Пісочниця wineprefix - видалити посилання до HOME" \
-    title="Sandbox the wineprefix - remove links to \$HOME"
+    title="Sandbox the wineprefix - remove links to \${HOME}"
 
 load_sandbox()
 {
     w_skip_windows sandbox && return
 
     # Unmap drive Z
-    w_try rm -f "$WINEPREFIX/dosdevices/z:"
+    w_try rm -f "${WINEPREFIX}/dosdevices/z:"
 
     # Disable unixfs
     # Unfortunately, when you run with a different version of Wine, Wine will recreate this key.
@@ -22532,14 +22532,14 @@ w_metadata sound=pulse settings \
 load_sound()
 {
     echo "Setting sound driver to $1"
-    cat > "$W_TMP"/set-sound.reg <<_EOF_
+    cat > "${W_TMP}"/set-sound.reg <<_EOF_
 REGEDIT4
 
 [HKEY_CURRENT_USER\\Software\\Wine\\Drivers]
 "Audio"="$1"
 
 _EOF_
-    w_try_regedit "$W_TMP_WIN"\\set-sound.reg
+    w_try_regedit "${W_TMP_WIN}"\\set-sound.reg
 }
 
 # settings->winversions
@@ -22771,26 +22771,26 @@ load_winxp()
 winetricks_stats_save()
 {
     # Save opt-in status
-    if test "$WINETRICKS_STATS_REPORT"; then
-        if test ! -d "$W_CACHE"; then
-            mkdir -p "$W_CACHE"
+    if test "${WINETRICKS_STATS_REPORT}"; then
+        if test ! -d "${W_CACHE}"; then
+            mkdir -p "${W_CACHE}"
         fi
-        echo "$WINETRICKS_STATS_REPORT" > "$W_CACHE"/track_usage
+        echo "${WINETRICKS_STATS_REPORT}" > "${W_CACHE}"/track_usage
     fi
 }
 
 winetricks_stats_init()
 {
     # Load opt-in status if not already set by a command-line option
-    if test ! "$WINETRICKS_STATS_REPORT" && test -f "$W_CACHE"/track_usage; then
-        WINETRICKS_STATS_REPORT=$(cat "$W_CACHE"/track_usage)
+    if test ! "${WINETRICKS_STATS_REPORT}" && test -f "${W_CACHE}"/track_usage; then
+        WINETRICKS_STATS_REPORT=$(cat "${W_CACHE}"/track_usage)
     fi
 
-    if test ! "$WINETRICKS_STATS_REPORT"; then
+    if test ! "${WINETRICKS_STATS_REPORT}"; then
         # No opt-in status found.  If GUI active, ask user whether they would like to opt in.
-        case $WINETRICKS_GUI in
+        case ${WINETRICKS_GUI} in
             zenity)
-                case $LANG in
+                case ${LANG} in
                 de*)
                     title="Einmalige Frage zur Hilfe an der Winetricks Entwicklung"
                     question="Möchten Sie die Winetricks Entwicklung unterstützen indem Sie Winetricks Statistiken übermitteln lassen? Sie können die Übermittlung jederzeit mit 'winetricks --optout' ausschalten"
@@ -22822,11 +22822,11 @@ winetricks_stats_init()
                     declined="OK, winetricks will *not* report statistics. You won't be asked this question again."
                     ;;
                 esac
-                if $WINETRICKS_GUI --question --text "$question" --title "$title"; then
-                    $WINETRICKS_GUI --info --text "$thanks"
+                if ${WINETRICKS_GUI} --question --text "${question}" --title "${title}"; then
+                    ${WINETRICKS_GUI} --info --text "${thanks}"
                     WINETRICKS_STATS_REPORT=1
                 else
-                    $WINETRICKS_GUI --info --text "$declined"
+                    ${WINETRICKS_GUI} --info --text "${declined}"
                     WINETRICKS_STATS_REPORT=0
                 fi
                 winetricks_stats_save
@@ -22839,9 +22839,9 @@ winetricks_stats_init()
 winetricks_os_description()
 {
     (
-        case "$W_PLATFORM" in
+        case "${W_PLATFORM}" in
             windows_cmd) echo "windows" ;;
-            *)  echo "$WINETRICKS_WINE_VERSION" ;;
+            *)  echo "${WINETRICKS_WINE_VERSION}" ;;
         esac
     ) | tr '\012' ' '
 }
@@ -22851,41 +22851,41 @@ winetricks_stats_report()
     winetricks_download_setup
 
     # If user has opted in to usage tracking, report what he used (if anything)
-    case "$WINETRICKS_STATS_REPORT" in
+    case "${WINETRICKS_STATS_REPORT}" in
         1) ;;
         *) return;;
     esac
 
-    BREADCRUMBS_FILE="$WINETRICKS_WORKDIR"/breadcrumbs
-    if test -f "$BREADCRUMBS_FILE"; then
-        WINETRICKS_STATS_BREADCRUMBS=$(tr '\012' ' ' < "$BREADCRUMBS_FILE")
-        echo "You opted in, so reporting '$WINETRICKS_STATS_BREADCRUMBS' to the winetricks maintainer so he knows which winetricks verbs get used and which don't.  Use --optout to disable future reports."
+    BREADCRUMBS_FILE="${WINETRICKS_WORKDIR}"/breadcrumbs
+    if test -f "${BREADCRUMBS_FILE}"; then
+        WINETRICKS_STATS_BREADCRUMBS=$(tr '\012' ' ' < "${BREADCRUMBS_FILE}")
+        echo "You opted in, so reporting '${WINETRICKS_STATS_BREADCRUMBS}' to the winetricks maintainer so he knows which winetricks verbs get used and which don't.  Use --optout to disable future reports."
 
-        report="os=$(winetricks_os_description)&winetricks=$WINETRICKS_VERSION&breadcrumbs=$WINETRICKS_STATS_BREADCRUMBS"
-        report="$(echo "$report" | sed 's/ /%20/g')"
+        report="os=$(winetricks_os_description)&winetricks=${WINETRICKS_VERSION}&breadcrumbs=${WINETRICKS_STATS_BREADCRUMBS}"
+        report="$(echo "${report}" | sed 's/ /%20/g')"
 
         # Just do a HEAD request with the raw command line.
         # Yes, this can be fooled by caches.  That's ok.
 
         # Note: these downloads are expected to fail (the resource won't exist), so don't use w_try and use '|| true' to ignore the expected errors
         if [ "${WINETRICKS_DOWNLOADER}" = "wget" ] ; then
-            $torify wget --timeout "${WINETRICKS_DOWNLOADER_TIMEOUT}" \
-                --tries "$WINETRICKS_DOWNLOADER_RETRIES" \
-                --spider "http://kegel.com/data/winetricks-usage?$report" > /dev/null 2>&1 || true
+            ${torify} wget --timeout "${WINETRICKS_DOWNLOADER_TIMEOUT}" \
+                --tries "${WINETRICKS_DOWNLOADER_RETRIES}" \
+                --spider "http://kegel.com/data/winetricks-usage?${report}" > /dev/null 2>&1 || true
         elif [ "${WINETRICKS_DOWNLOADER}" = "curl" ] ; then
-            $torify curl --connect-timeout "${WINETRICKS_DOWNLOADER_TIMEOUT}" \
-            --retry "$WINETRICKS_DOWNLOADER_RETRIES" \
-            -I "http://kegel.com/data/winetricks-usage?$report" > /dev/null 2>&1 || true
+            ${torify} curl --connect-timeout "${WINETRICKS_DOWNLOADER_TIMEOUT}" \
+            --retry "${WINETRICKS_DOWNLOADER_RETRIES}" \
+            -I "http://kegel.com/data/winetricks-usage?${report}" > /dev/null 2>&1 || true
         elif [ "${WINETRICKS_DOWNLOADER}" = "aria2c" ] ; then
-            $torify aria2c \
-                    ${aria2c_torify_opts:+"$aria2c_torify_opts"} \
+            ${torify} aria2c \
+                    ${aria2c_torify_opts:+"${aria2c_torify_opts}"} \
                     --connect-timeout="${WINETRICKS_DOWNLOADER_TIMEOUT}" \
                     --daemon=false \
                     --enable-rpc=false \
                     --input-file='' \
-                    --max-tries="$WINETRICKS_DOWNLOADER_RETRIES" \
+                    --max-tries="${WINETRICKS_DOWNLOADER_RETRIES}" \
                     --save-session='' \
-                    "http://kegel.com/data/winetricks-usage?$report" > /dev/null 2>&1 || true
+                    "http://kegel.com/data/winetricks-usage?${report}" > /dev/null 2>&1 || true
         else
             w_die "Here be dragons"
         fi
@@ -22895,16 +22895,16 @@ winetricks_stats_report()
 winetricks_stats_log_command()
 {
     # log what we execute for possible later statistics reporting
-    echo "$*" >> "$WINETRICKS_WORKDIR"/breadcrumbs
+    echo "$*" >> "${WINETRICKS_WORKDIR}"/breadcrumbs
 
     # and for the user's own reference later, when figuring out what he did
-    case "$W_PLATFORM" in
-        windows_cmd) _W_LOGDIR="$W_WINDIR_UNIX"/Temp ;;
-        *) _W_LOGDIR="$WINEPREFIX" ;;
+    case "${W_PLATFORM}" in
+        windows_cmd) _W_LOGDIR="${W_WINDIR_UNIX}"/Temp ;;
+        *) _W_LOGDIR="${WINEPREFIX}" ;;
     esac
 
-    mkdir -p "$_W_LOGDIR"
-    echo "$*" >> "$_W_LOGDIR"/winetricks.log
+    mkdir -p "${_W_LOGDIR}"
+    echo "$*" >> "${_W_LOGDIR}"/winetricks.log
     unset _W_LOGDIR
 }
 
@@ -22915,17 +22915,17 @@ winetricks_stats_log_command()
 winetricks_shell()
 {
     (
-        w_try_cd "$W_DRIVE_C"
+        w_try_cd "${W_DRIVE_C}"
         export WINE
 
-        case $WINETRICKS_GUI in
+        case ${WINETRICKS_GUI} in
             none)
-                $SHELL
+                ${SHELL}
                 ;;
             *)
                 for term in gnome-terminal konsole Terminal xterm; do
-                    if test "$(command -v $term 2>/dev/null)"; then
-                        $term
+                    if test "$(command -v ${term} 2>/dev/null)"; then
+                        ${term}
                         break
                     fi
                 done
@@ -22965,24 +22965,24 @@ execute_command()
         list-manual-download) winetricks_list_manual_download ;;
         list-installed) winetricks_list_installed ;;
         list-all)
-            old_menu="$WINETRICKS_CURMENU"
+            old_menu="${WINETRICKS_CURMENU}"
             for WINETRICKS_CURMENU in apps benchmarks dlls fonts games prefix settings; do
-                echo "===== $WINETRICKS_CURMENU ====="
+                echo "===== ${WINETRICKS_CURMENU} ====="
                 winetricks_list_all
             done
-            WINETRICKS_CURMENU="$old_menu"
+            WINETRICKS_CURMENU="${old_menu}"
             ;;
         unattended) winetricks_set_unattended 1 ;;
         attended) winetricks_set_unattended 0 ;;
-        arch=*) winetricks_set_winearch "$arg" ;;
-        prefix=*) winetricks_set_wineprefix "$arg" ;;
+        arch=*) winetricks_set_winearch "${arg}" ;;
+        prefix=*) winetricks_set_wineprefix "${arg}" ;;
         annihilate) winetricks_annihilate_wineprefix ;;
-        folder) w_open_folder "$WINEPREFIX" ;;
-        winecfg) "$WINE" winecfg ;;
-        regedit) "$WINE" regedit ;;
-        taskmgr) "$WINE" taskmgr & ;;
-        explorer) "$WINE" explorer & ;;
-        uninstaller) "$WINE" uninstaller ;;
+        folder) w_open_folder "${WINEPREFIX}" ;;
+        winecfg) "${WINE}" winecfg ;;
+        regedit) "${WINE}" regedit ;;
+        taskmgr) "${WINE}" taskmgr & ;;
+        explorer) "${WINE}" explorer & ;;
+        uninstaller) "${WINE}" uninstaller ;;
         shell) winetricks_shell ;;
 
         # These have to come before *=disabled to avoid looking like DLLs
@@ -22997,11 +22997,11 @@ execute_command()
 
         # Use winecfg if you want a GUI for plain old DLL overrides
         alldlls=*) w_call "$1" ;;
-        *=native) w_do_call native "$cmd";;
-        *=builtin) w_do_call builtin "$cmd";;
-        *=default) w_do_call default "$cmd";;
-        *=disabled) w_do_call disabled "$cmd";;
-        vd=*) w_do_call "$cmd";;
+        *=native) w_do_call native "${cmd}";;
+        *=builtin) w_do_call builtin "${cmd}";;
+        *=default) w_do_call default "${cmd}";;
+        *=disabled) w_do_call disabled "${cmd}";;
+        vd=*) w_do_call "${cmd}";;
 
         # Hacks for backwards compatibility
         # 2017/03/22: add deprecation notices
@@ -23065,13 +23065,13 @@ execute_command()
     esac
 }
 
-if ! test "$WINETRICKS_LIB"; then
+if ! test "${WINETRICKS_LIB}"; then
     # If user opted out, save that preference now.
     winetricks_stats_save
 
     # If user specifies menu on command line, execute that command, but don't commit to command-line mode
     # FIXME: this code is duplicated several times; unify it
-    if echo "$WINETRICKS_CATEGORIES" | grep -w "$1" > /dev/null; then
+    if echo "${WINETRICKS_CATEGORIES}" | grep -w "$1" > /dev/null; then
         WINETRICKS_CURMENU=$1
         shift
     fi
@@ -23090,7 +23090,7 @@ if ! test "$WINETRICKS_LIB"; then
             winetricks_volname "${1#volnameof=}"
             ;;
         "")
-            if [ -z "$DISPLAY" ]; then
+            if [ -z "${DISPLAY}" ]; then
                 if [ "$(uname -s)" = "Darwin" ]; then
                     echo "Running on OSX, but DISPLAY is not set...probably using Mac Driver."
                 else
@@ -23104,14 +23104,14 @@ if ! test "$WINETRICKS_LIB"; then
             # No non-option arguments given, so read them from GUI, and loop until user quits
             winetricks_detect_gui
             winetricks_detect_sudo
-            test -z "$WINETRICKS_ISO_MOUNT" && winetricks_detect_iso_mount
+            test -z "${WINETRICKS_ISO_MOUNT}" && winetricks_detect_iso_mount
             while true; do
-                case $WINETRICKS_CURMENU in
+                case ${WINETRICKS_CURMENU} in
                     main) verbs=$(winetricks_mainmenu) ;;
                     prefix)
                         verbs=$(winetricks_prefixmenu);
                         # Cheezy hack: choosing 'attended' or 'unattended' leaves you in same menu
-                        case "$verbs" in
+                        case "${verbs}" in
                             attended) winetricks_set_unattended 0 ; continue;;
                             unattended) winetricks_set_unattended 1 ; continue;;
                         esac
@@ -23121,35 +23121,35 @@ if ! test "$WINETRICKS_LIB"; then
                     *) verbs="$(winetricks_showmenu)" ;;
                 esac
 
-                if test "$verbs" = ""; then
+                if test "${verbs}" = ""; then
                     # "user didn't pick anything, back up a level in the menu"
                     case "${WINETRICKS_CURMENU}-${WINETRICKS_OPT_SHAREDPREFIX}" in
                         apps-0|benchmarks-0|games-0|main-*) WINETRICKS_CURMENU=prefix ;;
                         prefix-*) break ;;
                         *) WINETRICKS_CURMENU=main ;;
                     esac
-                elif echo "$WINETRICKS_CATEGORIES" | grep -w "$verbs" > /dev/null; then
-                    WINETRICKS_CURMENU=$verbs
+                elif echo "${WINETRICKS_CATEGORIES}" | grep -w "${verbs}" > /dev/null; then
+                    WINETRICKS_CURMENU=${verbs}
                 else
                     winetricks_stats_init
                     # Otherwise user picked one or more real verbs.
-                    case "$verbs" in
+                    case "${verbs}" in
                         prefix=*|arch=*)
                             # prefix menu is special, it only returns one verb, and the
                             # verb can contain spaces. If a 32bit wineprefix is created via
                             # the GUI, this may have an "arch=* " prefix
-                            _W_arch=$(echo "$verbs" | grep -o 'arch=.*' | cut -d' ' -f1)
-                            _W_prefix=$(echo "$verbs" | grep -o 'prefix=.*')
+                            _W_arch=$(echo "${verbs}" | grep -o 'arch=.*' | cut -d' ' -f1)
+                            _W_prefix=$(echo "${verbs}" | grep -o 'prefix=.*')
                             _W_prefix_name="${_W_prefix#*=}"
-                            if [ -n "$_W_arch" ]; then
-                                execute_command "$_W_arch"
+                            if [ -n "${_W_arch}" ]; then
+                                execute_command "${_W_arch}"
                             fi
-                            execute_command "$_W_prefix"
+                            execute_command "${_W_prefix}"
                             # after picking a prefix, want to land in main.
                             WINETRICKS_CURMENU=main ;;
                         *)
-                            for verb in $verbs; do
-                                execute_command "$verb"
+                            for verb in ${verbs}; do
+                                execute_command "${verb}"
                             done
 
                             case "${WINETRICKS_CURMENU}-${WINETRICKS_OPT_SHAREDPREFIX}" in
@@ -23171,23 +23171,23 @@ if ! test "$WINETRICKS_LIB"; then
             winetricks_stats_init
             # Command-line case
             winetricks_detect_sudo
-            test -z "$WINETRICKS_ISO_MOUNT" && winetricks_detect_iso_mount
+            test -z "${WINETRICKS_ISO_MOUNT}" && winetricks_detect_iso_mount
             # User gave command-line arguments, so just run those verbs and exit
             for verb; do
-                case $verb in
+                case ${verb} in
                     *.verb)
                         # Load the verb file
                         # shellcheck disable=SC1090
-                        case $verb in
-                            */*) . "$verb" ;;
-                            *) . ./"$verb" ;;
+                        case ${verb} in
+                            */*) . "${verb}" ;;
+                            *) . ./"${verb}" ;;
                         esac
 
                         # And forget that the verb comes from a file
-                        verb="$(echo "$verb" | sed 's,.*/,,;s,.verb,,')"
+                        verb="$(echo "${verb}" | sed 's,.*/,,;s,.verb,,')"
                         ;;
                 esac
-                execute_command "$verb"
+                execute_command "${verb}"
             done
             ;;
     esac


### PR DESCRIPTION
*  Added braces around variable references
From [SC2250](https://github.com/koalaman/shellcheck/wiki/SC2250):
```
If a variable gets called, and there is a string that gets appended to the variable that could get misinterpreted as possibly part of the name of the variable. Then it will not call the right variable.
```
But for me, is that you have a lot of variable that can be confused with others like the combination `${FontSmoothing}` and `${FontSmoothingType}`, so, knowing where the variable name ends, helps in reading the code.