### PR TITLE
fix w_package_broken: no longer silently exit when the wine version is good

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -328,16 +328,21 @@ w_package_broken()
     if [ -n "$good_version" ]; then
         if ! w_wine_version_in "${bad_version},${good_version}"; then
             w_warn "This package ($W_PACKAGE) is broken in ${_wine_version_stripped}. Upgrade to >=${good_version}. See ${bug_link} for more info."
+            _w_force_continue_check
+        else
+            echo "package was broken, now fixed"
         fi
     elif [ -n "$bad_version" ]; then
         if ! w_wine_version_in "${bad_version}"; then
             w_warn "This package ($W_PACKAGE) is broken in ${_wine_version_stripped}. Broken since ${bad_version}. See ${bug_link} for more info."
+            _w_force_continue_check
+        else
+            echo "Package is broken in future versions"
         fi
     else
         w_warn "This package ($W_PACKAGE) is broken. See ${bug_link} for more info."
+        _w_force_continue_check
     fi
-
-    _w_force_continue_check
 }
 
 w_detect_mingw()


### PR DESCRIPTION
There is a logic error in the `w_package_broken()` function: `_w_force_continue_check` will inevitably be executed, even if the wine version is good. So when the wine version is good, `winetricks` will exit without any prompt. (See #1596.)

Currently, adding the `--force` parameter is the only way to install a package that marked `w_package_broken` to a 32-bit prefix.

https://github.com/Winetricks/winetricks/blob/66f5122b39d50e0103b7a5d5852a199065e8c95d/src/winetricks#L340

```
w_package_broken()
{
    # FIXME: test cases for this

    bug_link="$1"
    bad_version="$2"
    good_version="$3"

    if [ -z "$bug_link" ] ; then
        w_die "Bug report link required!"
    fi

    if [ -n "$good_version" ]; then
        if ! w_wine_version_in "${bad_version},${good_version}"; then
            w_warn "This package ($W_PACKAGE) is broken in ${_wine_version_stripped}. Upgrade to >=${good_version}. See ${bug_link} for more info."
        fi
    elif [ -n "$bad_version" ]; then
        if ! w_wine_version_in "${bad_version}"; then
            w_warn "This package ($W_PACKAGE) is broken in ${_wine_version_stripped}. Broken since ${bad_version}. See ${bug_link} for more info."
        fi
    else
        w_warn "This package ($W_PACKAGE) is broken. See ${bug_link} for more info."
    fi

    _w_force_continue_check
}
```

----------------------

This patch will fix the above problem and make `w_package_broken()` consistent with other `w_package_broken*()` functions (such as `w_package_broken_win64()`).