### PR TITLE
cnc_ddraw: update to 1.3.5.0

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -6034,7 +6034,7 @@ w_metadata cnc_ddraw dlls \
     title="Reimplentation of ddraw for CnC games" \
     homepage="https://github.com/CnCNet/cnc-ddraw" \
     publisher="CnCNet" \
-    year="2018" \
+    year="2020" \
     media="download" \
     file1="cnc-ddraw.zip" \
     installed_file1="$W_SYSTEM32_DLLS_WIN/Shaders/readme.txt"
@@ -6042,7 +6042,7 @@ w_metadata cnc_ddraw dlls \
 load_cnc_ddraw()
 {
     # Note: only works if ddraw.ini contains settings for the executable
-    w_download https://github.com/CnCNet/cnc-ddraw/releases/download/1.3.4.0/cnc-ddraw.zip c1f85053223ab04a573cc482b43b93a58077e928a401f3364c9dc5542ad090ae
+    w_download https://github.com/CnCNet/cnc-ddraw/releases/download/1.3.5.0/cnc-ddraw.zip f603b2893cb6c73cf01743761a7d77917955e9a927752ef37b0b675e8b190f17
     w_try_unzip "$W_SYSTEM32_DLLS" "$W_CACHE/$W_PACKAGE/$file1"
 
     w_override_dlls native,builtin ddraw


### PR DESCRIPTION
Update to latest release of cnc-ddraw (Feb 4, 2020). See https://github.com/CnCNet/cnc-ddraw/releases.