### PR TITLE
EUupdate.EXE download link workaround

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -13899,7 +13899,8 @@ load_eufonts()
     # https://www.microsoft.com/en-us/download/details.aspx?id=16083
     # Previously at https://download.microsoft.com/download/a/1/8/a180e21e-9c2b-4b54-9c32-bf7fd7429970/EUupdate.EXE
     # 2020/09/11: https://sourceforge.net/projects/mscorefonts2/files/cabs/EUupdate.EXE
-    w_download "https://sourceforge.net/projects/mscorefonts2/files/cabs/EUupdate.EXE" 464dd2cd5f09f489f9ac86ea7790b7b8548fc4e46d9f889b68d2cdce47e09ea8
+    # 2020/09/14: http://ipfs.io/ipfs/QmXLYcBn5AKzdwcDwzD4rvNExZCuo7qjNzEQtxoizfyBtw/EUupdate.EXE
+    w_download "http://ipfs.io/ipfs/QmXLYcBn5AKzdwcDwzD4rvNExZCuo7qjNzEQtxoizfyBtw/EUupdate.EXE" 464dd2cd5f09f489f9ac86ea7790b7b8548fc4e46d9f889b68d2cdce47e09ea8
     w_try_cabextract -d "$W_TMP" "$W_CACHE"/eufonts/EUupdate.EXE
     w_try_cp_font_files "$W_TMP" "$W_FONTSDIR_UNIX"
 


### PR DESCRIPTION
Found a workaround for SourceForge link that is not working now (it leads to the CDN delay page) - the downloaded file with the correct hash uploaded to IPFS persistent storage system (CID `QmT1VxiU7HzcX6BNGiCCtpUr6pxaLDTjTxy8EvPw4X1EaD` EUupdate.EXE).

The root URI is made for the public IPFS directory CID `QmXLYcBn5AKzdwcDwzD4rvNExZCuo7qjNzEQtxoizfyBtw` to preserve filename.