### PR TITLE
fixed vc_redist sha256 checksums (2020-09-29)

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -12818,7 +12818,8 @@ load_vcrun2019()
     # 2020/03/23: ac96016f1511ae3eb5ec9de04551146fe351b7f97858dcd67163912e2302f5d6
     # 2020/05/20: a06aac66734a618ab33c1522920654ddfc44fc13cafaa0f0ab85b199c3d51dc0
     # 2020/08/05: b4d433e2f66b30b478c0d080ccd5217ca2a963c16e90caf10b1e0592b7d8d519
-    w_download https://aka.ms/vs/16/release/vc_redist.x86.exe b4d433e2f66b30b478c0d080ccd5217ca2a963c16e90caf10b1e0592b7d8d519
+    # 2020/09/29: caa38fd474164a38ab47ac1755c8ccca5ccfacfa9a874f62609e6439924e87ec
+    w_download https://aka.ms/vs/16/release/vc_redist.x86.exe caa38fd474164a38ab47ac1755c8ccca5ccfacfa9a874f62609e6439924e87ec
 
     w_override_dlls native,builtin api-ms-win-crt-private-l1-1-0 api-ms-win-crt-conio-l1-1-0 api-ms-win-crt-heap-l1-1-0 api-ms-win-crt-locale-l1-1-0 api-ms-win-crt-math-l1-1-0 api-ms-win-crt-runtime-l1-1-0 api-ms-win-crt-stdio-l1-1-0 api-ms-win-crt-time-l1-1-0 atl140 concrt140 msvcp140 msvcr140 ucrtbase vcomp140 vcruntime140
 
@@ -12832,11 +12833,12 @@ load_vcrun2019()
             # 2020/03/23: b6c82087a2c443db859fdbeaae7f46244d06c3f2a7f71c35e50358066253de52
             # 2020/05/20: 7d7105c52fcd6766beee1ae162aa81e278686122c1e44890712326634d0b055e
             # 2020/08/05: 952a0c6cb4a3dd14c3666ef05bb1982c5ff7f87b7103c2ba896354f00651e358
+            # 2020/09/29: 4b5890eb1aefdf8dfa3234b5032147eb90f050c5758a80901b201ae969780107
 
             # vcruntime140_1 is only shipped on x64:
             w_override_dlls native,builtin vcruntime140_1
 
-            w_download https://aka.ms/vs/16/release/vc_redist.x64.exe 952a0c6cb4a3dd14c3666ef05bb1982c5ff7f87b7103c2ba896354f00651e358
+            w_download https://aka.ms/vs/16/release/vc_redist.x64.exe 4b5890eb1aefdf8dfa3234b5032147eb90f050c5758a80901b201ae969780107
             w_try "${WINE}" vc_redist.x64.exe ${W_OPT_UNATTENDED:+/q}
             ;;
     esac


### PR DESCRIPTION
Microsoft has updated the vc_redist packages on 2020-09-29, see here:

https://docs.microsoft.com/de-de/visualstudio/releases/2019/release-notes

I updated the winetricks checksums so there is no mismatch error anymore