### PR TITLE
quartz_feb2010: new verb

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -11627,6 +11627,29 @@ load_quartz()
 
 #----------------------------------------------------------------
 
+w_metadata quartz_feb2010 dlls \
+    title="quartz.dll (February 2010)" \
+    publisher="Microsoft" \
+    year="2010" \
+    media="download" \
+    conflicts="quartz" \
+    file1="../directx9/directx_feb2010_redist.exe" \
+    installed_file1="$W_SYSTEM32_DLLS_WIN/quartz.dll"
+
+load_quartz_feb2010()
+{
+    helper_directx_dl
+
+    w_try_cabextract -d "$W_TMP" -L -F dxnt.cab "$W_CACHE"/directx9/$DIRECTX_NAME
+    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F quartz.dll "$W_TMP/dxnt.cab"
+
+    w_try_regsvr quartz.dll
+
+    w_override_dlls native quartz
+}
+
+#----------------------------------------------------------------
+
 w_metadata quicktime72 dlls \
     title="Apple QuickTime 7.2" \
     publisher="Apple" \

--- a/src/winetricks
+++ b/src/winetricks
@@ -11643,9 +11643,8 @@ load_quartz_feb2010()
     w_try_cabextract -d "${W_TMP}" -L -F dxnt.cab "${W_CACHE}"/directx9/${DIRECTX_NAME}
     w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F quartz.dll "${W_TMP}/dxnt.cab"
 
+    w_override_dlls native,builtin quartz
     w_try_regsvr quartz.dll
-
-    w_override_dlls native quartz
 }
 
 #----------------------------------------------------------------

--- a/src/winetricks
+++ b/src/winetricks
@@ -11634,14 +11634,14 @@ w_metadata quartz_feb2010 dlls \
     media="download" \
     conflicts="quartz" \
     file1="../directx9/directx_feb2010_redist.exe" \
-    installed_file1="$W_SYSTEM32_DLLS_WIN/quartz.dll"
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/quartz.dll"
 
 load_quartz_feb2010()
 {
     helper_directx_dl
 
-    w_try_cabextract -d "$W_TMP" -L -F dxnt.cab "$W_CACHE"/directx9/$DIRECTX_NAME
-    w_try_cabextract -d "$W_SYSTEM32_DLLS" -L -F quartz.dll "$W_TMP/dxnt.cab"
+    w_try_cabextract -d "${W_TMP}" -L -F dxnt.cab "${W_CACHE}"/directx9/${DIRECTX_NAME}
+    w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F quartz.dll "${W_TMP}/dxnt.cab"
 
     w_try_regsvr quartz.dll
 


### PR DESCRIPTION
RPG Maker (RPG Tkool) XP/VX/VXAce games need `gmdls`, `dmsynth`, `dmusic`, `dmband`, `dmime`, `dmstyle`, `dsdmo` and `dsound` for MIDI playback, but after installing them MP3 playback needs the "Feb 2010" version of `quartz`: Built-in version doesn't play MP3 files properly with native `dsound`, and "[win7sp1](https://github.com/Winetricks/winetricks/commit/20ec914d2025d0d3aec3c33cc75a276d53336db9)" version doesn't work.

So I really need the "Feb 2010" version of `quartz` for RPG Maker games.