### PR TITLE
Add travis job for ppc64le. Install shellcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: shell
 os:
   - linux
   - osx
+arch:
+  - amd64
+  - ppc64le
 sudo: required
 dist: bionic
 
@@ -67,6 +70,14 @@ before_install:
               fi
           done
       fi
+     
+    # Install shellcheck for power job
+    - |
+      if [[ "$TRAVIS_CPU_ARCH" == "ppc64le" ]]; then
+          time sudo apt update;
+          time sudo apt install -y shellcheck;
+      fi    
+      
 
 # Note if testing on a branch, you can replace this with your desired command, e.g.,:
 # script: time sh ./src/winetricks -q comctl32

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ addons:
     - devscripts
 
 # Ubuntu notes:
-#    * ShellCheck is already installed in TravisCI
+#    * ShellCheck is already installed in TravisCI (but not on ppc64le, see below) 
 #    * bashate is not available on Trusty and we need to install it manually
 # macOS note:
 #    * Homebrew doesn't provide bashate, they don't package things


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date. Since ppc64le doesn't have shellcheck by default, installing it before_install