### PR TITLE
directplay: add native override for dplaysvr.exe

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -6912,7 +6912,7 @@ load_directplay()
     w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dpnsvr.exe' "${W_TMP}/dxnt.cab"
     w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dpwsockx.dll' "${W_TMP}/dxnt.cab"
 
-    w_override_dlls native dplayx dpnet dpnhpast dpnsvr.exe dpwsockx
+    w_override_dlls native dplaysvr.exe dplayx dpnet dpnhpast dpnsvr.exe dpwsockx
 
     w_try_regsvr dplayx.dll
     w_try_regsvr dpnet.dll


### PR DESCRIPTION
A stub for dplaysvr.exe was added in [this commit](https://source.winehq.org/git/wine.git/commit/73afd2648c003fbddb657fc8a3f8f53a86754dcd), which started causing hangs when native directplay was installed. This PR fixes it. For reference, see [this bug](https://bugs.winehq.org/show_bug.cgi?id=50217).