### PR TITLE
vcrun improvements

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -12757,6 +12757,8 @@ load_vcrun2015()
             w_try "${WINE}" vc_redist.x64.exe ${W_OPT_UNATTENDED:+/q}
             ;;
     esac
+
+    w_set_winver 'default'
 }
 
 w_metadata mfc140 dlls \
@@ -12834,6 +12836,8 @@ load_vcrun2017()
             w_try "${WINE}" vc_redist.x64.exe ${W_OPT_UNATTENDED:+/q}
             ;;
     esac
+
+    w_set_winver 'default'
 }
 
 #----------------------------------------------------------------
@@ -12887,6 +12891,8 @@ load_vcrun2019()
             w_try "${WINE}" vc_redist.x64.exe ${W_OPT_UNATTENDED:+/q}
             ;;
     esac
+
+    w_set_winver 'default'
 }
 
 #----------------------------------------------------------------

--- a/src/winetricks
+++ b/src/winetricks
@@ -12745,11 +12745,17 @@ load_vcrun2015()
 
     w_set_winver winxp
 
+    # Otherwise ucrtbase doesn't get replaced
+    # See https://bugs.winehq.org/show_bug.cgi?id=46317
+    w_try rm -f "${W_SYSTEM32_DLLS}"/ucrtbase.dll
+
     w_try_cd "${W_CACHE}"/"${W_PACKAGE}"
     w_try "${WINE}" vc_redist.x86.exe ${W_OPT_UNATTENDED:+/q}
 
     case "${W_ARCH}" in
         win64)
+            # Also remove the 64-bit version
+            w_try rm -f "${W_SYSTEM64_DLLS}"/ucrtbase.dll
             # Also install the 64-bit version
             # 2015/10/12: 5eea714e1f22f1875c1cb7b1738b0c0b1f02aec5ecb95f0fdb1c5171c6cd93a3
             w_download https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe 5eea714e1f22f1875c1cb7b1738b0c0b1f02aec5ecb95f0fdb1c5171c6cd93a3
@@ -12818,11 +12824,17 @@ load_vcrun2017()
 
     w_set_winver winxp
 
+    # Otherwise ucrtbase doesn't get replaced
+    # See https://bugs.winehq.org/show_bug.cgi?id=46317
+    w_try rm -f "${W_SYSTEM32_DLLS}"/ucrtbase.dll
+
     w_try_cd "${W_CACHE}/${W_PACKAGE}"
     w_try "${WINE}" vc_redist.x86.exe ${W_OPT_UNATTENDED:+/q}
 
     case "${W_ARCH}" in
         win64)
+            # Also remove the 64-bit version
+            w_try rm -f "${W_SYSTEM64_DLLS}"/ucrtbase.dll
             # Also install the 64-bit version
             # https://support.microsoft.com/en-gb/help/2977003/the-latest-supported-visual-c-downloads
             # 2017/10/02: 7434bf559290cccc3dd3624f10c9e6422cce9927d2231d294114b2f929f0e465
@@ -12858,11 +12870,17 @@ load_vcrun2019()
 
     w_override_dlls native,builtin api-ms-win-crt-private-l1-1-0 api-ms-win-crt-conio-l1-1-0 api-ms-win-crt-heap-l1-1-0 api-ms-win-crt-locale-l1-1-0 api-ms-win-crt-math-l1-1-0 api-ms-win-crt-runtime-l1-1-0 api-ms-win-crt-stdio-l1-1-0 api-ms-win-crt-time-l1-1-0 atl140 concrt140 msvcp140 msvcr140 ucrtbase vcomp140 vcruntime140
 
+    # Otherwise ucrtbase doesn't get replaced
+    # See https://bugs.winehq.org/show_bug.cgi?id=46317
+    w_try rm -f "${W_SYSTEM32_DLLS}"/ucrtbase.dll
+
     w_try_cd "${W_CACHE}"/"${W_PACKAGE}"
     w_try "${WINE}" vc_redist.x86.exe ${W_OPT_UNATTENDED:+/q}
 
     case "${W_ARCH}" in
         win64)
+            # Also remove the 64-bit version
+            w_try rm -f "${W_SYSTEM64_DLLS}"/ucrtbase.dll
             # Also install the 64-bit version
             # 2019/12/26: 40ea2955391c9eae3e35619c4c24b5aaf3d17aeaa6d09424ee9672aa9372aeed
             # 2020/03/23: b6c82087a2c443db859fdbeaae7f46244d06c3f2a7f71c35e50358066253de52

--- a/src/winetricks
+++ b/src/winetricks
@@ -12800,7 +12800,7 @@ load_mfc140()
 #----------------------------------------------------------------
 
 w_metadata vcrun2017 dlls \
-    title="Visual C++ 2017 libraries (concrt140.dll,mfc140.dll,mfc140u.dll,mfcm140.dll,mfcm140u.dll,msvcp140.dll,vcamp140.dll,vccorlib140.dll,vcomp140.dll,vcruntime140.dll)" \
+    title="Visual C++ 2017 libraries (concrt140.dll,mfc140.dll,mfc140u.dll,mfcm140.dll,mfcm140u.dll,msvcp140.dll,msvcp140_1.dll,msvcp140_2.dll,vcamp140.dll,vccorlib140.dll,vcomp140.dll,vcruntime140.dll)" \
     publisher="Microsoft" \
     year="2017" \
     media="download" \
@@ -12820,7 +12820,7 @@ load_vcrun2017()
         :
     fi
 
-    w_override_dlls native,builtin api-ms-win-crt-private-l1-1-0 api-ms-win-crt-conio-l1-1-0 api-ms-win-crt-heap-l1-1-0 api-ms-win-crt-locale-l1-1-0 api-ms-win-crt-math-l1-1-0 api-ms-win-crt-runtime-l1-1-0 api-ms-win-crt-stdio-l1-1-0 api-ms-win-crt-time-l1-1-0 atl140 concrt140 msvcp140 msvcr140 ucrtbase vcomp140 vcruntime140
+    w_override_dlls native,builtin api-ms-win-crt-private-l1-1-0 api-ms-win-crt-conio-l1-1-0 api-ms-win-crt-heap-l1-1-0 api-ms-win-crt-locale-l1-1-0 api-ms-win-crt-math-l1-1-0 api-ms-win-crt-runtime-l1-1-0 api-ms-win-crt-stdio-l1-1-0 api-ms-win-crt-time-l1-1-0 atl140 concrt140 msvcp140 msvcp140_1 msvcp140_2 msvcr140 ucrtbase vcomp140 vcruntime140
 
     w_set_winver winxp
 
@@ -12849,7 +12849,7 @@ load_vcrun2017()
 #----------------------------------------------------------------
 
 w_metadata vcrun2019 dlls \
-    title="Visual C++ 2015-2019 libraries (concrt140.dll,mfc140.dll,mfc140u.dll,mfcm140.dll,mfcm140u.dll,msvcp140.dll,vcamp140.dll,vccorlib140.dll,vcomp140.dll,vcruntime140.dll) (and vcruntime140_1.dll on win64)" \
+    title="Visual C++ 2015-2019 libraries (concrt140.dll,mfc140.dll,mfc140u.dll,mfcm140.dll,mfcm140u.dll,msvcp140.dll,msvcp140_1,msvcp140_2,vcamp140.dll,vccorlib140.dll,vcomp140.dll,vcruntime140.dll) (and vcruntime140_1.dll on win64)" \
     publisher="Microsoft" \
     year="2019" \
     media="download" \
@@ -12868,7 +12868,7 @@ load_vcrun2019()
     # 2020/11/13: 50a3e92ade4c2d8f310a2812d46322459104039b9deadbd7fdd483b5c697c0c8
     w_download https://aka.ms/vs/16/release/vc_redist.x86.exe 50a3e92ade4c2d8f310a2812d46322459104039b9deadbd7fdd483b5c697c0c8
 
-    w_override_dlls native,builtin api-ms-win-crt-private-l1-1-0 api-ms-win-crt-conio-l1-1-0 api-ms-win-crt-heap-l1-1-0 api-ms-win-crt-locale-l1-1-0 api-ms-win-crt-math-l1-1-0 api-ms-win-crt-runtime-l1-1-0 api-ms-win-crt-stdio-l1-1-0 api-ms-win-crt-time-l1-1-0 atl140 concrt140 msvcp140 msvcr140 ucrtbase vcomp140 vcruntime140
+    w_override_dlls native,builtin api-ms-win-crt-private-l1-1-0 api-ms-win-crt-conio-l1-1-0 api-ms-win-crt-heap-l1-1-0 api-ms-win-crt-locale-l1-1-0 api-ms-win-crt-math-l1-1-0 api-ms-win-crt-runtime-l1-1-0 api-ms-win-crt-stdio-l1-1-0 api-ms-win-crt-time-l1-1-0 atl140 concrt140 msvcp140 msvcp140_1 msvcp140_2 msvcr140 ucrtbase vcomp140 vcruntime140
 
     # Otherwise ucrtbase doesn't get replaced
     # See https://bugs.winehq.org/show_bug.cgi?id=46317

--- a/src/winetricks
+++ b/src/winetricks
@@ -12737,16 +12737,11 @@ load_vcrun2015()
     # 2015/10/12: fdd1e1f0dcae2d0aa0720895eff33b927d13076e64464bb7c7e5843b7667cd14
     w_download https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x86.exe fdd1e1f0dcae2d0aa0720895eff33b927d13076e64464bb7c7e5843b7667cd14
 
-    if w_workaround_wine_bug 37781 "This may fail in non-XP mode, see https://bugs.winehq.org/show_bug.cgi?id=37781" ,4.15; then
-        :
-    fi
-
     w_override_dlls native,builtin api-ms-win-crt-private-l1-1-0 api-ms-win-crt-conio-l1-1-0 api-ms-win-crt-heap-l1-1-0 api-ms-win-crt-locale-l1-1-0 api-ms-win-crt-math-l1-1-0 api-ms-win-crt-runtime-l1-1-0 api-ms-win-crt-stdio-l1-1-0 api-ms-win-crt-time-l1-1-0 atl140 concrt140 msvcp140 msvcr140 ucrtbase vcomp140 vcruntime140
-
-    w_set_winver winxp
 
     # Otherwise ucrtbase doesn't get replaced
     # See https://bugs.winehq.org/show_bug.cgi?id=46317
+    w_set_winver winxp
     w_try rm -f "${W_SYSTEM32_DLLS}"/ucrtbase.dll
 
     w_try_cd "${W_CACHE}"/"${W_PACKAGE}"
@@ -12816,16 +12811,11 @@ load_vcrun2017()
     # 2019/08/14: 54ad46ae80984aa48cae6361213692c96b3639e322730d28c7fb93b183c761da
     w_download https://aka.ms/vs/15/release/vc_redist.x86.exe 54ad46ae80984aa48cae6361213692c96b3639e322730d28c7fb93b183c761da
 
-    if w_workaround_wine_bug 37781 "This may fail in non-XP mode, see https://bugs.winehq.org/show_bug.cgi?id=37781" ,4.15; then
-        :
-    fi
-
     w_override_dlls native,builtin api-ms-win-crt-private-l1-1-0 api-ms-win-crt-conio-l1-1-0 api-ms-win-crt-heap-l1-1-0 api-ms-win-crt-locale-l1-1-0 api-ms-win-crt-math-l1-1-0 api-ms-win-crt-runtime-l1-1-0 api-ms-win-crt-stdio-l1-1-0 api-ms-win-crt-time-l1-1-0 atl140 concrt140 msvcp140 msvcp140_1 msvcp140_2 msvcr140 ucrtbase vcomp140 vcruntime140
-
-    w_set_winver winxp
 
     # Otherwise ucrtbase doesn't get replaced
     # See https://bugs.winehq.org/show_bug.cgi?id=46317
+    w_set_winver winxp
     w_try rm -f "${W_SYSTEM32_DLLS}"/ucrtbase.dll
 
     w_try_cd "${W_CACHE}/${W_PACKAGE}"
@@ -12872,6 +12862,7 @@ load_vcrun2019()
 
     # Otherwise ucrtbase doesn't get replaced
     # See https://bugs.winehq.org/show_bug.cgi?id=46317
+    w_set_winver winxp
     w_try rm -f "${W_SYSTEM32_DLLS}"/ucrtbase.dll
 
     w_try_cd "${W_CACHE}"/"${W_PACKAGE}"


### PR DESCRIPTION
Fixes #1667 and fixes #1635.

To clarify commit 3, the bug mentioned doesn't seem to be the reason why it has to run in XP mode anymore. In Win7 it will refuse to install ucrtbase.dll if it's missing, but it won't replace it if it's not removed before the installer is run.

I split the commits into chucks that made sense for me, but feel free to request more splitting/changes.