### PR TITLE
WIP: ability to switch between zenity and kdialog

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -3458,24 +3458,32 @@ winetricks_early_wine_arch()
 
 winetricks_detect_gui()
 {
-    if [ $XDG_CURRENT_DESKTOP == "KDE" ] && [ "$1" != "zenity" ]; then
-        [ "$1" = "--gui" ] && echo "No GUI specified, defaulting to kdialog."
-        WINETRICKS_GUI=kdialog
-        WINETRICKS_GUI_VERSION="$(kdialog --version)"
-    elif test -x "$(command -v zenity 2>/dev/null)"; then
-        [ "$1" = "--gui" ] && echo "No GUI specified, defaulting to zenity."
+    if [[ -n "$1" ]]; then
+        if [ "$1" == "kdialog" ] && test -x "$(command -v kdialog 2>/dev/null)"; then
+            WINETRICKS_GUI=kdialog
+            WINETRICKS_GUI_VERSION="$(kdialog --version)"
+        elif [ "$1" == "zenity" ] && test -x "$(command -v zenity 2>/dev/null)"; then
+            WINETRICKS_GUI=zenity
+            WINETRICKS_GUI_VERSION="$(zenity --version)"
+            WINETRICKS_MENU_HEIGHT=500
+            WINETRICKS_MENU_WIDTH=1010
+        else
+            echo "Invalid argument for --gui"
+            echo "Valid options are 'zenity' and 'kdialog'"
+            exit 1
+        fi
+    elif test -x "$(command -v zenity 2>/dev/null)" && [ $XDG_CURRENT_DESKTOP != "KDE" ]; then
         WINETRICKS_GUI=zenity
         WINETRICKS_GUI_VERSION="$(zenity --version)"
         WINETRICKS_MENU_HEIGHT=500
         WINETRICKS_MENU_WIDTH=1010
     elif test -x "$(command -v kdialog 2>/dev/null)"; then
-        echo "Zenity not found!  Using kdialog as poor substitute."
         WINETRICKS_GUI=kdialog
         WINETRICKS_GUI_VERSION="$(kdialog --version)"
     else
         echo "No arguments given, so tried to start GUI, but neither zenity or"
-        echo "kdialog were not found. Please install one of them if you want a"
-        echo "graphical interface, or run with --help for more options."
+        echo "kdialog were not found. Please install one of them if you want"
+        echo "a graphical interface, or run with --help for more options."
         exit 1
     fi
 
@@ -3483,6 +3491,8 @@ winetricks_detect_gui()
     if [ -z "${WINETRICKS_SUPER_QUIET}" ] ; then
        echo "winetricks GUI enabled, using "${WINETRICKS_GUI}" ${WINETRICKS_GUI_VERSION##kdialog }"
     fi
+
+    exit 1
 }
 
 # Detect which sudo to use
@@ -23274,6 +23284,7 @@ if ! test "${WINETRICKS_LIB}"; then
 
             # GUI case
             # No non-option arguments given, so read them from GUI, and loop until user quits
+            
             if [ $WINETRICKS_GUI = "none" ]; then 
                 winetricks_detect_gui
             fi

--- a/src/winetricks
+++ b/src/winetricks
@@ -3489,7 +3489,7 @@ winetricks_detect_gui()
 
     # Print zenity/dialog version info for debugging:
     if [ -z "${WINETRICKS_SUPER_QUIET}" ] ; then
-       echo "winetricks GUI enabled, using "${WINETRICKS_GUI}" ${WINETRICKS_GUI_VERSION##kdialog }"
+       echo "winetricks GUI enabled, using ${WINETRICKS_GUI} ${WINETRICKS_GUI_VERSION##kdialog }"
     fi
 }
 

--- a/src/winetricks
+++ b/src/winetricks
@@ -3462,7 +3462,7 @@ winetricks_detect_gui()
         if [ "$1" == "kdialog" ] && test -x "$(command -v kdialog 2>/dev/null)"; then
             WINETRICKS_GUI=kdialog
             WINETRICKS_GUI_VERSION="$(kdialog --version)"
-        elif [ "$1" == "zenity" ] && test -x "$(command -v zenity 2>/dev/null)"; then
+        elif [ "$1" == "zenity" ] || [ "$1" == "--gui" ] && test -x "$(command -v zenity 2>/dev/null)"; then
             WINETRICKS_GUI=zenity
             WINETRICKS_GUI_VERSION="$(zenity --version)"
             WINETRICKS_MENU_HEIGHT=500

--- a/src/winetricks
+++ b/src/winetricks
@@ -3479,7 +3479,7 @@ winetricks_detect_gui()
         WINETRICKS_GUI=zenity
         WINETRICKS_GUI_VERSION="$(zenity --version)"
         WINETRICKS_MENU_HEIGHT=500
-        WINETRICKS_MENU_WIDTH=1010 
+        WINETRICKS_MENU_WIDTH=1010
     elif test -x "$(command -v kdialog 2>/dev/null)"; then
         WINETRICKS_GUI=kdialog
         WINETRICKS_GUI_VERSION="$(kdialog --version)"

--- a/src/winetricks
+++ b/src/winetricks
@@ -3472,7 +3472,7 @@ winetricks_detect_gui()
             echo "Valid options are 'zenity' and 'kdialog'"
             exit 1
         fi
-    elif [ "${XDG_CURRENT_DESKTOP}" == "KDE" ] && test -x "$(command -v kdialog 2>/dev/null)"; then
+    elif [ "${XDG_CURRENT_DESKTOP}" = "KDE" ] && test -x "$(command -v kdialog 2>/dev/null)"; then
         WINETRICKS_GUI=kdialog
         WINETRICKS_GUI_VERSION="$(kdialog --version)"
     elif test -x "$(command -v zenity 2>/dev/null)"; then

--- a/src/winetricks
+++ b/src/winetricks
@@ -3458,11 +3458,11 @@ winetricks_early_wine_arch()
 
 winetricks_detect_gui()
 {
-    if [[ -n "$1" ]]; then
-        if [ "$1" == "kdialog" ] && test -x "$(command -v kdialog 2>/dev/null)"; then
+    if [ -n "$1" ]; then
+        if [ "$1" = "kdialog" ] && test -x "$(command -v kdialog 2>/dev/null)"; then
             WINETRICKS_GUI=kdialog
             WINETRICKS_GUI_VERSION="$(kdialog --version)"
-        elif [ "$1" == "zenity" ] || [ "$1" == "--gui" ] && test -x "$(command -v zenity 2>/dev/null)"; then
+        elif [ "$1" = "zenity" ] || [ "$1" = "--gui" ] && test -x "$(command -v zenity 2>/dev/null)"; then
             WINETRICKS_GUI=zenity
             WINETRICKS_GUI_VERSION="$(zenity --version)"
             WINETRICKS_MENU_HEIGHT=500

--- a/src/winetricks
+++ b/src/winetricks
@@ -3458,7 +3458,12 @@ winetricks_early_wine_arch()
 
 winetricks_detect_gui()
 {
-    if test -x "$(command -v zenity 2>/dev/null)"; then
+    if [ $XDG_CURRENT_DESKTOP == "KDE" ] && [ "$1" != "zenity" ]; then
+        [ "$1" = "--gui" ] || [  -z "$1" ] && echo "No GUI specified, defaulting to kdialog."
+        WINETRICKS_GUI=kdialog
+        WINETRICKS_GUI_VERSION="$(kdialog --version)"
+    elif test -x "$(command -v zenity 2>/dev/null)"; then
+        [ "$1" = "--gui" ] || [  -z "$1" ] && echo "No GUI specified, defaulting to zenity."
         WINETRICKS_GUI=zenity
         WINETRICKS_GUI_VERSION="$(zenity --version)"
         WINETRICKS_MENU_HEIGHT=500
@@ -3468,15 +3473,15 @@ winetricks_detect_gui()
         WINETRICKS_GUI=kdialog
         WINETRICKS_GUI_VERSION="$(kdialog --version)"
     else
-        echo "No arguments given, so tried to start GUI, but zenity not found."
-        echo "Please install zenity if you want a graphical interface, or "
-        echo "run with --help for more options."
+        echo "No arguments given, so tried to start GUI, but neither zenity or"
+        echo "kdialog were not found. Please install one of them if you want a"
+        echo "graphical interface, or run with --help for more options."
         exit 1
     fi
 
     # Print zenity/dialog version info for debugging:
     if [ -z "${WINETRICKS_SUPER_QUIET}" ] ; then
-       echo "winetricks GUI enabled, using ${WINETRICKS_GUI} ${WINETRICKS_GUI_VERSION}"
+       echo "winetricks GUI enabled, using "${WINETRICKS_GUI}" ${WINETRICKS_GUI_VERSION##kdialog }"
     fi
 }
 
@@ -5609,6 +5614,7 @@ Options:
     --country=CC      Set country code to CC and don't detect your IP address
 -f, --force           Don't check whether packages were already installed
     --gui             Show gui diagnostics even when driven by commandline
+    --gui=OPT         Set OPT to kdialog or zenity to override GUI engine
     --isolate         Install each app or game in its own bottle (WINEPREFIX)
     --self-update     Update this application to the last version
     --update-rollback Rollback the last self update
@@ -5650,7 +5656,7 @@ winetricks_handle_option()
     case "$1" in
         --country=*) W_COUNTRY="${1##--country=}" ;;
         -f|--force) WINETRICKS_FORCE=1;;
-        --gui) winetricks_detect_gui;;
+        --gui*) winetricks_detect_gui "${1##--gui=}";;
         -h|--help) winetricks_usage ; exit 0 ;;
         --isolate) WINETRICKS_OPT_SHAREDPREFIX=0 ;;
         -k|--keep_isos) WINETRICKS_OPT_KEEPISOS=1 ;;
@@ -23268,7 +23274,9 @@ if ! test "${WINETRICKS_LIB}"; then
 
             # GUI case
             # No non-option arguments given, so read them from GUI, and loop until user quits
-            winetricks_detect_gui
+            if [ $WINETRICKS_GUI = "none" ]; then 
+                winetricks_detect_gui
+            fi
             winetricks_detect_sudo
             test -z "${WINETRICKS_ISO_MOUNT}" && winetricks_detect_iso_mount
             while true; do

--- a/src/winetricks
+++ b/src/winetricks
@@ -3459,11 +3459,11 @@ winetricks_early_wine_arch()
 winetricks_detect_gui()
 {
     if [ $XDG_CURRENT_DESKTOP == "KDE" ] && [ "$1" != "zenity" ]; then
-        [ "$1" = "--gui" ] || [  -z "$1" ] && echo "No GUI specified, defaulting to kdialog."
+        [ "$1" = "--gui" ] && echo "No GUI specified, defaulting to kdialog."
         WINETRICKS_GUI=kdialog
         WINETRICKS_GUI_VERSION="$(kdialog --version)"
     elif test -x "$(command -v zenity 2>/dev/null)"; then
-        [ "$1" = "--gui" ] || [  -z "$1" ] && echo "No GUI specified, defaulting to zenity."
+        [ "$1" = "--gui" ] && echo "No GUI specified, defaulting to zenity."
         WINETRICKS_GUI=zenity
         WINETRICKS_GUI_VERSION="$(zenity --version)"
         WINETRICKS_MENU_HEIGHT=500

--- a/src/winetricks
+++ b/src/winetricks
@@ -3491,8 +3491,6 @@ winetricks_detect_gui()
     if [ -z "${WINETRICKS_SUPER_QUIET}" ] ; then
        echo "winetricks GUI enabled, using "${WINETRICKS_GUI}" ${WINETRICKS_GUI_VERSION##kdialog }"
     fi
-
-    exit 1
 }
 
 # Detect which sudo to use

--- a/src/winetricks
+++ b/src/winetricks
@@ -3472,7 +3472,7 @@ winetricks_detect_gui()
             echo "Valid options are 'zenity' and 'kdialog'"
             exit 1
         fi
-    elif test -x "$(command -v zenity 2>/dev/null)" && [ $XDG_CURRENT_DESKTOP != "KDE" ]; then
+    elif test -x "$(command -v zenity 2>/dev/null)" && [ "${XDG_CURRENT_DESKTOP}" != "KDE" ]; then
         WINETRICKS_GUI=zenity
         WINETRICKS_GUI_VERSION="$(zenity --version)"
         WINETRICKS_MENU_HEIGHT=500
@@ -23282,7 +23282,7 @@ if ! test "${WINETRICKS_LIB}"; then
 
             # GUI case
             # No non-option arguments given, so read them from GUI, and loop until user quits
-            if [ $WINETRICKS_GUI = "none" ]; then
+            if [ ${WINETRICKS_GUI} = "none" ]; then
                 winetricks_detect_gui
             fi
             winetricks_detect_sudo

--- a/src/winetricks
+++ b/src/winetricks
@@ -23282,8 +23282,7 @@ if ! test "${WINETRICKS_LIB}"; then
 
             # GUI case
             # No non-option arguments given, so read them from GUI, and loop until user quits
-            
-            if [ $WINETRICKS_GUI = "none" ]; then 
+            if [ $WINETRICKS_GUI = "none" ]; then
                 winetricks_detect_gui
             fi
             winetricks_detect_sudo

--- a/src/winetricks
+++ b/src/winetricks
@@ -3472,17 +3472,20 @@ winetricks_detect_gui()
             echo "Valid options are 'zenity' and 'kdialog'"
             exit 1
         fi
-    elif test -x "$(command -v zenity 2>/dev/null)" && [ "${XDG_CURRENT_DESKTOP}" != "KDE" ]; then
+    elif [ "${XDG_CURRENT_DESKTOP}" == "KDE" ] && test -x "$(command -v kdialog 2>/dev/null)"; then
+        WINETRICKS_GUI=kdialog
+        WINETRICKS_GUI_VERSION="$(kdialog --version)"
+    elif test -x "$(command -v zenity 2>/dev/null)"; then
         WINETRICKS_GUI=zenity
         WINETRICKS_GUI_VERSION="$(zenity --version)"
         WINETRICKS_MENU_HEIGHT=500
-        WINETRICKS_MENU_WIDTH=1010
+        WINETRICKS_MENU_WIDTH=1010 
     elif test -x "$(command -v kdialog 2>/dev/null)"; then
         WINETRICKS_GUI=kdialog
         WINETRICKS_GUI_VERSION="$(kdialog --version)"
     else
-        echo "No arguments given, so tried to start GUI, but neither zenity nor"
-        echo "kdialog were not found. Please install one of them if you want"
+        echo "No arguments given, so tried to start GUI, but neither zenity"
+        echo "nor kdialog were found. Please install one of them if you want"
         echo "a graphical interface, or run with --help for more options."
         exit 1
     fi

--- a/src/winetricks
+++ b/src/winetricks
@@ -3481,7 +3481,7 @@ winetricks_detect_gui()
         WINETRICKS_GUI=kdialog
         WINETRICKS_GUI_VERSION="$(kdialog --version)"
     else
-        echo "No arguments given, so tried to start GUI, but neither zenity or"
+        echo "No arguments given, so tried to start GUI, but neither zenity nor"
         echo "kdialog were not found. Please install one of them if you want"
         echo "a graphical interface, or run with --help for more options."
         exit 1


### PR DESCRIPTION
Hello, after seeing an open issue about this(#1654), I've decided to create a patch.
As it is now, I've changed the --gui flag to accept an argument as well as keep it's previous behaviour intact (--gui without arguments meaning using zenity).
It is also defaulting to kdialog when using kde by checking the XDG_CURRENT_DESKTOP env var.

I'm not 100% sure about the last point though, given how kdialog seemed to be advised against.