### PR TITLE
steam: disable libglesv2

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -16355,6 +16355,10 @@ load_steam()
     if w_workaround_wine_bug 22053 "Disabling gameoverlayrenderer to prevent game crashes on some machines."; then
         w_override_dlls disabled gameoverlayrenderer
     fi
+
+    if w_workaround_wine_bug 44985 "Disabling libglesv2 to make Store and Library function correctly."; then
+        w_override_dlls disabled libglesv2
+    fi
 }
 
 #----------------------------------------------------------------


### PR DESCRIPTION
This is necessary because otherwise the Store and Library tabs will be black. It "works" with libglesv2 diabled. I say "works" because it's functional enough to be useful, but still suffers from flickering/repainting issues.