### PR TITLE
dxvk_master: delete verb - no longer supported Upstream

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -8391,30 +8391,6 @@ load_dxvk()
 
 #----------------------------------------------------------------
 
-w_metadata dxvk_master dlls \
-    title="Vulkan-based D3D9/D3D10/D3D11 implementation for Linux / Wine (master)" \
-    publisher="Philip Rebohle" \
-    year="2017" \
-    media="download" \
-    file1="dxvk_master.zip" \
-    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
-    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
-    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
-    installed_file4="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
-
-load_dxvk_master()
-{
-    # https://git.froggi.es/doitsujin/dxvk
-    # FIXME: Delete cached file, when verb is forced. Gitlab artifacts do not supply any version/commit hash information.
-    if test "${WINETRICKS_FORCE}" = 1 && test -f "${W_CACHE}/${W_PACKAGE}/${file1}"; then
-        w_try rm -f "${W_CACHE}/${W_PACKAGE}/${file1}"
-    fi
-    w_linkcheck_ignore=1 w_download_to "${W_CACHE}/${W_PACKAGE}" "https://git.froggi.es/doitsujin/dxvk/-/jobs/artifacts/master/download?job=dxvk" "" "dxvk_master.zip"
-    helper_dxvk_d9vk "${file1}" "5.8" "1.2.140" "dxgi,d3d9,d3d10core,d3d11"
-}
-
-#----------------------------------------------------------------
-
 w_metadata dmusic32 dlls \
     title="MS dmusic32.dll from DirectX user redistributable" \
     publisher="Microsoft" \
@@ -23065,7 +23041,6 @@ execute_command()
         comdlg32.ocx) w_warn "Calling comdlg32.ocx is deprecated, please use comdlg32ocx instead" ; w_call comdlg32ocx ;;
         dotnet1) w_warn "Calling dotnet1 is deprecated, please use dotnet11 instead" ; w_call dotnet11 ;;
         dotnet2) w_warn "Calling dotnet2 is deprecated, please use dotnet20 instead" ; w_call dotnet20 ;;
-        d9vk_master) w_warn "Calling d9vk_master is deprecated, please use dxvk_master instead" ; w_call dxvk_master ;;
         ddr=gdi) w_warn "Calling ddr=gdi is deprecated, please use renderer=gdi or renderer=no3d instead" ; w_call renderer=gdi ;;
         ddr=opengl) w_warn "Calling ddr=opengl is deprecated, please use renderer=gl instead" ; w_call renderer=gl ;;
         dxvk54) w_warn "Calling dxvk54 is deprecated, please use dxvk054 instead" ; w_call dxvk054 ;;

--- a/tests/winetricks-test
+++ b/tests/winetricks-test
@@ -102,8 +102,6 @@ BLACKLIST="${BLACKLIST}|ffdshow|python26|python27"
 BLACKLIST="${BLACKLIST}|dirac"
 # https://bugs.winehq.org/show_bug.cgi?id=50061 / https://github.com/Winetricks/winetricks/issues/1644
 BLACKLIST="${BLACKLIST}|quicktime76"
-# https://github.com/Winetricks/winetricks/issues/1638
-BLACKLIST="${BLACKLIST}|dxvk_master"
 
 # Travis CI is apparently blocking archive.org, which breaks several verbs:
 # https://github.com/travis-ci/travis-ci/issues/6798


### PR DESCRIPTION
 * fixes: https://github.com/Winetricks/winetricks/issues/1638