### PR TITLE
w_try_regsvr: Added more user-friendly error messages.

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -578,6 +578,9 @@ w_try()
     en_ms_105="exit status ${status} - normal, user selected 'restart now'"
     en_ms_194="exit status ${status} - normal, user selected 'restart later'"
 
+    en_regsvr32_3="regsvr32 exit status ${status} - regsvr32: ${_w_regsvr32} not found in syswow64 or system32 depending if wine or wine64. Aborting."
+    en_regsvr32_4="regsvr32 exit status ${status} - regsvr32: 'DllRegisterServer' not implemented in ${_w_regsvr32}, don't try to register such native DLLs. Aborting."
+
     en_abort="Note: command $* returned status ${status}. Aborting."
     pl_abort="Informacja: poelcenie $* zwróciło status ${status}. Przerywam."
     ru_abort="Важно: команда $* вернула статус ${status}. Прерывание."
@@ -591,6 +594,16 @@ w_try()
 
             # Fatal
             5) w_die "${en_ms_5}" ;;
+            *) w_die "${en_abort}" ;;
+        esac
+    elif [ -n "${_w_regsvr32}" ]; then
+        case ${status} in
+            # Nonfatal
+            0) ;;
+
+            # Fatal
+            3) w_die "${en_regsvr32_3}" ;;
+            4) w_die "${en_regsvr32_4}" ;;
             *) w_die "${en_abort}" ;;
         esac
     else
@@ -779,12 +792,16 @@ w_try_regedit64()
 
 w_try_regsvr()
 {
+    _w_regsvr32="$1"
     w_try "${WINE}" regsvr32 ${W_OPT_UNATTENDED:+/S} "$@"
+    unset _w_regsvr32
 }
 
 w_try_regsvr64()
 {
+    _w_regsvr32="$1"
     w_try "${WINE64}" regsvr32 ${W_OPT_UNATTENDED:+/S} "$@"
+    unset _w_regsvr32
 }
 
 w_try_unrar()


### PR DESCRIPTION
w_try_regsvr and w_try_regsvr64 now print a more user friendly message than, eg:
```
Executing /opt/wine-staging/bin/wine regsvr32 /S browsewm.dll
------------------------------------------------------
warning: Note: command /opt/wine-staging/bin/wine regsvr32 /S /home/gaming/.wine/dosdevices/c:/windows/syswow64/browsewm.dll returned status 3. Aborting.
------------------------------------------------------
[....OR....]
Executing /opt/wine-staging/bin/wine regsvr32 /S iesetup.dll
------------------------------------------------------
warning: Note: command /opt/wine-staging/bin/wine regsvr32 /S /home/gaming/.wine/dosdevices/c:/windows/system32/iesetup.dll returned status 4. Aborting.
------------------------------------------------------
```

Now they print like:
```
Executing /opt/wine-staging/bin/wine regsvr32 /S browsewm.dll
------------------------------------------------------
warning: regsvr32 exit status 3 - regsvr32: browsewm.dll not found in syswow64 or system32 depending if wine or wine64. Aborting.
------------------------------------------------------
[....OR....]
Executing /opt/wine-staging/bin/wine regsvr32 /S iesetup.dll
------------------------------------------------------
warning: regsvr32 exit status 4 - regsvr32: 'DllRegisterServer' not implemented in iesetup.dll, don't try to register such native DLLs. Aborting.
------------------------------------------------------
```

I guess you might like to revise the error messages, but I thought it more helpful than just error code 3 or 4.

I also see an error code 1 and 5 are possible, but I don't know what they mean. I'll be looking for a bit.

Ok I found a reference, I need to think about this more and I'll revise:
https://github.com/wine-mirror/wine/blob/master/programs/regsvr32/regsvr32.h