### PR TITLE
ev3 verb change link to archive.org

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -14901,7 +14901,8 @@ load_ev3()
 
     # 2016/03/22: LMS-EV3-WIN32-ENUS-01-02-01-full-setup.exe c47341f08242f0f6f01996530e7c93bda2d666747ada60ab93fa773a55d40a19
 
-    w_download http://esd.lego.com.edgesuite.net/digitaldelivery/mindstorms/6ecda7c2-1189-4816-b2dd-440e22d65814/public/LMS-EV3-WIN32-ENUS-01-02-01-full-setup.exe c47341f08242f0f6f01996530e7c93bda2d666747ada60ab93fa773a55d40a19
+    #w_download http://esd.lego.com.edgesuite.net/digitaldelivery/mindstorms/6ecda7c2-1189-4816-b2dd-440e22d65814/public/LMS-EV3-WIN32-ENUS-01-02-01-full-setup.exe c47341f08242f0f6f01996530e7c93bda2d666747ada60ab93fa773a55d40a19
+    w_download https://web.archive.org/web/20171108054720if_/http://esd.lego.com.edgesuite.net/digitaldelivery/mindstorms/6ecda7c2-1189-4816-b2dd-440e22d65814/public/LMS-EV3-WIN32-ENUS-01-02-01-full-setup.exe c2e65d3ca09f71d52931c5a0ff7cb0554b86b30ae80d1c61167dd68893a8237f
 
     w_try_cd "${W_CACHE}"/"${W_PACKAGE}"
     w_try "${WINE}" "${file1}" ${W_OPT_UNATTENDED:+/qb /AcceptLicenses yes}


### PR DESCRIPTION
The original download site for Lego Mindstorms EV3 Home Edition is down. I've changed the link to archive.org.
Strangely enough, the original download had a sha256 of `c47341f08242f0f6f01996530e7c93bda2d666747ada60ab93fa773a55d40a19`, but this archive.org version has a sha256 of `c2e65d3ca09f71d52931c5a0ff7cb0554b86b30ae80d1c61167dd68893a8237f`.
I have no explanation for why the shasum changed, but this discrepancy is consistent and the exe does launch fine.

Sidenote: Where's the best place to get help for this ev3 verb? I've tried various combinations for days to get it working. Right now there's a [$30 bounty](https://github.com/ptitSeb/box86/issues/296) on it.