### PR TITLE
set_mididevice: new setting

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -22192,6 +22192,29 @@ load_rtlm()
 {
     winetricks_set_wined3d_var RenderTargetLockMode "$1"
 }
+
+#----------------------------------------------------------------
+
+w_metadata set_mididevice settings \
+    title="Set MIDImap device to the value specified in the MIDI_DEVICE environment variable"
+
+load_set_mididevice()
+{
+    if [ -z "${MIDI_DEVICE}" ]; then
+        MIDI_DEVICE=$(w_question "Please specify MIDImap device: ")
+        [ -z "${MIDI_DEVICE}" ] && w_die "Please specify device in MIDI_DEVICE environment variable."
+    fi
+
+    echo "Setting MIDI device to \"${MIDI_DEVICE}\""
+    cat > "${W_TMP}"/set-mididevice.reg <<_EOF_
+REGEDIT4
+
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Multimedia\MIDIMap]
+"CurrentInstrument"="${MIDI_DEVICE}"
+_EOF_
+    w_try_regedit "${W_TMP_WIN}"\\set-mididevice.reg
+}
+
 #----------------------------------------------------------------
 
 w_metadata videomemorysize=default settings \


### PR DESCRIPTION
based on the [WINE documentation](https://wiki.winehq.org/MIDI), this setting adds the ability to easily specify the configured MIDImap device. since the device can be an arbitrary value, it didn't seem like the `key=val1,key=val2` pattern would work here so i came up with a solution based on an environment variable and `w_question`. let me know if you don't think this is appropriate for the scope of winetricks or if there's a better way to pass in arguments