### PR TITLE
steam: use /S instead of AutoHotkey for silent install

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -16215,29 +16215,7 @@ load_steam()
     w_download http://media.steampowered.com/client/installer/SteamSetup.exe 874788b45dfc043289ba05387e83f27b4a046004a88a4c5ee7c073187ff65b9d
     w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
-    if [ -n "${W_OPT_UNATTENDED}" ]; then
-            w_ahk_do "
-            run, SteamSetup.exe
-            SetTitleMatchMode, 2
-            WinWait, Steam, Using Steam
-            sleep 1000
-            ControlClick, Button2
-            WinWait, Steam, Select the language
-            sleep 1000
-            ControlClick, Button2
-            WinWait, Steam, Choose the folder
-            sleep 1000
-            ControlClick, Button2
-            WinWait, Steam, Steam has been installed
-            sleep 1000
-            ControlClick, Button4
-            sleep 1000
-            ControlClick, Button2
-            WinWaitClose
-            "
-    else
-            w_try "${WINE}" SteamSetup.exe
-    fi
+    w_try "${WINE}" SteamSetup.exe ${W_OPT_UNATTENDED:+ /S}
 
     # Not all users need this disabled, but let's play it safe for now
     if w_workaround_wine_bug 22053 "Disabling gameoverlayrenderer to prevent game crashes on some machines."; then


### PR DESCRIPTION
Apparently this switch has been around for a while, so we can be sure it's safe to remove the AHK script.