### PR TITLE
pdh_nt4: new verb

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -11466,6 +11466,37 @@ load_pdh()
     fi
 
     w_override_dlls native,builtin pdh
+    
+    # We just installed the latest version of pdh.dll and told winetricks that it was installed by logging it into winetricks.log.  If we want to be able to switch back and forth between the older (pdh_nt4) and the newer (pdh) pdh.dll's in the future, then we must tell winetricks to invalidate any log files of the version of pdh.dll that we just overwrote so that winetricks knows that that version is not installed anymore.
+    sed -i 's+\<pdh_nt4\>+_pdh_nt4+g' "${WINEPREFIX}/winetricks.log"
+}
+
+#----------------------------------------------------------------
+
+w_metadata pdh_nt4 dlls \
+    title="MS pdh.dll (Performance Data Helper); WinNT 4.0 Version" \
+    publisher="Microsoft" \
+    year="1997" \
+    media="download" \
+    file1="../pdh_nt4/nt4pdhdll.exe" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/pdh.dll"
+
+load_pdh_nt4()
+{
+    #w_download_to pdh_nt4 http://download.microsoft.com/download/winntsrv40/update/5.0.2195.2668/nt4/en-us/nt4pdhdll.exe a0a45ea8f4b82daaebcff7ad5bd1b7f5546e527e04790ca8c4c9b71b18c73e32
+    w_download_to pdhnt4 https://web.archive.org/web/20060826233132/http://download.microsoft.com/download/winntsrv40/update/5.0.2195.2668/nt4/en-us/nt4pdhdll.exe a0a45ea8f4b82daaebcff7ad5bd1b7f5546e527e04790ca8c4c9b71b18c73e32
+
+    w_try_unzip "${W_TMP}/${W_PACKAGE}" "${W_CACHE}/${W_PACKAGE}"/nt4pdhdll.exe
+    w_try cp "${W_TMP}/${W_PACKAGE}/pdh.dll" "${W_SYSTEM32_DLLS}/pdh.dll"
+
+    if [ "${W_ARCH}" = "win64" ]; then
+        echo "There is no 64-bit version of the WinNT 4.0 pdh.dll. Please either use a 32-bit wineprefix or try `winetricks pdh` instead."
+    fi
+
+    w_override_dlls native,builtin pdh
+    
+    # We just installed the older version of pdh.dll and told winetricks that it was installed by logging it into winetricks.log.  If we want to be able to switch back and forth between the older (pdh_nt4) and the newer (pdh) pdh.dll's in the future, then we must tell winetricks to invalidate any log files of the version of pdh.dll that we just overwrote so that winetricks knows that that version is not installed anymore.
+    sed -i 's+\<pdh\>+_pdh+g' "${WINEPREFIX}/winetricks.log"
 }
 
 #----------------------------------------------------------------


### PR DESCRIPTION
We discussed adding a verb to install the older WinNT 4.0 version of pdh.dll since it helps compatibility with some programs like VARA (part of Winlink / RMS Express).  I got the green light from austin987 to add it ( https://github.com/Winetricks/winetricks/issues/1579 ).  This is my first edit to winetricks, and I'm new to bash, so let me know if this implementation looks bad.