### PR TITLE
workaround SIP DYLD_ environment stripping

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -5353,6 +5353,12 @@ winetricks_init()
 
     winetricks_get_platform
 
+    # Workaround SIP DYLD_stripping
+    # See https://support.apple.com/en-us/HT204899
+    if [ -n "${WINETRICKS_FALLBACK_LIBRARY_PATH}" ]; then
+        export DYLD_FALLBACK_LIBRARY_PATH="${WINETRICKS_FALLBACK_LIBRARY_PATH}"
+    fi
+
     #---- Public Variables ----
 
     # Where application installers are cached


### PR DESCRIPTION
After the introduction of SIP (OS X 10.11) DYLD_ environment variables are stripped.

See https://support.apple.com/en-us/HT204899

<br>

As `winetricks` is launched from a system provided utility DYLD_ variables will be stripped leaving them empty. 

`DYLD_FALLBACK_LIBRARY_PATH` used to provide additional library paths.