### PR TITLE
w_verify_7z_available: new helper

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -901,6 +901,15 @@ w_read_key()
     unset _W_keyfile _W_keymsg _W_nokeymsg
 }
 
+w_verify_7z_available()
+{
+    # If verb_a requires verb_b, then verba will fail when the dependency for verb_b is installed
+    # This should be called by verb_a, to give a proper warning
+    if test ! -x "$(command -v 7z 2>/dev/null)"; then
+        w_die "Cannot find 7z.  Please install it (e.g. 'sudo apt-get install p7zip-full' or 'sudo yum install p7zip-plugins')."
+    fi
+}
+
 w_verify_cabextract_available()
 {
     # If verb_a requires verb_b, then verba will fail when the dependency for verb_b is installed


### PR DESCRIPTION
Calling w_try_7z when falling back to windows 7-zip wipes $W_TMP that can cause issues, where using a native version of 7z won't wipe $W_TMP this can come in handy.

Sending this before a new verb as I'm using this function, if not desirable I'll need to alter the verb in question to extract to $W_CACHE/W_PACKAGE and wipe once finished.