### PR TITLE
Solves Issue #1654 - Use kdialog instead of zenity in KDE Plasma, When Available

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -3520,21 +3520,39 @@ winetricks_early_wine_arch()
 
 winetricks_detect_gui()
 {
-    if test -x "$(command -v zenity 2>/dev/null)"; then
-        WINETRICKS_GUI=zenity
-        WINETRICKS_GUI_VERSION="$(zenity --version)"
-        WINETRICKS_MENU_HEIGHT=500
-        WINETRICKS_MENU_WIDTH=1010
-    elif test -x "$(command -v kdialog 2>/dev/null)"; then
-        echo "Zenity not found!  Using kdialog as poor substitute."
-        WINETRICKS_GUI=kdialog
-        WINETRICKS_GUI_VERSION="$(kdialog --version)"
-    else
-        echo "No arguments given, so tried to start GUI, but zenity not found."
-        echo "Please install zenity if you want a graphical interface, or "
-        echo "run with --help for more options."
-        exit 1
-    fi
+	if test "$XDG_CURRENT_DESKTOP" != "KDE"; then
+		if test -x "$(command -v zenity 2>/dev/null)"; then
+			WINETRICKS_GUI=zenity
+			WINETRICKS_GUI_VERSION="$(zenity --version)"
+			WINETRICKS_MENU_HEIGHT=500
+			WINETRICKS_MENU_WIDTH=1010
+		elif test -x "$(command -v kdialog 2>/dev/null)"; then
+			echo "Zenity not found!  Using kdialog as a substitute."
+			WINETRICKS_GUI=kdialog
+			WINETRICKS_GUI_VERSION="$(kdialog --version)"
+		else
+			echo "No arguments given, so tried to start GUI, but zenity or kdialog not found."
+			echo "Please install zenity or kdialog if you want a graphical interface, or "
+			echo "run with --help for more options."
+			exit 1
+		fi
+	elif test "$XDG_CURRENT_DESKTOP" == "KDE"; then
+		if test -x "$(command -v kdialog 2>/dev/null)"; then
+			echo "kdialog not found!  Using zenity as a substitute."
+			WINETRICKS_GUI=kdialog
+			WINETRICKS_GUI_VERSION="$(kdialog --version)"
+		elif test -x "$(command -v zenity 2>/dev/null)"; then
+			WINETRICKS_GUI=zenity
+			WINETRICKS_GUI_VERSION="$(zenity --version)"
+			WINETRICKS_MENU_HEIGHT=500
+			WINETRICKS_MENU_WIDTH=1010
+		else
+			echo "No arguments given, so tried to start GUI, but kdialog or zenity not found."
+			echo "Please install kdialog or zenity if you want a graphical interface, or "
+			echo "run with --help for more options."
+			exit 1
+		fi
+	fi
 
     # Print zenity/dialog version info for debugging:
     if [ -z "${WINETRICKS_SUPER_QUIET}" ] ; then

--- a/src/winetricks
+++ b/src/winetricks
@@ -3520,39 +3520,39 @@ winetricks_early_wine_arch()
 
 winetricks_detect_gui()
 {
-	if test "$XDG_CURRENT_DESKTOP" != "KDE"; then
-		if test -x "$(command -v zenity 2>/dev/null)"; then
-			WINETRICKS_GUI=zenity
-			WINETRICKS_GUI_VERSION="$(zenity --version)"
-			WINETRICKS_MENU_HEIGHT=500
-			WINETRICKS_MENU_WIDTH=1010
-		elif test -x "$(command -v kdialog 2>/dev/null)"; then
-			echo "Zenity not found!  Using kdialog as a substitute."
-			WINETRICKS_GUI=kdialog
-			WINETRICKS_GUI_VERSION="$(kdialog --version)"
-		else
-			echo "No arguments given, so tried to start GUI, but zenity or kdialog not found."
-			echo "Please install zenity or kdialog if you want a graphical interface, or "
-			echo "run with --help for more options."
-			exit 1
-		fi
-	elif test "$XDG_CURRENT_DESKTOP" == "KDE"; then
-		if test -x "$(command -v kdialog 2>/dev/null)"; then
-			echo "kdialog not found!  Using zenity as a substitute."
-			WINETRICKS_GUI=kdialog
-			WINETRICKS_GUI_VERSION="$(kdialog --version)"
-		elif test -x "$(command -v zenity 2>/dev/null)"; then
-			WINETRICKS_GUI=zenity
-			WINETRICKS_GUI_VERSION="$(zenity --version)"
-			WINETRICKS_MENU_HEIGHT=500
-			WINETRICKS_MENU_WIDTH=1010
-		else
-			echo "No arguments given, so tried to start GUI, but kdialog or zenity not found."
-			echo "Please install kdialog or zenity if you want a graphical interface, or "
-			echo "run with --help for more options."
-			exit 1
-		fi
-	fi
+    if test "$XDG_CURRENT_DESKTOP" != "KDE"; then
+        if test -x "$(command -v zenity 2>/dev/null)"; then
+            WINETRICKS_GUI=zenity
+            WINETRICKS_GUI_VERSION="$(zenity --version)"
+            WINETRICKS_MENU_HEIGHT=500
+            WINETRICKS_MENU_WIDTH=1010
+        elif test -x "$(command -v kdialog 2>/dev/null)"; then
+            echo "Zenity not found!  Using kdialog as a substitute."
+            WINETRICKS_GUI=kdialog
+            WINETRICKS_GUI_VERSION="$(kdialog --version)"
+        else
+            echo "No arguments given, so tried to start GUI, but zenity or kdialog not found."
+            echo "Please install zenity or kdialog if you want a graphical interface, or "
+            echo "run with --help for more options."
+            exit 1
+        fi
+    elif test "$XDG_CURRENT_DESKTOP" == "KDE"; then
+        if test -x "$(command -v kdialog 2>/dev/null)"; then
+            echo "kdialog not found!  Using zenity as a substitute."
+            WINETRICKS_GUI=kdialog
+            WINETRICKS_GUI_VERSION="$(kdialog --version)"
+        elif test -x "$(command -v zenity 2>/dev/null)"; then
+            WINETRICKS_GUI=zenity
+            WINETRICKS_GUI_VERSION="$(zenity --version)"
+            WINETRICKS_MENU_HEIGHT=500
+            WINETRICKS_MENU_WIDTH=1010
+        else
+            echo "No arguments given, so tried to start GUI, but kdialog or zenity not found."
+            echo "Please install kdialog or zenity if you want a graphical interface, or "
+            echo "run with --help for more options."
+            exit 1
+        fi
+    fi
 
     # Print zenity/dialog version info for debugging:
     if [ -z "${WINETRICKS_SUPER_QUIET}" ] ; then

--- a/src/winetricks
+++ b/src/winetricks
@@ -3520,7 +3520,7 @@ winetricks_early_wine_arch()
 
 winetricks_detect_gui()
 {
-    if test "$XDG_CURRENT_DESKTOP" != "KDE"; then
+    if test "${XDG_CURRENT_DESKTOP}" != "KDE"; then
         if test -x "$(command -v zenity 2>/dev/null)"; then
             WINETRICKS_GUI=zenity
             WINETRICKS_GUI_VERSION="$(zenity --version)"
@@ -3536,7 +3536,7 @@ winetricks_detect_gui()
             echo "run with --help for more options."
             exit 1
         fi
-    elif test "$XDG_CURRENT_DESKTOP" == "KDE"; then
+    elif test "${XDG_CURRENT_DESKTOP}" == "KDE"; then
         if test -x "$(command -v kdialog 2>/dev/null)"; then
             WINETRICKS_GUI=kdialog
             WINETRICKS_GUI_VERSION="$(kdialog --version)"

--- a/src/winetricks
+++ b/src/winetricks
@@ -3538,10 +3538,10 @@ winetricks_detect_gui()
         fi
     elif test "$XDG_CURRENT_DESKTOP" == "KDE"; then
         if test -x "$(command -v kdialog 2>/dev/null)"; then
-            echo "kdialog not found!  Using zenity as a substitute."
             WINETRICKS_GUI=kdialog
             WINETRICKS_GUI_VERSION="$(kdialog --version)"
         elif test -x "$(command -v zenity 2>/dev/null)"; then
+            echo "kdialog not found!  Using zenity as a substitute."
             WINETRICKS_GUI=zenity
             WINETRICKS_GUI_VERSION="$(zenity --version)"
             WINETRICKS_MENU_HEIGHT=500


### PR DESCRIPTION
Detects when KDE Plasma when currently running and checks if kdialog is installed first before zenity and , if available, chooses kdialog over zenity for desktop environment consistency.

Also stops calling alternatives a "poor substitute" and opts to call them "a substitute" instead.