### PR TITLE
Fix for 3539: test: KDE: unexpected operator

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -3536,7 +3536,7 @@ winetricks_detect_gui()
             echo "run with --help for more options."
             exit 1
         fi
-    elif test "${XDG_CURRENT_DESKTOP}" == "KDE"; then
+    elif test "${XDG_CURRENT_DESKTOP}" = "KDE"; then
         if test -x "$(command -v kdialog 2>/dev/null)"; then
             WINETRICKS_GUI=kdialog
             WINETRICKS_GUI_VERSION="$(kdialog --version)"


### PR DESCRIPTION
When using winetricks without any argument on KDE, this error happens:

```
------------------------------------------------------
warning: You are using a 64-bit WINEPREFIX. Note that many verbs only install 32-bit versions of packages. If you encounter problems, please retest in a clean 32-bit WINEPREFIX before reporting a bug.
------------------------------------------------------
Using winetricks 20210206-next - sha256sum: 9e9e998ff3412e991b36dc5d543edcffc83a16be88280b6d78ac67220d11ccb1 with wine-7.0 (Staging) and WINEARCH=win64
/usr/bin/winetricks: 3539: test: KDE: unexpected operator
winetricks GUI enabled, using none 
```

Because this is a simple fix, I am creating a pull request instead of an issue.