### PR TITLE
fix detection for --gui without args

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -3271,11 +3271,13 @@ winetricks_early_wine_arch()
 
 winetricks_detect_gui()
 {
-    if [ -n "$1" ]; then
-        if [ "$1" = "kdialog" ] && test -x "$(command -v kdialog 2>/dev/null)"; then
+    if [ "$1" != "--gui" ] ; then
+        if [ "$1" = "kdialog" ] ; then
+            test -x "$(command -v kdialog 2>/dev/null)" || w_die "--gui kdialog is forced, but kdialog command is missed."
             WINETRICKS_GUI=kdialog
             WINETRICKS_GUI_VERSION="$(kdialog --version)"
-        elif [ "$1" = "zenity" ] || [ "$1" = "--gui" ] && test -x "$(command -v zenity 2>/dev/null)"; then
+        elif [ "$1" = "zenity" ] ; then
+            test -x "$(command -v zenity 2>/dev/null)" || w_die "--gui zenity is forced, but zenity command is missed."
             WINETRICKS_GUI=zenity
             WINETRICKS_GUI_VERSION="$(zenity --version)"
             WINETRICKS_MENU_HEIGHT=500
@@ -23097,7 +23099,7 @@ if ! test "${WINETRICKS_LIB}"; then
             # GUI case
             # No non-option arguments given, so read them from GUI, and loop until user quits
             if [ ${WINETRICKS_GUI} = "none" ]; then
-                winetricks_detect_gui
+                winetricks_detect_gui --gui
             fi
             winetricks_detect_sudo
             test -z "${WINETRICKS_ISO_MOUNT}" && winetricks_detect_iso_mount


### PR DESCRIPTION
After last changes run with --gui without args can't detect kdialog. This fix restore correct behaviour.