### PR TITLE
Use tar --use-compress-program=unzstd to make it work on FreeBSD too.

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -8271,7 +8271,7 @@ helper_vkd3d_proton()
         w_try_unzip "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${_W_package_archive}"
     elif [ "${_W_package_archive##*.}" = "zst" ]; then
         w_try_cd "${W_TMP}"
-        w_try tar -I zstd -xvf "${W_CACHE}/${W_PACKAGE}/${_W_package_archive}"
+        w_try tar --use-compress-program=unzstd -xvf "${W_CACHE}/${W_PACKAGE}/${_W_package_archive}"
     else
         w_try_cd "${W_TMP}"
         w_try tar -zxf "${W_CACHE}/${W_PACKAGE}/${_W_package_archive}"


### PR DESCRIPTION
```
Executing cd /home/Alexander88207/.wine/dosdevices/c:/windows/temp
Executing tar -I zstd -xvf /home/Alexander88207/.cache/winetricks/vkd3d/vkd3d-proton-2.6.tar.zst
tar: Error inclusion pattern: Failed to open 'zstd'
```
with `--use-compress-program=unzstd` it works and afaik it should still work on linux too.