### PR TITLE
UPlay replaced by Ubisoft Connect

### DIFF
--- a/files/verbs/all.txt
+++ b/files/verbs/all.txt
@@ -46,7 +46,7 @@ qqintl                   QQ International Instant Messenger 2.11 (Tencent, 2014)
 safari                   Safari (Apple, 2010) [downloadable]
 sketchup                 SketchUp 8 (Google, 2012) [downloadable]
 steam                    Steam (Valve, 2010) [downloadable]
-uplay                    Uplay (Ubisoft, 2013) [downloadable]
+ubisoft                  Ubisoft Connect (Ubisoft, 2020) [downloadable]
 utorrent                 µTorrent 2.2.1 (BitTorrent, 2011)
 utorrent3                µTorrent 3.4 (BitTorrent, 2011) [downloadable]
 vc2005express            MS Visual C++ 2005 Express (Microsoft, 2005) [downloadable]

--- a/files/verbs/apps.txt
+++ b/files/verbs/apps.txt
@@ -45,7 +45,7 @@ qqintl                   QQ International Instant Messenger 2.11 (Tencent, 2014)
 safari                   Safari (Apple, 2010) [downloadable]
 sketchup                 SketchUp 8 (Google, 2012) [downloadable]
 steam                    Steam (Valve, 2010) [downloadable]
-uplay                    Uplay (Ubisoft, 2013) [downloadable]
+ubisoft                  Ubisoft Connect (Ubisoft, 2020) [downloadable]
 utorrent                 µTorrent 2.2.1 (BitTorrent, 2011)
 utorrent3                µTorrent 3.4 (BitTorrent, 2011) [downloadable]
 vc2005express            MS Visual C++ 2005 Express (Microsoft, 2005) [downloadable]

--- a/files/verbs/download.txt
+++ b/files/verbs/download.txt
@@ -357,10 +357,10 @@ tmnationsforever
 trebuchet
 trine_demo_steam
 trine_steam
+ubisoft
 uff
 unifont
 updspapi
-uplay
 urlmon
 usp10
 utorrent3

--- a/src/winetricks
+++ b/src/winetricks
@@ -16239,7 +16239,7 @@ w_metadata ubisoft apps \
     year="2020" \
     media="download" \
     file1="UbisoftConnectInstaller.exe" \
-    installed_exe1="${W_PROGRAMS_X86_WIN}/Ubisoft/Ubisoft Game Launcher/Uplay.exe"
+    installed_exe1="${W_PROGRAMS_X86_WIN}/Ubisoft/Ubisoft Game Launcher/UbisoftConnect.exe"
 
 load_ubisoft()
 {

--- a/src/winetricks
+++ b/src/winetricks
@@ -16233,22 +16233,22 @@ load_steam()
 
 #----------------------------------------------------------------
 
-w_metadata uplay apps \
-    title="Uplay" \
+w_metadata ubisoft apps \
+    title="Ubisoft Connect" \
     publisher="Ubisoft" \
-    year="2013" \
+    year="2020" \
     media="download" \
-    file1="UplayInstaller.exe" \
+    file1="UbisoftConnectInstaller.exe" \
     installed_exe1="${W_PROGRAMS_X86_WIN}/Ubisoft/Ubisoft Game Launcher/Uplay.exe"
 
-load_uplay()
+load_ubisoft()
 {
     # Changes too frequently, don't check anymore
-    w_download https://static3.cdn.ubi.com/orbit/launcher_installer/UplayInstaller.exe
+    w_download https://ubistatic3-a.akamaihd.net/orbit/launcher_installer/UbisoftConnectInstaller.exe
     w_try_cd "${W_CACHE}/${W_PACKAGE}"
 
     # NSIS installer
-    w_try "${WINE}" UplayInstaller.exe ${W_OPT_UNATTENDED:+ /S}
+    w_try "${WINE}" UbisoftConnectInstaller.exe ${W_OPT_UNATTENDED:+ /S}
 }
 
 #----------------------------------------------------------------


### PR DESCRIPTION
Hi,

in 2020 Uplay was replaced by Ubisoft connect.
I tried to exchange it once, it worked for me on it.
I hope it helps.