### PR TITLE
d3dcompiler_43: correct bug 24013

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -6147,7 +6147,7 @@ w_metadata d3dcompiler_43 dlls \
 
 load_d3dcompiler_43()
 {
-    if w_workaround_wine_bug 24013 "Native d3dcompiler_43 may cause some d3d10 apps to crash, see https://bugs.winehq.org/show_bug.cgi?id=24013" ,5.4; then
+    if w_workaround_wine_bug 24013 "Native d3dcompiler_43 may cause some d3d10 apps to crash, see https://bugs.winehq.org/show_bug.cgi?id=24013" 4.20,; then
         :
     fi
 


### PR DESCRIPTION
This was resolved in 4.20 Julliard only closed the bug out in 5.4.


Here's the output when this fix it applied.
```
Executing mkdir -p /Users/gcenx/Applications/Wineskin/Origin.app/Contents/SharedSupport
------------------------------------------------------
warning: You are using a 64-bit WINEPREFIX. Note that many verbs only install 32-bit versions of packages. If you encounter problems, please retest in a clean 32-bit WINEPREFIX before reporting a bug.
------------------------------------------------------
Using winetricks 20220411-next - sha256sum: f6d0b88306a3794d4a60cc9344504499aeaf39ad1dd589c8d3e77110e8963c50 with wine-6.0.2 (WineskinCX 21.2.0) and WINEARCH=win64
Executing w_do_call d3dcompiler_43
Executing mkdir -p /Users/gcenx/Applications/Wineskin/Origin.app/Contents/SharedSupport
------------------------------------------------------
warning: You are using a 64-bit WINEPREFIX. Note that many verbs only install 32-bit versions of packages. If you encounter problems, please retest in a clean 32-bit WINEPREFIX before reporting a bug.
------------------------------------------------------
Executing load_d3dcompiler_43 
Current Wine does not have Wine bug 24013, so not applying workaround
Executing cabextract -q -d /Users/gcenx/Applications/Wineskin/Origin.app/Contents/SharedSupport/prefix/dosdevices/c:/windows/temp -L -F *d3dcompiler_43*x86* /Users/gcenx/.cache/winetricks/directx9/directx_Jun2010_redist.exe
Executing cabextract -q -d /Users/gcenx/Applications/Wineskin/Origin.app/Contents/SharedSupport/prefix/dosdevices/c:/windows/syswow64 -L -F d3dcompiler_43.dll /Users/gcenx/Applications/Wineskin/Origin.app/Contents/SharedSupport/prefix/dosdevices/c:/windows/temp/jun2010_d3dcompiler_43_x86.cab
/Users/gcenx/Applications/Wineskin/Origin.app/Contents/SharedSupport/prefix/dosdevices/c:/windows/temp/jun2010_d3dcompiler_43_x86.cab: WARNING; possible 5960 extra bytes at end of file.
Executing cabextract -q -d /Users/gcenx/Applications/Wineskin/Origin.app/Contents/SharedSupport/prefix/dosdevices/c:/windows/temp -L -F *d3dcompiler_43*x64* /Users/gcenx/.cache/winetricks/directx9/directx_Jun2010_redist.exe
Executing cabextract -q -d /Users/gcenx/Applications/Wineskin/Origin.app/Contents/SharedSupport/prefix/dosdevices/c:/windows/system32 -L -F d3dcompiler_43.dll /Users/gcenx/Applications/Wineskin/Origin.app/Contents/SharedSupport/prefix/dosdevices/c:/windows/temp/jun2010_d3dcompiler_43_x64.cab
/Users/gcenx/Applications/Wineskin/Origin.app/Contents/SharedSupport/prefix/dosdevices/c:/windows/temp/jun2010_d3dcompiler_43_x64.cab: WARNING; possible 5960 extra bytes at end of file.
Using native override for following DLLs: d3dcompiler_43
Executing wine C:\windows\syswow64/regedit /S C:\windows\Temp\override-dll.reg
Executing wine64 C:\windows\system32/regedit /S C:\windows\Temp\override-dll.reg



 Winetricks Commands Finished!!
```