### PR TITLE
origin|originupdater: new verbs

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -16029,6 +16029,84 @@ load_openwatcom()
 
 #----------------------------------------------------------------
 
+w_metadata origin apps \
+    title="EA Origin" \
+    publisher="EA" \
+    year="2011" \
+    media="download" \
+    file1="OriginSetup.exe" \
+    installed_file1="${W_PROGRAMS_X86_WIN}/Origin/Origin.exe" \
+    homepage="https://www.origin.com/"
+
+helper_origin_dl()
+{
+    # Skipping checksum as this changes too often
+    w_download_to origin https://origin-a.akamaihd.net/Origin-Client-Download/origin/live/OriginSetup.exe
+}
+
+load_origin()
+{
+    # Need to force wine-6.0 as Origin doesn't run below WineCX21 (wine32on64)
+    if [ "$(uname -s)" = "Darwin" ] && w_wine_version_in ,6.0 ; then
+        w_die "${W_PACKAGE} requires wine version 6.0 (or newer)"
+    fi
+
+    if [ "${WINETRICKS_FORCE}" != 1 ] && w_workaround_wine_bug 44691 "Installer fails under wine, manually unpacking it instead" 6.7,; then
+        w_call originupdater
+        w_warn "${W_PACKAGE} might fail, to update use the originupdate verb"
+    else
+        helper_origin_dl
+        w_try_cd "${W_CACHE}/${W_PACKAGE}"
+        w_try "${WINE}" "${file1}" /NoLaunch ${W_OPT_UNATTENDED:+/SILENT}
+    fi
+
+    if w_workaround_wine_bug 32342 "QtWebEngineProcess.exe crashes when updating or launching Origin (missing fonts)"; then
+        w_call corefonts
+    fi
+
+    if w_workaround_wine_bug 44985 "Disabling libglesv2 to make Store and Library function correctly."; then
+        w_override_dlls disabled libglesv2
+    fi
+
+    # Origin requirements
+    w_call vcrun2010
+    w_call vcrun2019
+    w_call d3dcompiler_47
+
+    # Avoids "An unexpected error has occurred. Please try again in a few moments. Error: 327684:3"
+    # Games won't registor correctly unless disabled
+    w_override_app_dlls origin.exe disabled gameux
+}
+
+#----------------------------------------------------------------
+
+w_metadata originupdater apps \
+    title="EA Origin (updater)" \
+    publisher="EA" \
+    media="download" \
+    file1="../origin/OriginSetup.exe" \
+    homepage="https://www.origin.com/"
+
+load_originupdater()
+{
+    # Need to force wine-6.0 as Origin doesn't run below WineCX21 (wine32on64)
+    if [ "$(uname -s)" = "Darwin" ] && w_wine_version_in ,6.0 ; then
+        w_die "${W_PACKAGE} requires wine version 6.0 (or newer)"
+    fi
+
+    # Remove cached installer as the checksum changes too often that is even more critical for the updater function
+    w_try rm -f "${W_CACHE}/origin/OriginSetup.exe"
+
+    helper_origin_dl
+
+    w_try rm -rf "${W_PROGRAMS_X86_UNIX}"/Origin
+    w_try_7z "${W_CACHE}"/origin "${W_CACHE}"/origin/OriginSetup.exe update
+    w_try_7z "${W_PROGRAMS_X86_UNIX}"/Origin "${W_CACHE}"/origin/update/OriginUpdate_*_*_*_*.zip -aoa
+    w_try rm -rf "${W_CACHE}"/origin/update
+}
+
+#----------------------------------------------------------------
+
 w_metadata protectionid apps \
     title="Protection ID" \
     publisher="CDKiLLER & TippeX" \


### PR DESCRIPTION
The `origin` verb will install the Origin client and exit cleanly after install and can also be installed silently.

Darwin requirements need to be higher due to most being on more modern versions of macOS (10.15+) so forced to use a winecx variant where Origin _doesn't_ function until the more recent WineCX21.x based builds (Wine-6.0+) due to some missing thunks within `wine32on64` related functions

OriginSetup automatically installs the listed vcrun installers so added those to ensure they get registered correctly, `d3dcompiler_47` is used by the Origin client.

The override of `gameux` being set to disabled made games correctly register when left enabled games will goto 100% and then not show as playable without rebooting Origin where having this disabled makes games register without issue.

The `originupdated` verb is used to workaround Bugzilla `44691` by manually unpacking `OriginSetup.exe` and installing into place, this can also be used to force update the Origin client.