### PR TITLE
Wow64 tweaks

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -820,7 +820,7 @@ w_try_regedit64()
 
 w_try_regsvr()
 {
-    w_try "${WINE}" regsvr32 ${W_OPT_UNATTENDED:+/S} "$@"
+    w_try "${WINE}" "${W_SYSTEM64_DLLS_WIN32}/regsvr32" ${W_OPT_UNATTENDED:+/S} "$@"
 }
 
 w_try_regsvr64()

--- a/src/winetricks
+++ b/src/winetricks
@@ -803,7 +803,7 @@ w_try_regedit32()
     esac
 
     # shellcheck disable=SC2086
-    w_try "${WINE_MULTI}" ${cmdc} regedit ${W_OPT_UNATTENDED:+/S} "$@"
+    w_try "${WINE_MULTI}" ${cmdc} "${W_SYSTEM32_DLLS_WIN}/regedit" ${W_OPT_UNATTENDED:+/S} "$@"
 }
 
 w_try_regedit64()

--- a/src/winetricks
+++ b/src/winetricks
@@ -825,7 +825,7 @@ w_try_regsvr()
 
 w_try_regsvr64()
 {
-    w_try "${WINE64}" regsvr32 ${W_OPT_UNATTENDED:+/S} "$@"
+    w_try "${WINE64}" "${W_SYSTEM32_DLLS_WIN}/regsvr32" ${W_OPT_UNATTENDED:+/S} "$@"
 }
 
 w_try_unrar()

--- a/src/winetricks
+++ b/src/winetricks
@@ -815,7 +815,7 @@ w_try_regedit64()
     esac
 
     # shellcheck disable=SC2086
-    w_try "${WINE64}" ${cmdc} regedit ${W_OPT_UNATTENDED:+/S} "$@"
+    w_try "${WINE64}" ${cmdc} "${W_SYSTEM64_DLLS_WIN32}/regedit" ${W_OPT_UNATTENDED:+/S} "$@"
 }
 
 w_try_regsvr()


### PR DESCRIPTION
Upstreams wow64 system will use `wine64` for 32Bit binaries also, this is already being used within CrossOver-22.0.0