### PR TITLE
Steam Login UI black screen fix (reactlogin)

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -16492,6 +16492,15 @@ load_steam()
         w_warn "Steam needs to be launched with -noreactlogin"
     fi
 
+    if [ "$(uname -s)" = "Darwin" ] && w_workaround_wine_bug 49839 "Steamwebhelper.exe crashes when running Steam."; then
+        w_warn "Steam must be launched with -allosarches -cef-force-32bit -cef-in-process-gpu -no-cef-sandbox"
+    fi
+
+    # vulkandriverquery & vulkandriverquery64 crash a lot on macOS
+    if [ "$(uname -s)" = "Darwin" ]; then
+        w_call nocrashdialog
+    fi
+
     # Otherwise Steam Store and Library don't show
     w_call corefonts
 }

--- a/src/winetricks
+++ b/src/winetricks
@@ -16487,8 +16487,9 @@ load_steam()
         w_override_dlls disabled gameoverlayrenderer
     fi
 
-    if w_workaround_wine_bug 44985 "Disabling libglesv2 to make Store and Library function correctly."; then
+    if w_workaround_wine_bug 44985 "Disabling libglesv2 to make Store and Library function correctly." 7.0,; then
         w_override_dlls disabled libglesv2
+        w_warn "Steam needs to be launched with -noreactlogin"
     fi
 
     # Otherwise Steam Store and Library don't show


### PR DESCRIPTION
Steam Login UI when `libglesv2` is disabled

![Screenshot 2022-11-01 at 11 09 45 PM](https://user-images.githubusercontent.com/38226388/199514680-d515f3d5-4e95-424e-88ae-66e464dc4aae.png)

<br>

Steam Login UI when `libglesv2` isn't disabled

![Screenshot 2022-11-01 at 11 11 17 PM](https://user-images.githubusercontent.com/38226388/199514708-7f770615-17d0-48d7-9af1-35a949c6a7f5.png)

<br>

Tested this on;
- wine-7.0
- wine-7.19
- wine-crossover-22.0.1 (wine-7.7 with WoW64)

<br>

When using `-noreactlogin`

![Screenshot 2022-11-02 at 10 27 56 AM](https://user-images.githubusercontent.com/38226388/199515981-af0b41c1-58dd-42fa-a48a-92edd3a38c41.png)

<br>

<br>

Bug 49839 is macOS only, shows the needed launch commands on macOS.