### PR TITLE
steam: disable libglesv2 only for steamwebhelper.exe

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -16487,8 +16487,8 @@ load_steam()
         w_override_dlls disabled gameoverlayrenderer
     fi
 
-    if w_workaround_wine_bug 44985 "Disabling libglesv2 to make Store and Library function correctly." 7.0,; then
-        w_override_dlls disabled libglesv2
+    if w_workaround_wine_bug 44985 "Disabling libglesv2 to make Store and Library function correctly."; then
+        w_override_app_dlls steamwebhelper.exe disabled libglesv2
         w_warn "Steam needs to be launched with -noreactlogin"
     fi
 


### PR DESCRIPTION
Restore disabling `libglesv2` but make it targeted to `steamwebhelper.exe`, after expaneded testing across more wine/macOS versions sometimes this was required for the Libary/Store to not render black.