### PR TITLE
dxvk: Fix verb checking for files deprecated as of release 2.0

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -8312,7 +8312,7 @@ load_dxvk()
     _W_dxvk_version="$(w_get_github_latest_release doitsujin dxvk)"
     _W_dxvk_version="${_W_dxvk_version#v}"
     w_linkcheck_ignore=1 w_download "https://github.com/doitsujin/dxvk/releases/download/v${_W_dxvk_version}/dxvk-${_W_dxvk_version}.tar.gz"
-    helper_dxvk "dxvk-${_W_dxvk_version}.tar.gz" "5.14" "1.2.140" "dxgi,d3d9,d3d10core,d3d11"
+    helper_dxvk "dxvk-${_W_dxvk_version}.tar.gz" "7.1" "1.3.204" "dxgi,d3d9,d3d10core,d3d11"
     unset _W_dxvk_version
 }
 

--- a/src/winetricks
+++ b/src/winetricks
@@ -8302,11 +8302,9 @@ w_metadata dxvk dlls \
     year="2017" \
     media="download" \
     installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
-    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10.dll" \
-    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d10_1.dll" \
-    installed_file4="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
-    installed_file5="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
-    installed_file6="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d10core.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d11.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/dxgi.dll"
 
 load_dxvk()
 {
@@ -8314,7 +8312,7 @@ load_dxvk()
     _W_dxvk_version="$(w_get_github_latest_release doitsujin dxvk)"
     _W_dxvk_version="${_W_dxvk_version#v}"
     w_linkcheck_ignore=1 w_download "https://github.com/doitsujin/dxvk/releases/download/v${_W_dxvk_version}/dxvk-${_W_dxvk_version}.tar.gz"
-    helper_dxvk "dxvk-${_W_dxvk_version}.tar.gz" "5.14" "1.2.140" "dxgi,d3d9,d3d10core,d3d10,d3d11"
+    helper_dxvk "dxvk-${_W_dxvk_version}.tar.gz" "5.14" "1.2.140" "dxgi,d3d9,d3d10core,d3d11"
     unset _W_dxvk_version
 }
 


### PR DESCRIPTION
Remove deprecated files as of release 2.0

Tested on local machine
Changes compatible with verbs utilizing older dxvk versions

Fixes #1980 