### PR TITLE
tests/shell-checks: fix a bashate indentation issue

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -11338,7 +11338,7 @@ load_msmask()
     w_try_regsvr msmask32.ocx
 }
 
- #----------------------------------------------------------------
+#----------------------------------------------------------------
 
 w_metadata msftedit dlls \
     title="Microsoft RichEdit Control" \


### PR DESCRIPTION
src/winetricks:11341:1: E003 Indent not multiple of 4
