### PR TITLE
Correct typo for wmp11.exe in 32bit prefixes

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -17095,7 +17095,7 @@ load_wmp11()
 
         installer_exe=wmp11-windowsxp-x86-enu.exe
         wmf_exe=wmfdist11.exe
-        wmf_exe=wmp11.exe
+        wmp_exe=wmp11.exe
     elif [ "${W_ARCH}" = "win64" ]; then
         # https://appdb.winehq.org/objectManager.php?sClass=version&iId=32057
         w_download https://web.archive.org/web/20190512112704/https://download.microsoft.com/download/3/0/8/3080C52C-2517-43DE-BDB4-B7EAFD88F084/wmp11-windowsxp-x64-enu.exe 5af407cf336849aff435044ec28f066dd523bbdc22d1ce7aaddb5263084f5526


### PR DESCRIPTION
Installing WMP11 in a 32bit prefix will fail as is.