### PR TITLE
Add OpenAL support to winetricks.

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -11397,13 +11397,13 @@ w_metadata openal dlls \
     publisher="Creative" \
     year="2023" \
     media="download" \
-    file1="oalinst.zip" \
+    file1="https://www.openal.org/downloads/oalinst.zip" \
     installed_file1="${W_SYSTEM32_DLLS_WIN}/OpenAL32.dll"
 
 load_openal()
 {
     # Official version
-    w_download https://www.openal.org/downloads/${file1} d165bcb7628fd950d14847585468cc11943b2a1da92a59a839d397c68f9d4b06
+    w_download https://www.openal.org/downloads/oalinst.zip d165bcb7628fd950d14847585468cc11943b2a1da92a59a839d397c68f9d4b06
 
     w_try_unzip "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${file1}"
     w_try "${WINE}" "${W_TMP}/oalinst.exe" /silent

--- a/src/winetricks
+++ b/src/winetricks
@@ -11392,6 +11392,25 @@ load_oleaut32()
 
 #----------------------------------------------------------------
 
+w_metadata openal dlls \
+    title="OpenAL Runtime" \
+    publisher="Creative" \
+    year="2023" \
+    media="download" \
+    file1="oalinst.zip" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/OpenAL32.dll"
+
+load_openal()
+{
+    # Official version
+    w_download https://www.openal.org/downloads/${file1} d165bcb7628fd950d14847585468cc11943b2a1da92a59a839d397c68f9d4b06
+
+    w_try_unzip "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${file1}"
+    w_try "${WINE}" "${W_TMP}/oalinst.exe" /silent
+}
+
+#----------------------------------------------------------------
+
 w_metadata pdh dlls \
     title="MS pdh.dll (Performance Data Helper)" \
     publisher="Microsoft" \


### PR DESCRIPTION
WINE 7.21+ no longer includes openal as a built-in library[1]. This fixes issue #2011 

[1] https://gitlab.winehq.org/wine/wine/-/commit/45eca854c4fab7e864deebf9a51c74147884ebc8