### PR TITLE
zenity: Limit description length

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -12899,7 +12899,7 @@ load_mfc140()
 #----------------------------------------------------------------
 
 w_metadata vcrun2017 dlls \
-    title="Visual C++ 2017 libraries (concrt140.dll,mfc140.dll,mfc140u.dll,mfcm140.dll,mfcm140u.dll,msvcp140.dll,msvcp140_1.dll,msvcp140_2.dll,msvcp140_atomic_wait.dll,vcamp140.dll,vccorlib140.dll,vcomp140.dll,vcruntime140.dll,vcruntime140_1.dll)" \
+    title="Visual C++ 2015-2017 redistributable (VC2015 + msvcp140_2.dll)" \
     publisher="Microsoft" \
     year="2017" \
     media="download" \
@@ -12951,7 +12951,7 @@ load_vcrun2017()
 #----------------------------------------------------------------
 
 w_metadata vcrun2019 dlls \
-    title="Visual C++ 2015-2019 libraries (concrt140.dll,mfc140.dll,mfc140u.dll,mfcm140.dll,mfcm140u.dll,msvcp140.dll,msvcp140_1.dll,msvcp140_2.dll,msvcp140_atomic_wait.dll,msvcp140_codecvt_ids.dll,vcamp140.dll,vccorlib140.dll,vcomp140.dll,vcruntime140.dll,vcruntime140_1.dll" \
+    title="Visual C++ 2015-2019 libraries (VC2017 + msvcp140_codecvt_ids.dll)" \
     publisher="Microsoft" \
     year="2019" \
     media="download" \
@@ -13055,7 +13055,7 @@ load_ucrtbase2019()
 #----------------------------------------------------------------
 
 w_metadata vcrun2022 dlls \
-    title="Visual C++ 2015-2022 libraries (concrt140.dll,mfc140.dll,mfc140chs.dll,mfc140cht.dll,mfc140deu.dll,mfc140enu.dll,mfc140esn.dll,mfc140fra.dll,mfc140ita.dll,mfc140jpn.dll,mfc140kor.dll,mfc140rus.dll,mfc140u.dll,mfcm140.dll,mfcm140u.dll,msvcp140.dll,msvcp140_1.dll,msvcp140_2.dll,msvcp140_atomic_wait.dll,msvcp140_codecvt_ids.dll,vcamp140.dll,vccorlib140.dll,vcomp140.dll,vcruntime140.dll,vcruntime140_1.dll)" \
+    title="Visual C++ 2015-2022 libraries (VC2019 + mfc140chs.dll,mfc140cht.dll,mfc140deu.dll,mfc140enu.dll,mfc140esn.dll,mfc140fra.dll,mfc140ita.dll,mfc140jpn.dll,mfc140kor.dll,mfc140rus.dll)" \
     publisher="Microsoft" \
     year="2022" \
     media="download" \

--- a/src/winetricks
+++ b/src/winetricks
@@ -4034,7 +4034,8 @@ winetricks_showmenu()
                         echo "${code}" >> "${WINETRICKS_WORKDIR}"/installed.txt
                     fi
                     if [ "${#title}" -gt 100 ]; then
-                        title=$(printf "%s" "${title}" | head -c 90)
+                        # Small hysteresis of a few characters to not shorten descriptions that are close to the limit
+                        title=$(printf "%s" "${title}" | head -c 95)
                         title="${title} ..."
                     fi
                     printf %s " ${installed} \

--- a/src/winetricks
+++ b/src/winetricks
@@ -12899,7 +12899,7 @@ load_mfc140()
 #----------------------------------------------------------------
 
 w_metadata vcrun2017 dlls \
-    title="Visual C++ 2015-2017 redistributable (VC2015 + msvcp140_2.dll)" \
+    title="Visual C++ 2017 libraries (concrt140.dll,mfc140.dll,mfc140u.dll,mfcm140.dll,mfcm140u.dll,msvcp140.dll,msvcp140_1.dll,msvcp140_2.dll,msvcp140_atomic_wait.dll,vcamp140.dll,vccorlib140.dll,vcomp140.dll,vcruntime140.dll,vcruntime140_1.dll)" \
     publisher="Microsoft" \
     year="2017" \
     media="download" \
@@ -12951,7 +12951,7 @@ load_vcrun2017()
 #----------------------------------------------------------------
 
 w_metadata vcrun2019 dlls \
-    title="Visual C++ 2015-2019 libraries (VC2017 + msvcp140_codecvt_ids.dll)" \
+    title="Visual C++ 2015-2019 libraries (concrt140.dll,mfc140.dll,mfc140u.dll,mfcm140.dll,mfcm140u.dll,msvcp140.dll,msvcp140_1.dll,msvcp140_2.dll,msvcp140_atomic_wait.dll,msvcp140_codecvt_ids.dll,vcamp140.dll,vccorlib140.dll,vcomp140.dll,vcruntime140.dll,vcruntime140_1.dll" \
     publisher="Microsoft" \
     year="2019" \
     media="download" \
@@ -13055,7 +13055,7 @@ load_ucrtbase2019()
 #----------------------------------------------------------------
 
 w_metadata vcrun2022 dlls \
-    title="Visual C++ 2015-2022 libraries (VC2019 + mfc140chs.dll,mfc140cht.dll,mfc140deu.dll,mfc140enu.dll,mfc140esn.dll,mfc140fra.dll,mfc140ita.dll,mfc140jpn.dll,mfc140kor.dll,mfc140rus.dll)" \
+    title="Visual C++ 2015-2022 libraries (concrt140.dll,mfc140.dll,mfc140chs.dll,mfc140cht.dll,mfc140deu.dll,mfc140enu.dll,mfc140esn.dll,mfc140fra.dll,mfc140ita.dll,mfc140jpn.dll,mfc140kor.dll,mfc140rus.dll,mfc140u.dll,mfcm140.dll,mfcm140u.dll,msvcp140.dll,msvcp140_1.dll,msvcp140_2.dll,msvcp140_atomic_wait.dll,msvcp140_codecvt_ids.dll,vcamp140.dll,vccorlib140.dll,vcomp140.dll,vcruntime140.dll,vcruntime140_1.dll)" \
     publisher="Microsoft" \
     year="2022" \
     media="download" \

--- a/src/winetricks
+++ b/src/winetricks
@@ -4033,6 +4033,10 @@ winetricks_showmenu()
                         installed=TRUE
                         echo "${code}" >> "${WINETRICKS_WORKDIR}"/installed.txt
                     fi
+                    if [ "${#title}" -gt 100 ]; then
+                        title=$(printf "%s" "${title}" | head -c 90)
+                        title="${title} ..."
+                    fi
                     printf %s " ${installed} \
                         ${code} \
                         \"${title}\" \


### PR DESCRIPTION
The description column is too wide. This commit attempts to shorten it a bit.

The problem looks as follows:
![grafik](https://user-images.githubusercontent.com/1497498/216814386-8e99e10c-7eb9-44cc-94f5-78eed1d3499a.png)

With this PR the year and publisher columns will not appear but the description column is shorter now.