### PR TITLE
changing cabextract arguments due to its recent update

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -703,7 +703,11 @@ w_try_cabextract()
         w_die "Cannot find cabextract.  Please install it (e.g. 'sudo apt-get install cabextract' or 'sudo yum install cabextract')."
     fi
 
-    w_try cabextract -q --keep-symlinks "$@"
+    if cabextract -h 2>&1 | grep -q 'keep-symlinks'; then
+        w_try cabextract -q --keep-symlinks "$@"
+    else
+        w_try cabextract -q "$@"
+    fi
 }
 
 w_try_cd()

--- a/src/winetricks
+++ b/src/winetricks
@@ -703,7 +703,7 @@ w_try_cabextract()
         w_die "Cannot find cabextract.  Please install it (e.g. 'sudo apt-get install cabextract' or 'sudo yum install cabextract')."
     fi
 
-    w_try cabextract -q "$@"
+    w_try cabextract -q --keep-symlinks "$@"
 }
 
 w_try_cd()


### PR DESCRIPTION
`cabextract` has just been updated to 1.10 and breaks the installation of `riched20`, `gdiplus`, `quarks`, etc., see issue https://github.com/Winetricks/winetricks/issues/2023. Adding the `--keep-symlinks` argument can solve this problem. 