### PR TITLE
Fix w_store_winver when $WINE contains spaces

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -2401,7 +2401,7 @@ w_store_winver()
     # Only set if not set already; for cases where a verb changes the version multiple times
     # or calls a second verb that changes the version
     if [ -z "${_W_user_winver}" ]; then
-        _W_user_winver="$(${WINE} winecfg /v | tr -d '\r')"
+        _W_user_winver=$("${WINE}" winecfg /v | tr -d '\r')
     fi
 }
 


### PR DESCRIPTION
While at it, I tried to find and fix more issues with shellcheck... but the script gave no output; so I assume it's alright?

Tested and reproduced with the `dash` POSIX shell and `WINE="/path/with spaces/wine"`