### PR TITLE
Workaround missing /usr/bin/wine64.

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -5063,6 +5063,19 @@ winetricks_set_wineprefix()
         # Check the bitness of wineserver + wine binary, used later to determine if we're on a WOW setup (no wine64)
         # https://github.com/Winetricks/winetricks/issues/2030
         WINESERVER_BIN="$(which "${WINESERVER}")"
+
+        # wineboot often is a link pointing to wineapploader in Wine's bindir. If we don't find binaries we may look for them there later
+        if [ -n "${READLINK_F}" ]; then
+            true
+        elif [ "$(uname -s)" = "Darwin" ]; then
+            # readlink exists on MacOS, but does not support "-f" on MacOS < 12.3
+            # Use perl instead
+            READLINK_F="perl -MCwd=abs_path -le 'print abs_path readlink(shift);'"
+        else
+            READLINK_F="readlink -f"
+        fi
+        WINEBOOT_BIN="$(dirname "${WINESERVER_BIN}")/$(basename "${WINESERVER_BIN}"|sed 's,wineserver,wineboot,')"
+
         _W_wineserver_binary_arch="$(winetricks_get_file_arch "${WINESERVER_BIN}")"
         WINE_BIN="$(which "${WINE}")"
         _W_wine_binary_arch="$(winetricks_get_file_arch "${WINE_BIN}")"

--- a/src/winetricks
+++ b/src/winetricks
@@ -5102,10 +5102,18 @@ winetricks_set_wineprefix()
         elif command -v "${WINE}64" >/dev/null 2>&1; then
             WINE64="${WINE}64"
         else
-            # Handle case where wine binaries (or binary wrappers) have a suffix
-            WINE64="$(dirname "${WINE}")/"
-            [ "${WINE64}" = "./" ] && WINE64=""
-            WINE64="${WINE64}$(basename "${WINE}" | sed 's/^wine/wine64/')"
+            if [ -x "${WINEBOOT_BIN}" ]; then
+                WINE_BINDIR="$(dirname "$(${READLINK_F} "${WINEBOOT_BIN}" 2>/dev/null)" 2>/dev/null)"
+                if [ -x "${WINE_BINDIR}/wine64" ]; then
+                    # Workaround case where wine is in path, but wine64 is only in Wine's bindir
+                    WINE64="${WINE_BINDIR}/wine64"
+                fi
+            else
+                # Handle case where wine binaries (or binary wrappers) have a suffix
+                WINE64="$(dirname "${WINE}")/"
+                [ "${WINE64}" = "./" ] && WINE64=""
+                WINE64="${WINE64}$(basename "${WINE}" | sed 's/^wine/wine64/')"
+            fi
         fi
         WINE_ARCH="${WINE64}"
         WINE_MULTI="${WINE}"


### PR DESCRIPTION
Workaround case where wine and related binaries are in /usr/bin, but wine64 is only in Wine's bindir (as in Debian wine 8.0~repack-4). Use /usr/bin/wineboot (which is a symlink in Debian packaging) to figure out the bindir, because /usr/bin/wine is a wrapper script in Debian.

See discussion in https://bugs.debian.org/1031649.

I'm not sure if this already should be added in Winetricks, probably this depends on the next set of Debian Wine packages. For now I applied this patch in Debian.

Tested with the deb packages from Debian wine 8.0\~repack-2 and 8.0\~repack-4, and Winehq winehq-staging 8.2~bookworm-1.