### PR TITLE
Fix 'shell' and 'winecmd' commands

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -3618,7 +3618,7 @@ winetricks_mainmenu()
                     FALSE taskmgr     '${_W_msg_taskmgr}' \
                     FALSE explorer    '${_W_msg_explorer}' \
                     FALSE uninstaller '${_W_msg_uninstaller}' \
-                    FALSE cmd         '${_W_msg_winecmd}' \
+                    FALSE winecmd     '${_W_msg_winecmd}' \
                     FALSE shell       '${_W_msg_shell}' \
                     FALSE folder      '${_W_msg_folder}' \
                     FALSE annihilate  '${_W_msg_annihilate}' \
@@ -3642,7 +3642,7 @@ winetricks_mainmenu()
                     taskmgr     "${_W_msg_taskmgr}" off \
                     explorer    "${_W_msg_explorer}" off \
                     uninstaller "${_W_msg_uninstaller}" off \
-                    cmd         "${_W_msg_winecmd}" off \
+                    winecmd     "${_W_msg_winecmd}" off \
                     shell       "${_W_msg_shell}" off \
                     folder      "${_W_msg_folder}" off \
                     annihilate  "${_W_msg_annihilate}" off \

--- a/src/winetricks
+++ b/src/winetricks
@@ -23148,7 +23148,11 @@ winetricks_shell()
             *)
                 for term in gnome-terminal konsole Terminal xterm; do
                     if test "$(command -v ${term} 2>/dev/null)"; then
-                        WINEDEBUG=-all ${term} -e "${@}"
+                        if [ -n "${*}" ]; then
+                            WINEDEBUG=-all ${term} -e "${*}"
+                        else
+                            WINEDEBUG=-all ${term}
+                        fi
                         break
                     fi
                 done


### PR DESCRIPTION
Two small fixes to `winecmd` and `shell` commands:

* Do not use `-e` parameter when launching terminal emulator if no command
was provided. This is the case for `shell` verb, which does not provide
any predefined command and should just launch the terminal.
  In addition, pass the `-e` argument as one quoted string. Some terminal emulators only accept one value, while others consume all parameters following the option. Using a single string works with both.

* Fix `winecmd` launch. `winecmd` seems to be the intended command here. `cmd` only installed an
application of the same name without launching it.