### PR TITLE
galliumnine09: new verb

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -10107,6 +10107,7 @@ load_galliumnine02()
 {
     w_package_broken "https://bugs.winehq.org/show_bug.cgi?id=49676" 5.13
     w_package_broken "https://github.com/iXit/wine-nine-standalone/issues/83" 5.14
+    w_package_broken "https://github.com/iXit/wine-nine-standalone/issues/149" 8.3
 
     w_download "https://github.com/iXit/wine-nine-standalone/releases/download/v0.2/gallium-nine-standalone-v0.2.tar.gz" 6818fe890e343aa32d3d53179bfeb63df40977797bd7b6263e85e2bb57559313
     helper_galliumnine "${file1}"
@@ -10126,6 +10127,7 @@ load_galliumnine03()
 {
     w_package_broken "https://bugs.winehq.org/show_bug.cgi?id=49676" 5.13
     w_package_broken "https://github.com/iXit/wine-nine-standalone/issues/83" 5.14
+    w_package_broken "https://github.com/iXit/wine-nine-standalone/issues/149" 8.3
 
     w_download "https://github.com/iXit/wine-nine-standalone/releases/download/v0.3/gallium-nine-standalone-v0.3.tar.gz" 8bb564073ab2198e5b9b870f7b8cac8d9bc20bc6accf66c4c798e4b450ec0c91
     helper_galliumnine "${file1}"
@@ -10145,6 +10147,7 @@ load_galliumnine04()
 {
     w_package_broken "https://bugs.winehq.org/show_bug.cgi?id=49676" 5.13
     w_package_broken "https://github.com/iXit/wine-nine-standalone/issues/83" 5.14
+    w_package_broken "https://github.com/iXit/wine-nine-standalone/issues/149" 8.3
 
     w_download "https://github.com/iXit/wine-nine-standalone/releases/download/v0.4/gallium-nine-standalone-v0.4.tar.gz" 4423c32d46419830c8e68fea86d28e740f17f182c365250c379b5493176e19ab
     helper_galliumnine "${file1}"
@@ -10163,6 +10166,7 @@ w_metadata galliumnine05 dlls \
 load_galliumnine05()
 {
     w_package_broken "https://github.com/iXit/wine-nine-standalone/issues/83" 5.14
+    w_package_broken "https://github.com/iXit/wine-nine-standalone/issues/149" 8.3
 
     w_download "https://github.com/iXit/wine-nine-standalone/releases/download/v0.5/gallium-nine-standalone-v0.5.tar.gz" c46e06b13a3ba0adee75b27a8b54e9d772f83ed29dee5e203364460771fb1bcd
     helper_galliumnine "${file1}"
@@ -10180,6 +10184,8 @@ w_metadata galliumnine06 dlls \
 
 load_galliumnine06()
 {
+    w_package_broken "https://github.com/iXit/wine-nine-standalone/issues/149" 8.3
+
     w_download "https://github.com/iXit/wine-nine-standalone/releases/download/v0.6/gallium-nine-standalone-v0.6.tar.gz" 1a085b5175791414fdd513b5adb5682985917fef81e84f0116ef2b4d5295ad1c
     helper_galliumnine "${file1}"
 }
@@ -10196,6 +10202,8 @@ w_metadata galliumnine07 dlls \
 
 load_galliumnine07()
 {
+    w_package_broken "https://github.com/iXit/wine-nine-standalone/issues/149" 8.3
+
     w_download "https://github.com/iXit/wine-nine-standalone/releases/download/v0.7/gallium-nine-standalone-v0.7.tar.gz" e0b3005280119732d2ca48a5aa5aad27eaf08e6e1dd5598652744a04554a9475
     helper_galliumnine "${file1}"
 }
@@ -10212,6 +10220,8 @@ w_metadata galliumnine08 dlls \
 
 load_galliumnine08()
 {
+    w_package_broken "https://github.com/iXit/wine-nine-standalone/issues/149" 8.3
+
     w_download "https://github.com/iXit/wine-nine-standalone/releases/download/v0.8/gallium-nine-standalone-v0.8.tar.gz" 8d73dcf78e4b5edf7a3aea8c339459b5138acd1c957c91c5c06432cb2fc51893
     helper_galliumnine "${file1}"
 }

--- a/src/winetricks
+++ b/src/winetricks
@@ -10247,7 +10247,7 @@ load_galliumnine09()
 w_metadata galliumnine dlls \
     title="Gallium Nine Standalone (latest)" \
     publisher="Gallium Nine Team" \
-    year="2019" \
+    year="2023" \
     media="download" \
     installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9-nine.dll" \
     installed_file2="${W_SYSTEM32_DLLS_WIN}/ninewinecfg.exe" \
@@ -10255,6 +10255,11 @@ w_metadata galliumnine dlls \
 
 load_galliumnine()
 {
+    if w_wine_version_in ,5.7 ; then
+        w_call galliumnine08
+        return
+    fi
+
     _W_galliumnine_version="$(w_get_github_latest_release iXit wine-nine-standalone)"
     w_linkcheck_ignore=1 w_download "https://github.com/iXit/wine-nine-standalone/releases/download/${_W_galliumnine_version}/gallium-nine-standalone-${_W_galliumnine_version}.tar.gz"
     helper_galliumnine "gallium-nine-standalone-${_W_galliumnine_version}.tar.gz"

--- a/src/winetricks
+++ b/src/winetricks
@@ -10226,6 +10226,24 @@ load_galliumnine08()
     helper_galliumnine "${file1}"
 }
 
+w_metadata galliumnine09 dlls \
+    title="Gallium Nine Standalone (v0.9)" \
+    publisher="Gallium Nine Team" \
+    year="2023" \
+    media="download" \
+    file1="gallium-nine-standalone-v0.9.tar.gz" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d9-nine.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/ninewinecfg.exe" \
+    homepage="https://github.com/iXit/wine-nine-standalone"
+
+load_galliumnine09()
+{
+    w_package_broken "https://github.com/iXit/wine-nine-standalone/issues/149" "" 5.7
+
+    w_download "https://github.com/iXit/wine-nine-standalone/releases/download/v0.9/gallium-nine-standalone-v0.9.tar.gz" 0f6826e48cb979bc6d1fb85dbbb9da6025eb364af61f5ee8dbfd0058430778b1
+    helper_galliumnine "${file1}"
+}
+
 w_metadata galliumnine dlls \
     title="Gallium Nine Standalone (latest)" \
     publisher="Gallium Nine Team" \


### PR DESCRIPTION
The new version was released because of binary compatibility with wine v8.3.
Extend the current galliumnine verbs to handle the incompatible combinations.