### PR TITLE
d8vk: new verb

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -8439,8 +8439,23 @@ load_d8vk()
     # https://github.com/AlpyneDreams/d8vk
     _W_dxvk_version="$(w_get_github_latest_release AlpyneDreams d8vk)"
     w_linkcheck_ignore=1 w_download "https://github.com/AlpyneDreams/d8vk/releases/download/${_W_dxvk_version}/${_W_dxvk_version}.tar.gz"
-    helper_dxvk "${_W_dxvk_version}.tar.gz" "7.1" "1.3.204" "d3d8,d3d9" "AlpyneDreams/d8vk"  # Not completely sure on min Vulkan version
+    helper_dxvk "${_W_dxvk_version}.tar.gz" "7.1" "1.3.204" "d3d8,d3d9" "AlpyneDreams/d8vk"
     unset _W_dxvk_version
+}
+
+w_metadata d8vk0010 dlls \
+    title="Direct3D 8 to Vulkan translation for DXVK" \
+    publisher="Jeffery Ellison" \
+    year="2023" \
+    media="download" \
+    file1="d8vk-v0.10.tar.gz" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d8.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+
+load_d8vk0010()
+{
+    w_download "https://github.com/AlpyneDreams/d8vk/releases/download/d8vk-v0.10/d8vk-v0.10.tar.gz" 43e3d1051b31d91541fba1a6c59d0991208869203e66779bfab8a861eb545eb1
+    helper_dxvk "${file1}" "7.1" "1.3.204" "d3d8,d3d9" "AlpyneDreams/d8vk"
 }
 
 #----------------------------------------------------------------

--- a/src/winetricks
+++ b/src/winetricks
@@ -6919,7 +6919,7 @@ helper_dxvk()
         w_try mv "${W_TMP}/${_W_package_dir}/x32/${_W_dll}.dll" "${W_SYSTEM32_DLLS}/"
         [ "${_W_dll}" = "d3d9" ] && _W_d3d9_support="1"
     done
-    if test "${W_ARCH}" = "win64" && -d "${W_TMP}/${_W_package_dir}/x64"; then
+    if test "${W_ARCH}" = "win64" && test -d "${W_TMP}/${_W_package_dir}/x64"; then
         for _W_dll in ${_W_dll_overrides}; do
             w_try mv "${W_TMP}/${_W_package_dir}/x64/${_W_dll}.dll" "${W_SYSTEM64_DLLS}/"
         done

--- a/src/winetricks
+++ b/src/winetricks
@@ -6898,7 +6898,7 @@ helper_dxvk()
     _W_dll_overrides="$(echo "${_W_dll_overrides}" | sed 's/d3d10 /&d3d10_1 /')"
     _W_package_dir="${_W_package_archive%.tar.gz}"
     _W_package_version="${_W_package_dir#*-}"
-    w_warn "Please refer to ${_W_repository#*/} version ${_W_package_version} release notes... See: https://github.com/${_W_repository}/releases/tag/${_W_package_version}"  # TODO wrong url - d8vk release tags are d8vk-vX.X 
+    w_warn "Please refer to ${_W_repository#*/} version ${_W_package_version} release notes... See: https://github.com/${_W_repository}/releases/tag/${_W_package_version}"  # TODO wrong url - d8vk release tags are d8vk-vX.X
     w_warn "Please refer to current ${_W_repository#*/} base graphics driver requirements... See: https://github.com/${_W_repository}/wiki/Driver-support"
 
     if w_wine_version_in ",${_W_min_wine_version}" ; then

--- a/src/winetricks
+++ b/src/winetricks
@@ -6887,9 +6887,9 @@ helper_dxvk()
     _W_min_vulkan_version="${3}"
     _W_dll_overrides="$(echo "${4}" | sed 's/,/ /g')"
     # dxvk repository, for d3d9/d3d10/d3d11 support
-    _W_repository="doitsujin/dxvk"
+    _W_repository="${5:-doitsujin/dxvk}"
 
-    _W_supported_overrides="dxgi d3d9 d3d10core d3d10 d3d11"
+    _W_supported_overrides="dxgi d3d8 d3d9 d3d10core d3d10 d3d11"
     _W_invalid_overrides="$(echo "${_W_dll_overrides}" | awk -vvalid_overrides_regex="$(echo "${_W_supported_overrides}" | sed 's/ /|/g')" '{ gsub(valid_overrides_regex,""); sub("[ ]*",""); print $0 }')"
     if [ "${_W_invalid_overrides}" != "" ]; then
         w_die "parameter (4) unsupported dll override: '${_W_invalid_overrides}' ; supported dll overrides: ${_W_supported_overrides}"
@@ -6898,8 +6898,8 @@ helper_dxvk()
     _W_dll_overrides="$(echo "${_W_dll_overrides}" | sed 's/d3d10 /&d3d10_1 /')"
     _W_package_dir="${_W_package_archive%.tar.gz}"
     _W_package_version="${_W_package_dir#*-}"
-    w_warn "Please refer to ${_W_repository#*/} version ${_W_package_version} release notes... See: https://github.com/${_W_repository}/releases/tag/${_W_package_version}"
-    w_warn "Please refer to current dxvk base graphics driver requirements... See: https://github.com/doitsujin/dxvk/wiki/Driver-support"
+    w_warn "Please refer to ${_W_repository#*/} version ${_W_package_version} release notes... See: https://github.com/${_W_repository}/releases/tag/${_W_package_version}"  # TODO wrong url - d8vk release tags are d8vk-vX.X 
+    w_warn "Please refer to current ${_W_repository#*/} base graphics driver requirements... See: https://github.com/${_W_repository}/wiki/Driver-support"
 
     if w_wine_version_in ",${_W_min_wine_version}" ; then
         # shellcheck disable=SC2140
@@ -6912,14 +6912,14 @@ helper_dxvk()
         w_try_unzip "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${_W_package_archive}"
     else
         w_try_cd "${W_TMP}"
-        w_try tar -zxf "${W_CACHE}/${W_PACKAGE}/${_W_package_archive}"
+        w_try tar -zxf "${W_CACHE}/${W_PACKAGE}/${_W_package_archive}" --one-top-level
     fi
 
     for _W_dll in ${_W_dll_overrides}; do
         w_try mv "${W_TMP}/${_W_package_dir}/x32/${_W_dll}.dll" "${W_SYSTEM32_DLLS}/"
         [ "${_W_dll}" = "d3d9" ] && _W_d3d9_support="1"
     done
-    if test "${W_ARCH}" = "win64"; then
+    if test "${W_ARCH}" = "win64" && -d "${W_TMP}/${_W_package_dir}/x64"; then
         for _W_dll in ${_W_dll_overrides}; do
             w_try mv "${W_TMP}/${_W_package_dir}/x64/${_W_dll}.dll" "${W_SYSTEM64_DLLS}/"
         done
@@ -8198,6 +8198,25 @@ load_dxvk()
     _W_dxvk_version="${_W_dxvk_version#v}"
     w_linkcheck_ignore=1 w_download "https://github.com/doitsujin/dxvk/releases/download/v${_W_dxvk_version}/dxvk-${_W_dxvk_version}.tar.gz"
     helper_dxvk "dxvk-${_W_dxvk_version}.tar.gz" "7.1" "1.3.204" "dxgi,d3d9,d3d10core,d3d11"
+    unset _W_dxvk_version
+}
+
+#----------------------------------------------------------------
+
+w_metadata d8vk dlls \
+    title="Direct3D 8 to Vulkan translation for DXVK" \
+    publisher="Jeffery Ellison" \
+    year="2023" \
+    media="download" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/d3d8.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+
+load_d8vk()
+{
+    # https://github.com/AlpyneDreams/d8vk
+    _W_dxvk_version="$(w_get_github_latest_release AlpyneDreams d8vk)"
+    w_linkcheck_ignore=1 w_download "https://github.com/AlpyneDreams/d8vk/releases/download/${_W_dxvk_version}/${_W_dxvk_version}.tar.gz"
+    helper_dxvk "${_W_dxvk_version}.tar.gz" "7.1" "1.3.204" "d3d8,d3d9" "AlpyneDreams/d8vk"  # Not completely sure on min Vulkan version
     unset _W_dxvk_version
 }
 

--- a/src/winetricks
+++ b/src/winetricks
@@ -7055,7 +7055,7 @@ helper_dxvk()
 
     _W_dll_overrides="$(echo "${_W_dll_overrides}" | sed 's/d3d10 /&d3d10_1 /')"
     _W_package_dir="${_W_package_archive%.tar.gz}"
-    _W_package_version="v${_W_package_dir#*-}"
+    _W_package_version="${_W_package_dir#*-}"
     w_warn "Please refer to ${_W_repository#*/} version ${_W_package_version} release notes... See: https://github.com/${_W_repository}/releases/tag/v${_W_package_version}"  # TODO wrong url - d8vk release tags are d8vk-vX.X
     w_warn "Please refer to current ${_W_repository#*/} base graphics driver requirements... See: https://github.com/${_W_repository}/wiki/Driver-support"
 
@@ -7069,7 +7069,9 @@ helper_dxvk()
     if [ "${_W_package_archive##*.}" = "zip" ]; then
         w_try_unzip "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${_W_package_archive}"
     else
-        w_try tar -C "${W_TMP}" -zxf "${W_CACHE}/${W_PACKAGE}/${_W_package_archive}"
+        w_try_cd "${W_TMP}"
+        w_try_mkdir "${_W_package_dir}"
+        w_try tar -zxf "${W_CACHE}/${W_PACKAGE}/${_W_package_archive}" -C "${_W_package_dir}"
     fi
 
     for _W_dll in ${_W_dll_overrides}; do

--- a/src/winetricks
+++ b/src/winetricks
@@ -6912,7 +6912,8 @@ helper_dxvk()
         w_try_unzip "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${_W_package_archive}"
     else
         w_try_cd "${W_TMP}"
-        w_try tar -zxf "${W_CACHE}/${W_PACKAGE}/${_W_package_archive}" --one-top-level
+        w_try_mkdir "${_W_package_dir}"
+        w_try tar -zxf "${W_CACHE}/${W_PACKAGE}/${_W_package_archive}" -C "${_W_package_dir}"
     fi
 
     for _W_dll in ${_W_dll_overrides}; do

--- a/src/winetricks
+++ b/src/winetricks
@@ -7056,8 +7056,8 @@ helper_dxvk()
     _W_dll_overrides="$(echo "${_W_dll_overrides}" | sed 's/d3d10 /&d3d10_1 /')"
     _W_package_dir="${_W_package_archive%.tar.gz}"
     _W_package_version="v${_W_package_dir#*-}"
-    w_warn "Please refer to ${_W_repository#*/} version ${_W_package_version} release notes... See: https://github.com/${_W_repository}/releases/tag/${_W_package_version}"
-    w_warn "Please refer to current dxvk base graphics driver requirements... See: https://github.com/${_W_repository}/wiki/Driver-support"
+    w_warn "Please refer to ${_W_repository#*/} version ${_W_package_version} release notes... See: https://github.com/${_W_repository}/releases/tag/v${_W_package_version}"  # TODO wrong url - d8vk release tags are d8vk-vX.X
+    w_warn "Please refer to current ${_W_repository#*/} base graphics driver requirements... See: https://github.com/${_W_repository}/wiki/Driver-support"
 
     if w_wine_version_in ",${_W_min_wine_version}" ; then
         # shellcheck disable=SC2140
@@ -8419,8 +8419,10 @@ w_metadata dxvk_nvapi0061 dlls \
 load_dxvk_nvapi0061()
 {
     w_download "https://github.com/jp7677/dxvk-nvapi/releases/download/v0.6.1/dxvk-nvapi-v0.6.1.tar.gz" c05196dd1ba10522e23ae8e30fec9c7e8ce624467558b1b3000499bf5b3d83aa
-    helper_dxvk "${file1}" "7.1" "nvapi,nvapi64"
+    helper_dxvk_nvapi "${file1}" "7.1" "nvapi,nvapi64"
 }
+
+#----------------------------------------------------------------
 
 w_metadata d8vk dlls \
     title="Direct3D 8 to Vulkan translation for DXVK" \


### PR DESCRIPTION
Adds d8vk verb as requested in #2004.

Tested with Touhou 6 via Lutris, MangoHud showed the renderer changed from WINED3D to DXVK. The selection of D3D8 games I can test with is somewhat limited it seems so further testing is of course welcome.

This PR touches `helper_dxvk`, I was specifically concerned with the changes to the `tar` command which now uses `--one-top-level`, so I tested installing regular `dxvk` and it seemed to work fine. This extra flag is required because DXVK archives have a root folder in the archive, but D8VK does not.

One outstanding issue is with the URL in `helper_dxvk` that points to the release notes; this URL is incorrect for D8VK. This is because DXVK release tags are just the version, e.g. `v2.1`, but D8VK is `d8vk-vX.X`. The `_W_package_version` needs to be set differently and I wasn't sure of the best approach to take with this.

First time contribution and first time even looking at Winetricks code so any and all feedback is very welcome :-)

Thanks!