### PR TITLE
Fix DXVK install

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -8354,7 +8354,7 @@ load_dxvk()
 {
     # https://github.com/doitsujin/dxvk
     _W_dxvk_version="$(w_get_github_latest_release doitsujin dxvk)"
-    _W_dxvk_version="${_W_dxvk_version#v}"
+    _W_dxvk_version="${_W_dxvk_version#?}"
     w_linkcheck_ignore=1 w_download "https://github.com/doitsujin/dxvk/releases/download/v${_W_dxvk_version}/dxvk-${_W_dxvk_version}.tar.gz"
     helper_dxvk "dxvk-${_W_dxvk_version}.tar.gz" "7.1" "1.3.204" "dxgi,d3d9,d3d10core,d3d11"
     unset _W_dxvk_version


### PR DESCRIPTION
Now the dxvk.tar.gz can be downloaded from GitHub