### PR TITLE
Add name to workflows and update checkout version

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,11 +1,12 @@
 on: [push, pull_request]
+name: install
 jobs:
   macos:
     name: make install (with prefix)
     runs-on: macos-latest
     steps:
       - name: checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # OSX doesn't allow writing to /usr/bin, so skip the non-PREFIX check
       - name: run make install (with PREFIX)
         run: time make install PREFIX="$(mktemp -d)"
@@ -14,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: run make install (with PREFIX)
         run: time make install PREFIX="$(mktemp -d)"
       - name: run make install (without PREFIX)

--- a/.github/workflows/shell-checks.yml
+++ b/.github/workflows/shell-checks.yml
@@ -1,10 +1,11 @@
 on: [push, pull_request]
+name: shellcheck
 jobs:
   shellcheck:
     name: shellcheck
     runs-on: ubuntu-latest
     steps:
       - name: checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: run shell-checks
         run: sudo apt-get -y install shellcheck python3-bashate && time ./tests/shell-checks

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,4 +1,5 @@
 on: [push, pull_request]
+name: Update
 jobs:
   update:
     name: self-update-test
@@ -8,6 +9,6 @@ jobs:
         os: [macos-latest, ubuntu-latest]
     steps:
       - name: checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: run self-update-test
         run: ./tests/self-update-test


### PR DESCRIPTION
- Add a name to the workflows, so GitHub does not just show the file.
- update the actions/checkout version from v2 to v3 so the actions warning goes away