### PR TITLE
Add Textractor 5.2.0 Verb

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -16773,6 +16773,22 @@ load_steam()
 
 #----------------------------------------------------------------
 
+w_metadata textractor520 apps \
+    title="Textractor 5.2.0" \
+    publisher="Akash Mozumdar" \
+    year="2022" \
+    media="manual_download" \
+    file1="Textractor-5.2.0-Setup.exe"
+
+load_textractor520()
+{
+    w_download "https://github.com/artikash/textractor/releases/download/v5.2.0/Textractor-5.2.0-Setup.exe"
+    w_try_cd "${W_CACHE}/${W_PACKAGE}"
+    w_try "${WINE}" "${file1}"
+}
+
+#----------------------------------------------------------------
+
 w_metadata ubisoftconnect apps \
     title="Ubisoft Connect" \
     publisher="Ubisoft" \


### PR DESCRIPTION
Textractor is an application that extracts text into a copyable format from visual novels by injecting hooks. 5.2.0 is likely to be the last version of Textractor.

This works, but the user needs to go through the install wizard.

Some notes:

* Textractor installs into `drive_c/users/$USERNAME/Desktop/Textractor` by default.
* I'm not sure how to automate this install. Do I need to use AutoHotKey and `W_OPT_UNATTENDED`? You need to click 4 buttons to install it.
* The verb definition originally contained this metadata, but it prevented the verb from attempting a download, and I'm not sure why:

```
    installed_exe1="${WINEPREFIX}/drive_c/users/${USERNAME}/Desktop/Textractor/x86/Textractor.exe" \
    installed_exe2="${WINEPREFIX}/drive_c/users/${USERNAME}/Desktop/Textractor/x86/TextractorCLI.exe" \
    installed_exe3="${WINEPREFIX}/drive_c/users/${USERNAME}/Desktop/Textractor/x64/Textractor.exe" \
    installed_exe4="${WINEPREFIX}/drive_c/users/${USERNAME}/Desktop/Textractor/x64/TextractorCLI.exe"
```