### PR TITLE
Fix remove_mono breaks dotnet40 on subsequent dotnet* installs

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -18758,18 +18758,15 @@ load_remove_mono()
         for uuid in ${mono_uuid}; do
             "${WINE_ARCH}" uninstaller --remove "${uuid}"
         done
+        "${WINE_ARCH}" reg delete "HKLM\\Software\\Microsoft\\NET Framework Setup\\NDP\\v3.5" /f || true
+        "${WINE_ARCH}" reg delete "HKLM\\Software\\Microsoft\\NET Framework Setup\\NDP\\v4" /f || true
+
+        w_try rm -f "${W_WINDIR_UNIX}/system32/mscoree.dll"
+        if [ "${W_ARCH}" = "win64" ]; then
+            w_try rm -f "${W_WINDIR_UNIX}/syswow64/mscoree.dll"
+        fi
     elif [ -z "$1" ] || [ "$1" != "internal" ]; then
-        # Bail out if mono isn't installed, so we don't break .Net setups
         w_warn "Mono does not appear to be installed."
-        return
-    fi
-
-    "${WINE_ARCH}" reg delete "HKLM\\Software\\Microsoft\\NET Framework Setup\\NDP\\v3.5" /f || true
-    "${WINE_ARCH}" reg delete "HKLM\\Software\\Microsoft\\NET Framework Setup\\NDP\\v4" /f || true
-
-    w_try rm -f "${W_WINDIR_UNIX}/system32/mscoree.dll"
-    if [ "${W_ARCH}" = "win64" ]; then
-        w_try rm -f "${W_WINDIR_UNIX}/syswow64/mscoree.dll"
     fi
 }
 

--- a/src/winetricks
+++ b/src/winetricks
@@ -18761,8 +18761,10 @@ load_remove_mono()
         "${WINE_ARCH}" reg delete "HKLM\\Software\\Microsoft\\NET Framework Setup\\NDP\\v3.5" /f || true
         "${WINE_ARCH}" reg delete "HKLM\\Software\\Microsoft\\NET Framework Setup\\NDP\\v4" /f || true
 
-        w_try rm -f "${W_WINDIR_UNIX}/system32/mscoree.dll"
-        if [ "${W_ARCH}" = "win64" ]; then
+        if grep --quiet --text "WINE_MONO_OVERRIDES" ${W_WINDIR_UNIX}/system32/mscoree.dll; then
+            w_try rm -f "${W_WINDIR_UNIX}/system32/mscoree.dll"
+        fi
+        if grep --quiet --text "WINE_MONO_OVERRIDES" ${W_WINDIR_UNIX}/syswow64/mscoree.dll; then
             w_try rm -f "${W_WINDIR_UNIX}/syswow64/mscoree.dll"
         fi
     elif [ -z "$1" ] || [ "$1" != "internal" ]; then

--- a/src/winetricks
+++ b/src/winetricks
@@ -18761,10 +18761,10 @@ load_remove_mono()
         "${WINE_ARCH}" reg delete "HKLM\\Software\\Microsoft\\NET Framework Setup\\NDP\\v3.5" /f || true
         "${WINE_ARCH}" reg delete "HKLM\\Software\\Microsoft\\NET Framework Setup\\NDP\\v4" /f || true
 
-        if grep --quiet --text "WINE_MONO_OVERRIDES" ${W_WINDIR_UNIX}/system32/mscoree.dll; then
+        if grep --quiet --text "WINE_MONO_OVERRIDES" "${W_WINDIR_UNIX}/system32/mscoree.dll"; then
             w_try rm -f "${W_WINDIR_UNIX}/system32/mscoree.dll"
         fi
-        if grep --quiet --text "WINE_MONO_OVERRIDES" ${W_WINDIR_UNIX}/syswow64/mscoree.dll; then
+        if grep --quiet --text "WINE_MONO_OVERRIDES" "${W_WINDIR_UNIX}/syswow64/mscoree.dll"; then
             w_try rm -f "${W_WINDIR_UNIX}/syswow64/mscoree.dll"
         fi
     elif [ -z "$1" ] || [ "$1" != "internal" ]; then


### PR DESCRIPTION
We should not be removing mscoree.dll in all dotnet* installs because it could have been placed by the dotnet40 verb, which would cause subsequent dotnet* verbs to break dotnet40. The deletion should instead only happen when the native dotnet is detected. We continue to remove the registry keys in any case, though, since they are only relevant to the native DLL.

Closes #2072