### PR TITLE
icodevs: override ir50_32 as native,builtin before trying to regsvr it

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -10820,7 +10820,8 @@ load_icodecs()
     # Work around bug in codec's installer?
     # https://support.britannica.com/other/touchthesky/win/issues/TSTUw_150.htm
     # https://appdb.winehq.org/objectManager.php?sClass=version&iId=7091
-    w_try_regsvr ir50_32.dll
+    w_override_dlls native,builtin ir50_32
+    w_try_regsvr ir50_32
 
     # Apparently some codecs are missing, see https://github.com/Winetricks/winetricks/issues/302
     # Download at https://www.moviecodec.com/download-codec-packs/indeo-codecs-legacy-package-31/


### PR DESCRIPTION
Fixes #2103 