### PR TITLE
Make curl not swallow errors

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -1565,6 +1565,7 @@ w_download_to()
                 -L \
                 -o "${_W_file}" \
                 -C - \
+                --fail \
                 --retry "${WINETRICKS_DOWNLOADER_RETRIES}" \
                 ${_W_cookiejar:+--cookie "${_W_cookiejar}"} \
                 ${_W_agent:+--user-agent "${_W_agent}"} \


### PR DESCRIPTION
By default, curl doesn't handle 4xx and 5xx specially, it will just download the body of the error response. The `--fail` parameter is necessary to make it exit with a nonzero status code so download errors don't get silently swallowed.