### PR TITLE
Improve compatibility with wget2 (mostly for web.archive.org URLs)

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -1551,6 +1551,7 @@ w_download_to()
                 --retry-connrefused \
                 --timeout "${WINETRICKS_DOWNLOADER_TIMEOUT}" \
                 --tries "${WINETRICKS_DOWNLOADER_RETRIES}" \
+                --header "Accept: */*" \
                 ${_W_cookiejar:+--load-cookies "${_W_cookiejar}"} \
                 ${_W_agent:+--user-agent="${_W_agent}"} \
                 "${_W_url}"


### PR DESCRIPTION
When using [wget2](https://gitlab.com/gnuwget/wget2) in place of wget 1.x (which I don't think is a good idea in the first place because the compatibility is not 100%, but let's assume our software choices have led us to this timeline anyway), web.archive.org URLs don't download as expected because apparently wget2 sends an HTTP Accept header that the site interprets to not send the file but instead send some HTML referencing the file. This causes an issue in the Lutris Flatpak when using fallback archive.org URLs because the Flatpak runtime includes wget2: https://github.com/flathub/net.lutris.Lutris/issues/365#issuecomment-1741590369.

The suggestion was to explicitly set the Accept header to accept any content type instead of preferring HTML (https://gitlab.com/gnuwget/wget2/-/issues/646#note_1584888546). I've checked that this both fixes the issue with wget2 for these URLs and that the parameter also works with wget 1.x. Hopefully this is effectively a no-op change with wget 1.x because it already defaults to this behaviour. It seems like it should be fine, but I've only tested it with the problematic archive.org URLs so unfortunately I can't promise that this change won't break other sites.