### PR TITLE
Ensure `winetricks_get_file_arch` gets full paths

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -5053,8 +5053,10 @@ winetricks_set_wineprefix()
     if test -d "${W_DRIVE_C}/windows/syswow64"; then
         # Check the bitness of wineserver + wine binary, used later to determine if we're on a WOW setup (no wine64)
         # https://github.com/Winetricks/winetricks/issues/2030
-        _W_wineserver_binary_arch="$(winetricks_get_file_arch "${WINESERVER}")"
-        _W_wine_binary_arch="$(winetricks_get_file_arch "${WINE}")"
+        WINESERVER_BIN="$(which ${WINESERVER})"
+        _W_wineserver_binary_arch="$(winetricks_get_file_arch "${WINESERVER_BIN}")"
+        WINE_BIN="$(which ${WINE})"
+        _W_wine_binary_arch="$(winetricks_get_file_arch "${WINE_BIN}")"
 
         # determine wow64 type (new/old)
         # FIXME: check what upstream is calling them


### PR DESCRIPTION
`od` needs the actual path to the binary. This PR fixes #2143.