### PR TITLE
Determine if there is an internet connection first using getent befor…

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -2950,10 +2950,26 @@ _EOF_
 
 #---- Private Functions ----
 
+export INTERNET="no"
+internet_check() {
+  hasinternet=$(getent hosts cloudflare.com)
+  # Check for internet connection
+  if [ "${hasinternet}" != '' ]; then
+    export INTERNET="yes"
+  fi
+}
+
 # Determines downloader to use, etc.
 # I.e., things common to w_download_to(), winetricks_download_to_stdout(), and winetricks_stats_report())
 winetricks_download_setup()
 {
+    if [ "${INTERNET}" = "no" ] ; then
+        internet_check
+        if [ "${INTERNET}" = "no" ] ; then
+            w_die "No internet connection found, aborting download attempt."
+        fi
+    fi
+
     # shellcheck disable=SC2104
     case "${WINETRICKS_DOWNLOADER}" in
         aria2c|curl|wget|fetch) : ;;


### PR DESCRIPTION
…e attempting to download anything.

This method uses getent which is part of glibc, a pretty much hard requirement for any linux system.

Since winetricks is capable of both downloading and installing software as well as performing library overrides or registry edits, this is useful when you run a script that performs multiple winetricks with a mixture of all types (such as a lutris install script or protontricks) and don't have an internet connection. This way anything that does not require an internet connection is not forced to wait on those that do to fail before continuing.