### PR TITLE
7zip in w_try_unzip needs -y flag to autoconfirm

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -705,7 +705,7 @@ w_try_7z()
         w_try_cd "${PWD}"
 
         # errors out if there is a space between -o and path
-        w_try "${WINE}" "${W_PROGRAMS_X86_WIN}\\7-Zip\\7z.exe" x "$(w_pathconv -w "${filename}")" -o"$(w_pathconv -w "${destdir}")" "$@"
+        w_try "${WINE}" "${W_PROGRAMS_X86_WIN}\\7-Zip\\7z.exe" x "$(w_pathconv -w "${filename}")" -y -o"$(w_pathconv -w "${destdir}")" "$@"
     fi
 }
 


### PR DESCRIPTION
Otherwise it fails due to not receiving a response:

Would you like to replace the existing file:
  Path:     C:\windows\syswow64\ddraw.dll
  Size:     1053865 bytes (1030 KiB)
  Modified: 2024-01-28 17:55:30
with the file from archive:
  Path:     ddraw.dll
  Size:     316928 bytes (310 KiB)
  Modified: 2023-01-16 21:18:30
? (Y)es / (N)o / (A)lways / (S)kip all / A(u)to rename all / (Q)uit?
Archives with Errors: 1