### PR TITLE
minor update to win64 warning messages to support toggling via env var

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -5123,19 +5123,24 @@ winetricks_set_wineprefix()
         W_COMMONFILES_WIN="$(w_expand_env CommonProgramW6432)"
         W_COMMONFILES="$(w_pathconv -u "${W_COMMONFILES_WIN}")"
 
-        # 64-bit prefixes still have plenty of issues/a lot of verbs only install 32-bit libraries
-        # Allow the user to disable that (globally, or per prefix).
-        if test -f "${W_CACHE}/no_win64_warnings"; then
-            echo "${W_CACHE}/no_win64_warnings exists, not issuing 64-bit prefix warning"
-            _W_no_win64_warnings=1
-        elif test -f "${WINEPREFIX}/no_win64_warnings"; then
-            echo "${WINEPREFIX}/no_win64_warnings exists, not issuing 64-bit prefix warning"
-            _W_no_win64_warnings=1
-        elif test -f "${W_TMP_EARLY}/no_win64_warnings"; then
-            echo "${W_TMP_EARLY}/no_win64_warnings exists, not issuing 64-bit prefix warning"
-            _W_no_win64_warnings=1
-        else
-            _W_no_win64_warnings=0
+        # check if user has exported env variable or not
+        # if set, use value directly later when determining if win64 warnings should be displayed or not
+        # if empty, then fallback to checking for location-specific files and set accordingly
+        if test -z "${W_NO_WIN64_WARNINGS}"; then
+            # 64-bit prefixes still have plenty of issues/a lot of verbs only install 32-bit libraries
+            # Allow the user to disable that (globally, or per prefix).
+            if test -f "${W_CACHE}/no_win64_warnings"; then
+                echo "${W_CACHE}/no_win64_warnings exists, not issuing 64-bit prefix warning"
+                W_NO_WIN64_WARNINGS=1
+            elif test -f "${WINEPREFIX}/no_win64_warnings"; then
+                echo "${WINEPREFIX}/no_win64_warnings exists, not issuing 64-bit prefix warning"
+                W_NO_WIN64_WARNINGS=1
+            elif test -f "${W_TMP_EARLY}/no_win64_warnings"; then
+                echo "${W_TMP_EARLY}/no_win64_warnings exists, not issuing 64-bit prefix warning"
+                W_NO_WIN64_WARNINGS=1
+            else
+                W_NO_WIN64_WARNINGS=0
+            fi
         fi
 
         # In case of GUI, only warn once per prefix, per session (i.e., don't warn next time)
@@ -5145,7 +5150,7 @@ winetricks_set_wineprefix()
             *) touch "${W_TMP_EARLY}/no_win64_warnings" ;;
         esac
 
-        if [ "${_W_no_win64_warnings}" = 0 ]; then
+        if [ "${W_NO_WIN64_WARNINGS}" = 0 ]; then
             case ${LANG} in
                 bg*) w_warn "Използвате 64-битова папка. Повечето програми са за 32-битова архитектура. Ако възникнат проблеми, моля, използвайте 32-битова папка, преди да ги докладвате." ;;
                 ru*) w_warn "Вы используете 64-битный WINEPREFIX. Важно: многие ветки устанавливают только 32-битные версии пакетов. Если у вас возникли проблемы, пожалуйста, проверьте еще раз на чистом 32-битном WINEPREFIX до отправки отчета об ошибке." ;;


### PR DESCRIPTION
This adds support to allow users to `export W_NO_WIN64_WARNINGS=1` for toggling off win64 warning messages (this new way is in addition to the file-based logic from [an earlier commit](https://github.com/austin987/winetricks/commit/01de762dfa656471cee0df3f6508b82a07de9117) and so should not break any existing setups).

This proposal and the advantages were previously discussed in the comments of issue #1730 but for convenience, those were:

> 1. Allows users to _completely_ suppress the message (including echo statement from touched file) if they _really_ want to
>
> 2. Allows to set an environment variable for a terminal session but not forever (or alternately could use `.bashrc` or equivalent for all terminal sessions)
> 
> 3. Reduced number of I/O hits checking for a file (I know it is an _extremely_ minor I/O hit but it's still _technically_ a plus)
> 
> 4. This also allows a user to temporarily turn the warning back on if they have created the file but wish to restore the warning temporarily such as for a single debugging session.

I think the actual changes should be pretty straight forward and keeping with the same coding style. But if there are any issues / questions / comments / etc, please let me know.