### PR TITLE
Fix architecture detection mechanism for wrapper scripts

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -5063,6 +5063,19 @@ winetricks_set_wineprefix()
         # Check the bitness of wineserver + wine binary, used later to determine if we're on a WOW setup (no wine64)
         # https://github.com/Winetricks/winetricks/issues/2030
         WINESERVER_BIN="$(which "${WINESERVER}")"
+
+        # wineboot often is a link pointing to wineapploader in Wine's bindir. If we don't find binaries we may look for them there later
+        if [ -n "${READLINK_F}" ]; then
+            true
+        elif [ "$(uname -s)" = "Darwin" ]; then
+            # readlink exists on MacOS, but does not support "-f" on MacOS < 12.3
+            # Use perl instead
+            READLINK_F="perl -MCwd=abs_path -le 'print abs_path readlink(shift);'"
+        else
+            READLINK_F="readlink -f"
+        fi
+        WINEBOOT_BIN="$(dirname "${WINESERVER_BIN}")/$(basename "${WINESERVER_BIN}"|sed 's,wineserver,wineboot,')"
+
         _W_wineserver_binary_arch="$(winetricks_get_file_arch "${WINESERVER_BIN}")"
         WINE_BIN="$(which "${WINE}")"
         _W_wine_binary_arch="$(winetricks_get_file_arch "${WINE_BIN}")"

--- a/src/winetricks
+++ b/src/winetricks
@@ -1064,7 +1064,7 @@ w_expand_env()
     winetricks_early_wine_arch cmd.exe /c echo "%$1%"
 }
 
-# Determine what architecture a binary file is built for
+# Determine what architecture a binary file is built for, silently continue in case of failure.
 winetricks_get_file_arch()
 {
     _W_file="$1"
@@ -1075,7 +1075,7 @@ winetricks_get_file_arch()
             "arm64")  _W_file_arch="arm64" ;;
             "i386")   _W_file_arch="i386" ;;
             "x86_64") _W_file_arch="x86_64" ;;
-            *)        w_die "Unknown file arch: ${_W_lipo_output}" ;;
+            *)        _W_file_arch="" ;;
         esac
     else
         # Assume ELF binaries for everything else
@@ -1085,7 +1085,7 @@ winetricks_get_file_arch()
             "03"|"06") _W_file_arch="i386" ;;
             "b7")      _W_file_arch="aarch64" ;;
             "28")      _W_file_arch="aarch32" ;;
-            *)         w_die "Unknown file arch: ${_W_ob_output}";;
+            *)         _W_file_arch="" ;;
         esac
     fi
 
@@ -5077,8 +5077,39 @@ winetricks_set_wineprefix()
         WINEBOOT_BIN="$(dirname "${WINESERVER_BIN}")/$(basename "${WINESERVER_BIN}"|sed 's,wineserver,wineboot,')"
 
         _W_wineserver_binary_arch="$(winetricks_get_file_arch "${WINESERVER_BIN}")"
+        if [ -z "${_W_wineserver_binary_arch}" ]; then
+            # wineserver might be a script calling a binary in Wine's bindir.
+            if [ -z "${WINE_BINDIR}" ] && [ -x "${WINEBOOT_BIN}" ]; then
+                WINE_BINDIR="$(dirname "$(${READLINK_F} "${WINEBOOT_BIN}" 2>/dev/null)" 2>/dev/null)"
+            fi
+            # wineserver in Wine's bindir might be a script calling wineserver64 preferably over wineserver32 (Debian).
+            # Try these before testing wineserver itself
+            if [ -x "${WINE_BINDIR}/wineserver64" ]; then
+                _W_wineserver_binary_arch="$(winetricks_get_file_arch "${WINE_BINDIR}/wineserver64")"
+            elif [ -x "${WINE_BINDIR}/wineserver32" ]; then
+                _W_wineserver_binary_arch="$(winetricks_get_file_arch "${WINE_BINDIR}/wineserver32")"
+            elif [ -x "${WINE_BINDIR}/wineserver" ]; then
+                _W_wineserver_binary_arch="$(winetricks_get_file_arch "${WINE_BINDIR}/wineserver")"
+            fi
+        fi
+        if [ -z "${_W_wineserver_binary_arch}" ]; then
+            w_warn "Unknown file arch of ${WINESERVER_BIN}."
+        fi
+
         WINE_BIN="$(which "${WINE}")"
         _W_wine_binary_arch="$(winetricks_get_file_arch "${WINE_BIN}")"
+        if [ -z "${_W_wine_binary_arch}" ]; then
+            # wine might be a script calling a binary in Wine's bindir.
+            if [ -z "${WINE_BINDIR}" ] && [ -x "${WINEBOOT_BIN}" ]; then
+                WINE_BINDIR="$(dirname "$(${READLINK_F} "${WINEBOOT_BIN}" 2>/dev/null)" 2>/dev/null)"
+            fi
+            if [ -x "${WINE_BINDIR}/wine" ]; then
+                _W_wine_binary_arch="$(winetricks_get_file_arch "${WINE_BINDIR}/wine")"
+            fi
+        fi
+        if [ -z "${_W_wine_binary_arch}" ]; then
+            w_warn "Unknown file arch of ${WINE_BIN}."
+        fi
 
         # determine wow64 type (new/old)
         # FIXME: check what upstream is calling them

--- a/src/winetricks
+++ b/src/winetricks
@@ -193,7 +193,7 @@ W_TEXT_LINE="------------------------------------------------------"
 # Ask permission to continue
 w_askpermission()
 {
-    printf '%s\n%b\n%s\n' "${W_TEXT_LINE}" "${@}" "${W_TEXT_LINE}"
+    printf '%s\n%b\n%s\n' "${W_TEXT_LINE}" "${@}" "${W_TEXT_LINE}" >&2
 
     if test "${W_OPT_UNATTENDED}"; then
         _W_timeout="--timeout"
@@ -208,7 +208,7 @@ w_askpermission()
                 # -t / TMOUT don't seem to be portable, so just assume yes in unattended mode
                 w_info "Unattended mode, not prompting for confirmation"
             else
-                printf %s "Press Y or N, then Enter: "
+                printf %s "Press Y or N, then Enter: " >&2
                 read -r response
                 test "${response}" = Y || test "${response}" = y
             fi
@@ -232,7 +232,7 @@ w_info()
 {
     # If $WINETRICKS_SUPER_QUIET is set, w_info is a no-op:
     if [ -z "${WINETRICKS_SUPER_QUIET}" ] ; then
-        printf '%s\n%b\n%s\n' "${W_TEXT_LINE}" "${@}" "${W_TEXT_LINE}"
+        printf '%s\n%b\n%s\n' "${W_TEXT_LINE}" "${@}" "${W_TEXT_LINE}" >&2
     fi
 
     # kdialog doesn't allow a timeout unless you use --passivepopup
@@ -254,9 +254,9 @@ w_info()
 # Display warning message to stderr (since it is called inside redirected code)
 w_warn()
 {
-    # If $WINETRICKS_SUPER_QUIET is set, w_info is a no-op:
+    # If $WINETRICKS_SUPER_QUIET is set, w_warn is a no-op:
     if [ -z "${WINETRICKS_SUPER_QUIET}" ] ; then
-        printf '%s\nwarning: %b\n%s\n' "${W_TEXT_LINE}" "${*}" "${W_TEXT_LINE}"
+        printf '%s\nwarning: %b\n%s\n' "${W_TEXT_LINE}" "${*}" "${W_TEXT_LINE}" >&2
     fi
 
     # kdialog doesn't allow a timeout unless you use --passivepopup
@@ -618,7 +618,7 @@ w_try()
     export WINEDLLOVERRIDES
     # If $WINETRICKS_SUPER_QUIET is set, make w_try quiet
     if [ -z "${WINETRICKS_SUPER_QUIET}" ]; then
-        printf '%s\n' "Executing $*"
+        printf '%s\n' "Executing $*" >&2
     fi
 
     # On Vista, we need to jump through a few hoops to run commands in Cygwin.
@@ -999,7 +999,7 @@ w_read_key()
             *zenity) W_KEY=$(zenity --entry --text "${_W_keymsg}") ;;
             *kdialog) W_KEY=$(kdialog --inputbox "${_W_keymsg}") ;;
             *xmessage) w_die "sorry, can't read key from GUI with xmessage" ;;
-            none) printf %s "${_W_keymsg}": ; read -r W_KEY ;;
+            none) printf %s "${_W_keymsg}": >&2 ; read -r W_KEY ;;
         esac
 
         if test "${W_KEY}" = ""; then

--- a/src/winetricks
+++ b/src/winetricks
@@ -5113,7 +5113,9 @@ winetricks_set_wineprefix()
 
         # determine wow64 type (new/old)
         # FIXME: check what upstream is calling them
-        if [ "${_W_wineserver_binary_arch}" = "${_W_wine_binary_arch}" ]; then
+        if [ -z "${_W_wineserver_binary_arch}" ] || [ -z "${_W_wine_binary_arch}" ]; then
+            _W_wow64_style="unknown"
+        elif [ "${_W_wineserver_binary_arch}" = "${_W_wine_binary_arch}" ]; then
             _W_wow64_style="new"
         else
             _W_wow64_style="classic"
@@ -5199,6 +5201,8 @@ winetricks_set_wineprefix()
 
             if [ "${_W_wow64_style}" = "new" ]; then
                 w_warn "You apppear to be using Wine's new wow64 mode. Note that this is EXPERIMENTAL and not yet fully supported. If reporting an issue, be sure to mention this."
+            elif [ "${_W_wow64_style}" = "unknown" ]; then
+                w_warn "WoW64 type could not be detected."
             fi
         fi
 


### PR DESCRIPTION
There are 2 general issues related to this fix, each handled in a separate commit:
winetricks: display messages for users to stderr
winetricks_get_file_arch: try workaround for wrapper scripts
winetricks_set_wineprefix: warn if binary arch is unknown

Please have a look at the detailed commit messages. E.g. not all of the stderr stuff is needed.

Feedback welcome!

3 open questions:

1. Is my readlink implementation sufficient?
"readlink -f" is not working on MacOS < 12.3
(https://apple.stackexchange.com/questions/464136/which-macos-version-introduced-readlink-f)

Alternatives are:
(See https://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac)
  - greadlink (extra package, in /usr/local/bin/)
  - perl -MCwd=abs_path -le 'print abs_path readlink(shift);' $FILE (if perl is installed)
  - stat -f%Y $FILE (the -f%Y option will show the target of a symlink, not an absolute pathname, should still work. Does not work on Linux)
  
For now I just use the perl alternative on MacOS. I think that's sufficient, but if wanted and with the help of some MacOS users I might add some changes:
  - If we know the MacOS version, we might use "readlink -f" on current MacOS >=12.3.
  - If I know the exact filepath we might use greadlink (provided by a separate package)
  - As fallback we might use "stat" - but the syntax I found on the web doesn't work on Linux.
  
  Whatever we do, even if the implemented readlink alternative fails, there still shouldn't be a regression, because if "readlink -f" or the alternative is non-functional all error messages (as long as they are on stderr) go to /dev/null and the output should be empty. Then the binaries would be tested directly in "/" (where they really shouldn't exist), and the same "Unknown file arch" would result as without this code.

2.  Should I factor the readlink logic out? [EDIT: Done]
Since this PR uses the same readlink logic as in https://github.com/Winetricks/winetricks/pull/2035 I might combine both PRs and factor this out to deduplicate code. Please tell me if I should do so.

3. Should I warn, exit or completely ignore if the binary arch is unknown? [EDIT: Done: exit/w_die]
For now I only warn, but continue.
Depending on whether the user has an old or new style WoW64 setup, this still might give the correct outcome accidentally. See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1063466
Once we're satisfied that my fix works I suggest to use w_die instead.