### PR TITLE
Rewrite new style wow64 support

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -1064,6 +1064,16 @@ w_expand_env()
     winetricks_early_wine_arch cmd.exe /c echo "%$1%"
 }
 
+w_expand_env32()
+{
+    winetricks_early_wine "${W_SYSTEM32_DLLS_WIN}\\cmd.exe" /c echo "%$1%"
+}
+
+w_expand_env64()
+{
+    WINE=${WINE64} winetricks_early_wine "${W_SYSTEM64_DLLS_WIN64}\\cmd.exe" /c echo "%$1%"
+}
+
 # Get the latest tagged release from github.com API
 w_get_github_latest_release()
 {
@@ -5063,9 +5073,6 @@ winetricks_set_wineprefix()
         WINE_MULTI="${WINE}"
         W_ARCH=win64
 
-        W_PROGRAMS_WIN="$(w_expand_env ProgramFiles)"
-        W_PROGRAMS_UNIX="$(w_pathconv -u "${W_PROGRAMS_WIN}")"
-
         # Common variable for 32-bit dlls on win32/win64:
         W_SYSTEM32_DLLS="${W_WINDIR_UNIX}/syswow64"
         W_SYSTEM32_DLLS_WIN="C:\\windows\\syswow64"
@@ -5074,18 +5081,21 @@ winetricks_set_wineprefix()
         W_SYSTEM64_DLLS_WIN32="C:\\windows\\sysnative" # path to access 64-bit dlls from 32-bit apps
         W_SYSTEM64_DLLS_WIN64="C:\\windows\\system32"  # path to access 64-bit dlls from 64-bit apps
 
+        W_PROGRAMS_WIN="$(w_expand_env64 ProgramFiles)"
+        W_PROGRAMS_UNIX="$(w_pathconv -u "${W_PROGRAMS_WIN}")"
+
         # There's also ProgramW6432, which =%ProgramFiles%(but only available when running under a 64 bit OS)
         # See https://ss64.com/nt/syntax-variables.html
-        W_PROGRAMW6432_WIN="$(w_expand_env ProgramW6432)"
+        W_PROGRAMW6432_WIN="$(w_expand_env64 ProgramW6432)"
         W_PROGRAMW6432_UNIX="$(w_pathconv -u "${W_PROGRAMW6432_WIN}")"
 
         # 64-bit Windows has a second directory for program files
-        W_PROGRAMS_X86_WIN="${W_PROGRAMS_WIN} (x86)"
-        W_PROGRAMS_X86_UNIX="${W_PROGRAMS_UNIX} (x86)"
+        W_PROGRAMS_X86_WIN="$(w_expand_env32 ProgramFiles)"
+        W_PROGRAMS_X86_UNIX="$(w_pathconv -u "${W_PROGRAMS_X86_WIN}")"
 
-        W_COMMONFILES_X86_WIN="$(w_expand_env CommonProgramFiles\(x86\))"
+        W_COMMONFILES_X86_WIN="$(w_expand_env64 CommonProgramFiles\(x86\))"
         W_COMMONFILES_X86="$(w_pathconv -u "${W_COMMONFILES_X86_WIN}")"
-        W_COMMONFILES_WIN="$(w_expand_env CommonProgramW6432)"
+        W_COMMONFILES_WIN="$(w_expand_env64 CommonProgramW6432)"
         W_COMMONFILES="$(w_pathconv -u "${W_COMMONFILES_WIN}")"
 
         # 64-bit prefixes still have plenty of issues/a lot of verbs only install 32-bit libraries
@@ -5130,9 +5140,6 @@ winetricks_set_wineprefix()
         WINE_MULTI="${WINE}"
         W_ARCH=win32
 
-        W_PROGRAMS_WIN="$(w_expand_env ProgramFiles)"
-        W_PROGRAMS_UNIX="$(w_pathconv -u "${W_PROGRAMS_WIN}")"
-
         # Common variable for 32-bit dlls on win32/win64:
         W_SYSTEM32_DLLS="${W_WINDIR_UNIX}/system32"
         W_SYSTEM32_DLLS_WIN="C:\\windows\\system32"
@@ -5143,19 +5150,22 @@ winetricks_set_wineprefix()
         W_SYSTEM64_DLLS_WIN32="C:\\does-not-exist-on-win32" # path to access 64-bit dlls from 32-bit apps
         W_SYSTEM64_DLLS_WIN64="C:\\does-not-exist-on-win32"  # path to access 64-bit dlls from 64-bit apps
 
+        W_PROGRAMS_WIN="$(w_expand_env32 ProgramFiles)"
+        W_PROGRAMS_UNIX="$(w_pathconv -u "${W_PROGRAMS_WIN}")"
+
         W_PROGRAMS_X86_WIN="${W_PROGRAMS_WIN}"
         W_PROGRAMS_X86_UNIX="${W_PROGRAMS_UNIX}"
 
-        W_COMMONFILES_X86_WIN="$(w_expand_env CommonProgramFiles)"
+        W_COMMONFILES_X86_WIN="$(w_expand_env32 CommonProgramFiles)"
         W_COMMONFILES_X86="$(w_pathconv -u "${W_COMMONFILES_X86_WIN}")"
-        W_COMMONFILES_WIN="$(w_expand_env CommonProgramFiles)"
+        W_COMMONFILES_WIN="$(w_expand_env32 CommonProgramFiles)"
         W_COMMONFILES="$(w_pathconv -u "${W_COMMONFILES_WIN}")"
     fi
 
     ## Arch independent variables:
 
     # Note: using AppData since it's arch independent
-    W_APPDATA_WIN="$(w_expand_env AppData)"
+    W_APPDATA_WIN="$(w_expand_env32 AppData)"
     W_APPDATA_UNIX="$(w_pathconv -u "${W_APPDATA_WIN}")"
 
     case "${W_APPDATA_WIN}" in

--- a/src/winetricks
+++ b/src/winetricks
@@ -5062,13 +5062,6 @@ winetricks_set_wineprefix()
             test -x "${WINE64}" || WINE64="${WINE}"
         fi
 
-        # if we can't detect wine64 command, it is the new wow64 mode
-        if echo "${WINE64}" | grep -q "wine64" ; then
-            _W_wow64_style="classic"
-        else
-            _W_wow64_style="new"
-        fi
-
         WINE_ARCH="${WINE64}"
         WINE_MULTI="${WINE}"
         W_ARCH=win64
@@ -5128,13 +5121,9 @@ winetricks_set_wineprefix()
                 *) w_warn "You are using a 64-bit WINEPREFIX. Note that many verbs only install 32-bit versions of packages. If you encounter problems, please retest in a clean 32-bit WINEPREFIX before reporting a bug." ;;
             esac
 
-            if [ "${_W_wow64_style}" = "new" ]; then
-                w_warn "You apppear to be using Wine's new wow64 mode. Note that this is EXPERIMENTAL and not yet fully supported. If reporting an issue, be sure to mention this."
-            fi
         fi
 
     else
-        _W_wow64_style="none"
         WINE64="false"
         WINE_ARCH="${WINE}"
         WINE_MULTI="${WINE}"

--- a/src/winetricks
+++ b/src/winetricks
@@ -882,7 +882,7 @@ w_try_regedit64()
     w_try "${WINE64}" ${cmdc} "C:\\windows\\regedit.exe" ${W_OPT_UNATTENDED:+/S} "$@"
 }
 
-w_try_regsvr()
+w_try_regsvr32()
 {
     w_try "${WINE}" "${W_SYSTEM32_DLLS_WIN}\\regsvr32.exe" ${W_OPT_UNATTENDED:+/S} "$@"
 }
@@ -5915,7 +5915,7 @@ load_amstream()
 
     w_override_dlls native,builtin amstream
 
-    w_try_regsvr amstream.dll
+    w_try_regsvr32 amstream.dll
 
     if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-directshow-other_31bf3856ad364e35_6.1.7601.17514_none_6b778d68f75a1a54/amstream.dll
@@ -6102,9 +6102,9 @@ load_comctl32ocx()
 {
     helper_vb6sp6 "${W_SYSTEM32_DLLS}" comctl32.ocx mscomctl.ocx mscomct2.ocx
 
-    w_try_regsvr comctl32.ocx
-    w_try_regsvr mscomctl.ocx
-    w_try_regsvr mscomct2.ocx
+    w_try_regsvr32 comctl32.ocx
+    w_try_regsvr32 mscomctl.ocx
+    w_try_regsvr32 mscomct2.ocx
 }
 
 #----------------------------------------------------------------
@@ -6121,7 +6121,7 @@ load_comdlg32ocx()
 {
     helper_vb6sp6 "${W_TMP}" ComDlg32.ocx
     w_try mv "${W_TMP}/ComDlg32.ocx" "${W_SYSTEM32_DLLS}/comdlg32.ocx"
-    w_try_regsvr comdlg32.ocx
+    w_try_regsvr32 comdlg32.ocx
 }
 
 #----------------------------------------------------------------
@@ -6851,7 +6851,7 @@ load_devenum()
     w_try_cabextract -d "${W_TMP}" -L -F 'dxnt.cab' "${W_CACHE}/directx9/${DIRECTX_NAME}"
     w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'devenum.dll' "${W_TMP}/dxnt.cab"
     w_override_dlls native devenum
-    w_try_regsvr devenum.dll
+    w_try_regsvr32 devenum.dll
 }
 
 #----------------------------------------------------------------
@@ -6871,7 +6871,7 @@ load_dinput()
     w_try_cabextract -d "${W_TMP}" -L -F 'dxnt.cab' "${W_CACHE}"/directx9/${DIRECTX_NAME}
     w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dinput.dll' "${W_TMP}/dxnt.cab"
     w_override_dlls native dinput
-    w_try_regsvr dinput
+    w_try_regsvr32 dinput
 }
 
 #----------------------------------------------------------------
@@ -6975,10 +6975,10 @@ load_directplay()
 
     w_override_dlls native dplaysvr.exe dplayx dpmodemx dpnet dpnhpast dpnhupnp dpnsvr.exe dpwsockx
 
-    w_try_regsvr dplayx.dll
-    w_try_regsvr dpnet.dll
-    w_try_regsvr dpnhpast.dll
-    w_try_regsvr dpnhupnp.dll
+    w_try_regsvr32 dplayx.dll
+    w_try_regsvr32 dpnet.dll
+    w_try_regsvr32 dpnhpast.dll
+    w_try_regsvr32 dpnhupnp.dll
 }
 
 #----------------------------------------------------------------
@@ -7019,9 +7019,9 @@ load_dpvoice()
         w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dpvacm.dll' "${x}"
     done
     w_override_dlls native dpvoice dpvvox dpvacm
-    w_try_regsvr dpvoice.dll
-    w_try_regsvr dpvvox.dll
-    w_try_regsvr dpvacm.dll
+    w_try_regsvr32 dpvoice.dll
+    w_try_regsvr32 dpvvox.dll
+    w_try_regsvr32 dpvacm.dll
 }
 
 #----------------------------------------------------------------
@@ -7041,8 +7041,8 @@ load_dsdmo()
     w_try_cabextract -d "${W_TMP}" -L -F dxnt.cab "${W_CACHE}"/directx9/${DIRECTX_NAME}
     w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dsdmo.dll' "${W_TMP}/dxnt.cab"
     w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dsdmoprp.dll' "${W_TMP}/dxnt.cab"
-    w_try_regsvr dsdmo.dll
-    w_try_regsvr dsdmoprp.dll
+    w_try_regsvr32 dsdmo.dll
+    w_try_regsvr32 dsdmoprp.dll
 }
 
 #----------------------------------------------------------------
@@ -7104,7 +7104,7 @@ load_dxtrans()
     helper_winxpsp3 i386/dxtrans.dl_
     w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_TMP}"/i386/dxtrans.dl_
     w_override_dlls native,builtin dxtrans
-    w_try_regsvr dxtrans.dll
+    w_try_regsvr32 dxtrans.dll
 }
 
 #----------------------------------------------------------------
@@ -8645,7 +8645,7 @@ load_dmband()
     w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dmband.dll' "${W_TMP}/dxnt.cab"
 
     w_override_dlls native dmband
-    w_try_regsvr dmband.dll
+    w_try_regsvr32 dmband.dll
 }
 
 #----------------------------------------------------------------
@@ -8666,7 +8666,7 @@ load_dmcompos()
     w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dmcompos.dll' "${W_TMP}/dxnt.cab"
 
     w_override_dlls native dmcompos
-    w_try_regsvr dmcompos.dll
+    w_try_regsvr32 dmcompos.dll
 }
 
 #----------------------------------------------------------------
@@ -8687,7 +8687,7 @@ load_dmime()
     w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dmime.dll' "${W_TMP}/dxnt.cab"
 
     w_override_dlls native dmime
-    w_try_regsvr dmime.dll
+    w_try_regsvr32 dmime.dll
 }
 
 #----------------------------------------------------------------
@@ -8708,7 +8708,7 @@ load_dmloader()
     w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dmloader.dll' "${W_TMP}/dxnt.cab"
 
     w_override_dlls native dmloader
-    w_try_regsvr dmloader.dll
+    w_try_regsvr32 dmloader.dll
 }
 
 #----------------------------------------------------------------
@@ -8729,7 +8729,7 @@ load_dmscript()
     w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dmscript.dll' "${W_TMP}/dxnt.cab"
 
     w_override_dlls native dmscript
-    w_try_regsvr dmscript.dll
+    w_try_regsvr32 dmscript.dll
 }
 
 #----------------------------------------------------------------
@@ -8750,7 +8750,7 @@ load_dmstyle()
     w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dmstyle.dll' "${W_TMP}/dxnt.cab"
 
     w_override_dlls native dmstyle
-    w_try_regsvr dmstyle.dll
+    w_try_regsvr32 dmstyle.dll
 }
 
 #----------------------------------------------------------------
@@ -8771,7 +8771,7 @@ load_dmsynth()
     w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dmsynth.dll' "${W_TMP}/dxnt.cab"
 
     w_override_dlls native dmsynth
-    w_try_regsvr dmsynth.dll
+    w_try_regsvr32 dmsynth.dll
 }
 
 #----------------------------------------------------------------
@@ -8792,7 +8792,7 @@ load_dmusic()
     w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dmusic.dll' "${W_TMP}/dxnt.cab"
 
     w_override_dlls native dmusic
-    w_try_regsvr dmusic.dll
+    w_try_regsvr32 dmusic.dll
 }
 
 #----------------------------------------------------------------
@@ -8813,7 +8813,7 @@ load_dswave()
     w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dswave.dll' "${W_TMP}/dxnt.cab"
 
     w_override_dlls native dswave
-    w_try_regsvr dswave.dll
+    w_try_regsvr32 dswave.dll
 }
 
 #----------------------------------------------------------------
@@ -10191,7 +10191,7 @@ load_dxdiagn()
     helper_win7sp1 x86_microsoft-windows-d..x-directxdiagnostic_31bf3856ad364e35_6.1.7601.17514_none_25cb021dbc0611db/dxdiagn.dll
     w_try_cp_dll "${W_TMP}/x86_microsoft-windows-d..x-directxdiagnostic_31bf3856ad364e35_6.1.7601.17514_none_25cb021dbc0611db/dxdiagn.dll" "${W_SYSTEM32_DLLS}/dxdiagn.dll"
     w_override_dlls native,builtin dxdiagn
-    w_try_regsvr dxdiagn.dll
+    w_try_regsvr32 dxdiagn.dll
 
     if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-d..x-directxdiagnostic_31bf3856ad364e35_6.1.7601.17514_none_81e99da174638311/dxdiagn.dll
@@ -10218,7 +10218,7 @@ load_dxdiagn_feb2010()
     w_try_cabextract -d "${W_TMP}" -L -F dxnt.cab "${W_CACHE}"/directx9/${DIRECTX_NAME}
     w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'dxdiagn.dll' "${W_TMP}/dxnt.cab"
     w_override_dlls native dxdiagn
-    w_try_regsvr dxdiagn.dll
+    w_try_regsvr32 dxdiagn.dll
 }
 
 #----------------------------------------------------------------
@@ -10926,7 +10926,7 @@ load_icodecs()
     # https://support.britannica.com/other/touchthesky/win/issues/TSTUw_150.htm
     # https://appdb.winehq.org/objectManager.php?sClass=version&iId=7091
     w_override_dlls native,builtin ir50_32
-    w_try_regsvr ir50_32
+    w_try_regsvr32 ir50_32
 
     # Apparently some codecs are missing, see https://github.com/Winetricks/winetricks/issues/302
     # Download at https://www.moviecodec.com/download-codec-packs/indeo-codecs-legacy-package-31/
@@ -11053,7 +11053,7 @@ load_itircl()
     w_try_cabextract -d "${W_TMP}" -F hhupd.exe "${W_CACHE}"/hhw/htmlhelp.exe
     w_try_cabextract -d "${W_SYSTEM32_DLLS}" -F itircl.dll "${W_TMP}"/hhupd.exe
     w_override_dlls native itircl
-    w_try_regsvr itircl.dll
+    w_try_regsvr32 itircl.dll
 }
 
 #----------------------------------------------------------------
@@ -11074,7 +11074,7 @@ load_itss()
     w_try_cabextract -d "${W_TMP}" -F hhupd.exe "${W_CACHE}"/hhw/htmlhelp.exe
     w_try_cabextract -d "${W_SYSTEM32_DLLS}" -F itss.dll "${W_TMP}"/hhupd.exe
     w_override_dlls native itss
-    w_try_regsvr itss.dll
+    w_try_regsvr32 itss.dll
 }
 
 #----------------------------------------------------------------
@@ -11221,7 +11221,7 @@ load_l3codecx()
     w_try_cabextract -d "${W_TMP}" -L -F dxnt.cab "${W_CACHE}"/directx9/${DIRECTX_NAME}
     w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F 'l3codecx.ax' "${W_TMP}/dxnt.cab"
 
-    w_try_regsvr l3codecx.ax
+    w_try_regsvr32 l3codecx.ax
 }
 
 #----------------------------------------------------------------
@@ -11582,7 +11582,7 @@ load_msdxmocx()
     w_download http://hell.pl/agnus/windows95/mpfull.exe a39b2b9735cedd513fcb78f8634695d35073e9d7e865e536a0da6db38c7225e4
 
     w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_CACHE}/${W_PACKAGE}/${file1}"
-    w_try_regsvr msdxm.ocx
+    w_try_regsvr32 msdxm.ocx
 }
 
 #----------------------------------------------------------------
@@ -11599,7 +11599,7 @@ load_msflxgrd()
 {
     helper_vb6sp6 "${W_TMP}" MSFlxGrd.ocx
     w_try mv "${W_TMP}/MSFlxGrd.ocx" "${W_SYSTEM32_DLLS}/msflxgrd.ocx"
-    w_try_regsvr msflxgrd.ocx
+    w_try_regsvr32 msflxgrd.ocx
 }
 
 #----------------------------------------------------------------
@@ -11616,7 +11616,7 @@ load_mshflxgd()
 {
     helper_vb6sp6 "${W_TMP}" MShflxgd.ocx
     w_try mv "${W_TMP}/MShflxgd.ocx" "${W_SYSTEM32_DLLS}/mshflxgd.ocx"
-    w_try_regsvr mshflxgd.ocx
+    w_try_regsvr32 mshflxgd.ocx
 }
 
 #----------------------------------------------------------------
@@ -11689,7 +11689,7 @@ load_msmask()
 {
     helper_vb6sp6 "${W_TMP}" msmask32.ocx
     w_try mv "${W_TMP}/msmask32.ocx" "${W_SYSTEM32_DLLS}/msmask32.ocx"
-    w_try_regsvr msmask32.ocx
+    w_try_regsvr32 msmask32.ocx
 }
 
 #----------------------------------------------------------------
@@ -12178,7 +12178,7 @@ load_pngfilt()
 
     helper_winxpsp3 i386/pngfilt.dl_
     w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_TMP}"/i386/pngfilt.dl_
-    w_try_regsvr pngfilt.dll
+    w_try_regsvr32 pngfilt.dll
 }
 
 #----------------------------------------------------------------
@@ -12198,7 +12198,7 @@ load_prntvpt()
     w_try_cp_dll "${W_TMP}/x86_microsoft-windows-p..g-printticket-win32_31bf3856ad364e35_6.1.7601.17514_none_1562129afd710f2c/prntvpt.dll" "${W_SYSTEM32_DLLS}/prntvpt.dll"
 
     w_override_dlls native,builtin prntvpt
-    w_try_regsvr prntvpt.dll
+    w_try_regsvr32 prntvpt.dll
 
     if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-p..g-printticket-win32_31bf3856ad364e35_6.1.7601.17514_none_7180ae1eb5ce8062/prntvpt.dll
@@ -12293,7 +12293,7 @@ load_qasf()
     w_try_cp_dll "${W_TMP}/x86_microsoft-windows-directshow-asf_31bf3856ad364e35_6.1.7601.17514_none_1cc4e9c15ccc8ae8/qasf.dll" "${W_SYSTEM32_DLLS}/qasf.dll"
 
     w_override_dlls native,builtin qasf
-    w_try_regsvr qasf.dll
+    w_try_regsvr32 qasf.dll
 
     if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-directshow-asf_31bf3856ad364e35_6.1.7601.17514_none_78e385451529fc1e/qasf.dll
@@ -12317,7 +12317,7 @@ load_qcap()
     helper_win7sp1 x86_microsoft-windows-directshow-capture_31bf3856ad364e35_6.1.7601.17514_none_bae08d1e7dcccf2a/qcap.dll
     w_try_cp_dll "${W_TMP}/x86_microsoft-windows-directshow-capture_31bf3856ad364e35_6.1.7601.17514_none_bae08d1e7dcccf2a/qcap.dll" "${W_SYSTEM32_DLLS}/qcap.dll"
     w_override_dlls native,builtin qcap
-    w_try_regsvr qcap.dll
+    w_try_regsvr32 qcap.dll
 
     if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-directshow-capture_31bf3856ad364e35_6.1.7601.17514_none_16ff28a2362a4060/qcap.dll
@@ -12341,7 +12341,7 @@ load_qdvd()
     helper_win7sp1 x86_microsoft-windows-directshow-dvdsupport_31bf3856ad364e35_6.1.7601.17514_none_562994bd321aac67/qdvd.dll
     w_try_cp_dll "${W_TMP}/x86_microsoft-windows-directshow-dvdsupport_31bf3856ad364e35_6.1.7601.17514_none_562994bd321aac67/qdvd.dll" "${W_SYSTEM32_DLLS}/qdvd.dll"
     w_override_dlls native,builtin qdvd
-    w_try_regsvr qdvd.dll
+    w_try_regsvr32 qdvd.dll
 
     if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-directshow-dvdsupport_31bf3856ad364e35_6.1.7601.17514_none_b2483040ea781d9d/qdvd.dll
@@ -12365,7 +12365,7 @@ load_qedit()
     helper_win7sp1 x86_microsoft-windows-qedit_31bf3856ad364e35_6.1.7601.17514_none_5ca34698a5a970d2/qedit.dll
     w_try_cp_dll "${W_TMP}/x86_microsoft-windows-qedit_31bf3856ad364e35_6.1.7601.17514_none_5ca34698a5a970d2/qedit.dll" "${W_SYSTEM32_DLLS}/qedit.dll"
     w_override_dlls native,builtin qedit
-    w_try_regsvr qedit.dll
+    w_try_regsvr32 qedit.dll
 
     if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-qedit_31bf3856ad364e35_6.1.7601.17514_none_b8c1e21c5e06e208/qedit.dll
@@ -12389,7 +12389,7 @@ load_quartz()
     helper_win7sp1 x86_microsoft-windows-directshow-core_31bf3856ad364e35_6.1.7601.17514_none_a877a1cc4c284497/quartz.dll
     w_try_cp_dll "${W_TMP}/x86_microsoft-windows-directshow-core_31bf3856ad364e35_6.1.7601.17514_none_a877a1cc4c284497/quartz.dll" "${W_SYSTEM32_DLLS}/quartz.dll"
     w_override_dlls native,builtin quartz
-    w_try_regsvr quartz.dll
+    w_try_regsvr32 quartz.dll
 
     if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-directshow-core_31bf3856ad364e35_6.1.7601.17514_none_04963d500485b5cd/quartz.dll
@@ -12417,7 +12417,7 @@ load_quartz_feb2010()
     w_try_cabextract -d "${W_SYSTEM32_DLLS}" -L -F quartz.dll "${W_TMP}/dxnt.cab"
 
     w_override_dlls native,builtin quartz
-    w_try_regsvr quartz.dll
+    w_try_regsvr32 quartz.dll
 }
 
 #----------------------------------------------------------------
@@ -12570,7 +12570,7 @@ w_metadata richtx32 dlls \
 load_richtx32()
 {
     helper_vb6sp6 "${W_SYSTEM32_DLLS}" richtx32.ocx
-    w_try_regsvr richtx32.ocx
+    w_try_regsvr32 richtx32.ocx
 }
 
 #----------------------------------------------------------------
@@ -12596,7 +12596,7 @@ load_sapi()
     helper_win7sp1 x86_microsoft-windows-speechcommon_31bf3856ad364e35_6.1.7601.17514_none_d809b28230ecfe46/sapi.dll
     w_try_cp_dll "${W_TMP}/x86_microsoft-windows-speechcommon_31bf3856ad364e35_6.1.7601.17514_none_d809b28230ecfe46/sapi.dll" "${W_SYSTEM32_DLLS}/sapi.dll"
     w_override_dlls native sapi
-    w_try_regsvr sapi.dll
+    w_try_regsvr32 sapi.dll
 
     if [ "${W_ARCH}" = "win64" ]; then
         helper_win7sp1_x64 amd64_microsoft-windows-speechcommon_31bf3856ad364e35_6.1.7601.17514_none_34284e05e94a6f7c/sapi.dll
@@ -12750,7 +12750,7 @@ load_tabctl32()
 {
     helper_vb6sp6 "${W_TMP}" TabCtl32.ocx
     w_try mv "${W_TMP}/TabCtl32.ocx" "${W_SYSTEM32_DLLS}/tabctl32.ocx"
-    w_try_regsvr tabctl32.ocx
+    w_try_regsvr32 tabctl32.ocx
 }
 
 #----------------------------------------------------------------
@@ -13981,7 +13981,7 @@ load_wsh57()
 
     # Wine doesn't provide the other dll's (yet?)
     w_override_dlls native,builtin jscript scrrun vbscript cscript.exe wscript.exe
-    w_try_regsvr dispex.dll jscript.dll scrobj.dll scrrun.dll vbscript.dll wshcon.dll wshext.dll
+    w_try_regsvr32 dispex.dll jscript.dll scrobj.dll scrrun.dll vbscript.dll wshcon.dll wshext.dll
 }
 
 #----------------------------------------------------------------
@@ -14020,12 +14020,12 @@ load_xact()
 
     # Register xactengine?_?.dll
     for x in "${W_SYSTEM32_DLLS}"/xactengine* ; do
-        w_try_regsvr "$(basename "${x}")"
+        w_try_regsvr32 "$(basename "${x}")"
     done
 
     # and xaudio?_?.dll, but not xaudio2_8 (unsupported)
     for x in 0 1 2 3 4 5 6 7 ; do
-        w_try_regsvr "$(basename "${W_SYSTEM32_DLLS}/xaudio2_${x}")"
+        w_try_regsvr32 "$(basename "${W_SYSTEM32_DLLS}/xaudio2_${x}")"
     done
 }
 

--- a/src/winetricks
+++ b/src/winetricks
@@ -1064,34 +1064,6 @@ w_expand_env()
     winetricks_early_wine_arch cmd.exe /c echo "%$1%"
 }
 
-# Determine what architecture a binary file is built for
-winetricks_get_file_arch()
-{
-    _W_file="$1"
-    # macOS uses Mach-O binaries, not ELF
-    if [ "$(uname -s)" = "Darwin" ]; then
-        _W_lipo_output="$(lipo -archs "${_W_file}")"
-        case "${_W_lipo_output}" in
-            "arm64")  _W_file_arch="arm64" ;;
-            "i386")   _W_file_arch="i386" ;;
-            "x86_64") _W_file_arch="x86_64" ;;
-            *)        w_die "Unknown file arch: ${_W_lipo_output}" ;;
-        esac
-    else
-        # Assume ELF binaries for everything else
-        _W_ob_output="$(od -An -t x1 -j 0x12 -N 1 "${_W_file}" | tr -d "[:space:]")"
-        case "${_W_ob_output}" in
-            "3e")      _W_file_arch="x86_64" ;;
-            "03"|"06") _W_file_arch="i386" ;;
-            "b7")      _W_file_arch="aarch64" ;;
-            "28")      _W_file_arch="aarch32" ;;
-            *)         w_die "Unknown file arch: ${_W_ob_output}";;
-        esac
-    fi
-
-    echo "${_W_file_arch}"
-}
-
 # Get the latest tagged release from github.com API
 w_get_github_latest_release()
 {
@@ -5060,20 +5032,6 @@ winetricks_set_wineprefix()
     # Using the variable W_SYSTEM32_DLLS instead of SYSTEM32 because some stuff does go under system32 for both arch's
     # e.g., spool/drivers/color
     if test -d "${W_DRIVE_C}/windows/syswow64"; then
-        # Check the bitness of wineserver + wine binary, used later to determine if we're on a WOW setup (no wine64)
-        # https://github.com/Winetricks/winetricks/issues/2030
-        WINESERVER_BIN="$(which "${WINESERVER}")"
-        _W_wineserver_binary_arch="$(winetricks_get_file_arch "${WINESERVER_BIN}")"
-        WINE_BIN="$(which "${WINE}")"
-        _W_wine_binary_arch="$(winetricks_get_file_arch "${WINE_BIN}")"
-
-        # determine wow64 type (new/old)
-        # FIXME: check what upstream is calling them
-        if [ "${_W_wineserver_binary_arch}" = "${_W_wine_binary_arch}" ]; then
-            _W_wow64_style="new"
-        else
-            _W_wow64_style="classic"
-        fi
 
         # Probably need fancier handling/checking, but for a basic start:
         # Note 'wine' may be named 'wine-stable'/'wine-staging'/etc.):
@@ -5082,8 +5040,6 @@ winetricks_set_wineprefix()
         # WINE_MULTI = generic wine, new name
         if [ -n "${WINE64}" ]; then
             true
-        elif [ "${_W_wow64_style}" = "new" ]; then
-            WINE64="${WINE}"
         elif [ "${WINE%??}64" = "${WINE}" ]; then
             WINE64="${WINE}"
         elif command -v "${WINE}64" >/dev/null 2>&1; then
@@ -5093,7 +5049,16 @@ winetricks_set_wineprefix()
             WINE64="$(dirname "${WINE}")/"
             [ "${WINE64}" = "./" ] && WINE64=""
             WINE64="${WINE64}$(basename "${WINE}" | sed 's/^wine/wine64/')"
+            test -x "${WINE64}" || WINE64="${WINE}"
         fi
+
+        # if we can't detect wine64 command, it is the new wow64 mode
+        if echo "${WINE64}" | grep -q "wine64" ; then
+            _W_wow64_style="classic"
+        else
+            _W_wow64_style="new"
+        fi
+
         WINE_ARCH="${WINE64}"
         WINE_MULTI="${WINE}"
         W_ARCH=win64


### PR DESCRIPTION
This rewrite done in continue to #2030 and #2143 and pretent to be better improvement than #2189.

The first commit removed wine binary arch detection (these binaries can be wrapper scripts) and add new style wow64 detection by missed wine64 command.
The second commit fix environment expand macro to get correct %ProgramFiles% path.
And w_try_regsvr is renamed to w_try_regsvr32 to be more consisency with other 32/64 functions. Now some code is already using w_try_regsvr32 and this code is broken without this commit.

