### PR TITLE
alldlls=builtin: remove openal32

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -2350,7 +2350,7 @@ w_override_all_dlls()
         newdev ninput normaliz npmshtml npptools ntdsapi \
         ntprint objsel odbc32 odbccp32 odbccu32 ole32 oleacc \
         oleaut32 olecli32 oledb32 oledlg olepro32 olesvr32 \
-        olethk32 opcservices openal32 opencl packager pdh \
+        olethk32 opcservices opencl packager pdh \
         photometadatahandler pidgen powrprof printui prntvpt \
         propsys psapi pstorec qcap qedit qmgr qmgrprxy \
         quartz query qwave rasapi32 rasdlg regapi resutils \


### PR DESCRIPTION
Wine no longer has a builtin openal32.