### PR TITLE
More consistent unpacking

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -705,7 +705,7 @@ w_try_7z()
         w_try_cd "${PWD}"
 
         # errors out if there is a space between -o and path
-        w_try "${WINE}" "${W_PROGRAMS_X86_WIN}\\7-Zip\\7z.exe" x "$(w_pathconv -w "${filename}")" -y -o"$(w_pathconv -w "${destdir}")" "$@"
+        w_try "${WINE}" "${W_PROGRAMS_X86_WIN}\\7-Zip\\7z.exe" x "$(w_pathconv -w "${filename}")" -o"$(w_pathconv -w "${destdir}")" "$@"
     fi
 }
 


### PR DESCRIPTION
All other calls of `7z.exe` omit the `-y` parameter, as well as the other unpacking tools don't overwrite files (I think).

If that is intentional, just close the PR.