### PR TITLE
winetricks.1: update license to GNU Lesser General Public 2.1

### DIFF
--- a/src/winetricks.1
+++ b/src/winetricks.1
@@ -189,9 +189,9 @@ please see the "Copyright" section in the file 'winetricks'.
 
 .SH COPYRIGHT
 This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU Library General Public
+modify it under the terms of the GNU Lesser General Public
 License as published by the Free Software Foundation; either
-version 2 of the License, or (at your option) any later version.
+version 2.1 of the License, or (at your option) any later version.
 See <https://www.gnu.org/licenses/>.
 .SH BUGS
 .PP


### PR DESCRIPTION
Streamline license text for consistent use of LGPL 2.1+. The GNU Lesser General Public 2.1 license is the successor of the GNU Library General Public 2 license, so this change is within the "any later" clause.