### PR TITLE
winlinkexpress: new verb

### DIFF
--- a/files/verbs/all.txt
+++ b/files/verbs/all.txt
@@ -59,6 +59,7 @@ vc2010express            MS Visual C++ 2010 Express (Microsoft, 2010) [downloada
 vlc                      VLC media player 2.2.1 (VideoLAN, 2015) [downloadable]
 vstools2019              MS Visual Studio Build Tools 2019 (Microsoft, 2019) [downloadable]
 winamp                   Winamp (Radionomy (AOL (Nullsoft)), 2013) [downloadable]
+winlinkexpress           Winlink Express (Winlink Radio Messaging System client app) (Winlink, 2024) [downloadable]
 winrar                   WinRAR 6.11 (RARLAB, 1993) [downloadable]
 wme9                     MS Windows Media Encoder 9 (broken in Wine) (Microsoft, 2002) [downloadable]
 ===== benchmarks =====

--- a/files/verbs/apps.txt
+++ b/files/verbs/apps.txt
@@ -61,5 +61,6 @@ vc2010express            MS Visual C++ 2010 Express (Microsoft, 2010) [downloada
 vlc                      VLC media player 2.2.1 (VideoLAN, 2015) [downloadable]
 vstools2019              MS Visual Studio Build Tools 2019 (Microsoft, 2019) [downloadable]
 winamp                   Winamp (Radionomy (AOL (Nullsoft)), 2013) [downloadable]
+winlinkexpress           Winlink Express (Winlink Radio Messaging System client app) (Winlink, 2024) [downloadable]
 winrar                   WinRAR 6.11 (RARLAB, 1993) [downloadable]
 wme9                     MS Windows Media Encoder 9 (broken in Wine) (Microsoft, 2002) [downloadable]

--- a/files/verbs/download.txt
+++ b/files/verbs/download.txt
@@ -394,6 +394,7 @@ windowscodecs
 winhttp
 wininet
 wininet_win2k
+winlinkexpress
 winrar
 wme9
 wmi

--- a/src/winetricks
+++ b/src/winetricks
@@ -17678,6 +17678,41 @@ load_winamp()
 
 #----------------------------------------------------------------
 
+w_metadata winlinkexpress apps \
+    title="Winlink Express 1.7.15.0 (Winlink Radio Messaging System client app)" \
+    publisher="Winlink Global Radio Email" \
+    year="2024" \
+    media="download" \
+    file1="Winlink_Express_install_1-7-15-0.zip" \
+    file2="Winlink_Express_install.exe" \
+    installed_exe1="c:/RMS Express/RMS Express.exe" \
+    homepage="https://winlink.org"
+
+load_winlinkexpress()
+{
+    if [ ! -d "${W_WINDIR_UNIX}/Microsoft.NET/Framework/v4.0.30319" ]; then
+        #echo -e '\n    NOTE!!! You must install wine-mono before continuing.'
+        #echo -e '        (dotnet46 also works but is not recommended)'
+        #echo -e '         Cancelling Winlink Express installation...\n'
+        w_warn "\n    NOTE!!! You must install wine-mono before continuing.\n        (dotnet46 also works but is not recommended)\n         Cancelling Winlink Express installation...\n"
+        return
+    fi
+
+    load_sound alsa
+    w_set_winver win10
+    w_download https://web.archive.org/web/20240529202203/https://downloads.winlink.org/User%20Programs/Winlink_Express_install_1-7-15-0.zip d520f9c89b4024ffb2d7e36fa28bd3e91a861b61fc9cff660b94edd8ebe7d540
+    w_try_unzip "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${file1}"
+    w_try "${WINE}" "${W_TMP}/${file2}" ${W_OPT_UNATTENDED:+/VERYSILENT}
+
+    #echo -e '\n          NOTE!!! RUN THIS COMMAND TO ENABLE COM PORTS FOR'
+    #echo -e '\n          RADIO-TO-COMPUTER \"USB CAT CONTROL\" CONNECTIONS:'
+    #echo -e '\n                 sudo usermod -a -G dialout \$USER'
+    #echo -e '\n                 (then log out and log in again)\n'
+    w_warn "\n          NOTE!!! RUN THIS COMMAND TO ENABLE COM PORTS FOR\n          RADIO-TO-COMPUTER \"USB CAT CONTROL\" CONNECTIONS:\n                 sudo usermod -a -G dialout \$USER\n                 (then log out and log in again)\n"
+}
+
+#----------------------------------------------------------------
+
 w_metadata winrar apps \
     title="WinRAR 6.11" \
     publisher="RARLAB" \

--- a/src/winetricks
+++ b/src/winetricks
@@ -17684,16 +17684,12 @@ w_metadata winlinkexpress apps \
     year="2024" \
     media="download" \
     file1="Winlink_Express_install_1-7-15-0.zip" \
-    file2="Winlink_Express_install.exe" \
     installed_exe1="c:/RMS Express/RMS Express.exe" \
     homepage="https://winlink.org"
 
 load_winlinkexpress()
 {
     if [ ! -d "${W_WINDIR_UNIX}/Microsoft.NET/Framework/v4.0.30319" ]; then
-        #echo -e '\n    NOTE!!! You must install wine-mono before continuing.'
-        #echo -e '        (dotnet46 also works but is not recommended)'
-        #echo -e '         Cancelling Winlink Express installation...\n'
         w_warn "\n    NOTE!!! You must install wine-mono before continuing.\n        (dotnet46 also works but is not recommended)\n         Cancelling Winlink Express installation...\n"
         return
     fi
@@ -17702,12 +17698,7 @@ load_winlinkexpress()
     w_set_winver win10
     w_download https://web.archive.org/web/20240529202203/https://downloads.winlink.org/User%20Programs/Winlink_Express_install_1-7-15-0.zip d520f9c89b4024ffb2d7e36fa28bd3e91a861b61fc9cff660b94edd8ebe7d540
     w_try_unzip "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${file1}"
-    w_try "${WINE}" "${W_TMP}/${file2}" ${W_OPT_UNATTENDED:+/VERYSILENT}
-
-    #echo -e '\n          NOTE!!! RUN THIS COMMAND TO ENABLE COM PORTS FOR'
-    #echo -e '\n          RADIO-TO-COMPUTER \"USB CAT CONTROL\" CONNECTIONS:'
-    #echo -e '\n                 sudo usermod -a -G dialout \$USER'
-    #echo -e '\n                 (then log out and log in again)\n'
+    w_try "${WINE}" "${W_TMP}/Winlink_Express_install.exe" ${W_OPT_UNATTENDED:+/VERYSILENT}
     w_warn "\n          NOTE!!! RUN THIS COMMAND TO ENABLE COM PORTS FOR\n          RADIO-TO-COMPUTER \"USB CAT CONTROL\" CONNECTIONS:\n                 sudo usermod -a -G dialout \$USER\n                 (then log out and log in again)\n"
 }
 

--- a/src/winetricks
+++ b/src/winetricks
@@ -17689,17 +17689,25 @@ w_metadata winlinkexpress apps \
 
 load_winlinkexpress()
 {
+    # check for wine-mono or dotnet46
     if [ ! -d "${W_WINDIR_UNIX}/Microsoft.NET/Framework/v4.0.30319" ]; then
-        w_warn "\n    NOTE!!! You must install wine-mono before continuing.\n        (dotnet46 also works but is not recommended)\n         Cancelling Winlink Express installation...\n"
+        w_warn "\n    NOTE!!! You must install wine-mono before continuing.\n        dotnet46 also works but is not recommended.\n\n     You can download a wine-mono .msi file from\n https://github.com/madewokherd/wine-mono/releases/latest/\n and install it with \"wine msiexec /i wine-mono-*-x86.msi\"\n\n         Cancelling Winlink Express installation..."
         return
     fi
 
+    # vb6run and pdh_nt4 are required for VARA Winlink modems
+    # since winetricks requires static links with hard-coded SHA256's, and since VARA doesn't auto-update, the user must manually install VARA modems for now
+    w_call vb6run
+    w_call pdh_nt4
+
+    # alsa may produce less errors than pulse during modem connections
     load_sound alsa
     w_set_winver win10
+
     w_download https://web.archive.org/web/20240529202203/https://downloads.winlink.org/User%20Programs/Winlink_Express_install_1-7-15-0.zip d520f9c89b4024ffb2d7e36fa28bd3e91a861b61fc9cff660b94edd8ebe7d540
     w_try_unzip "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${file1}"
     w_try "${WINE}" "${W_TMP}/Winlink_Express_install.exe" ${W_OPT_UNATTENDED:+/VERYSILENT}
-    w_warn "\n          NOTE!!! RUN THIS COMMAND TO ENABLE COM PORTS FOR\n          RADIO-TO-COMPUTER \"USB CAT CONTROL\" CONNECTIONS:\n                 sudo usermod -a -G dialout \$USER\n                 (then log out and log in again)\n"
+    w_warn "\n          NOTE!!! RUN THIS COMMAND TO ENABLE COM PORTS FOR\n          RADIO-TO-COMPUTER \"USB CAT CONTROL\" CONNECTIONS:\n\n                 sudo usermod -a -G dialout \$USER\n\n          Then log out and log in again.\n\n          VARA modems must be downloaded from\n          https://downloads.winlink.org/VARA%20Products/\n          and installed manually since they don't auto-update."
 }
 
 #----------------------------------------------------------------

--- a/src/winetricks
+++ b/src/winetricks
@@ -17689,14 +17689,12 @@ w_metadata winlinkexpress apps \
 
 load_winlinkexpress()
 {
-    # check for wine-mono or dotnet46
-    if [ ! -d "${W_WINDIR_UNIX}/Microsoft.NET/Framework/v4.0.30319" ]; then
-        w_warn "\n    NOTE!!! You must install wine-mono before continuing.\n        dotnet46 also works but is not recommended.\n\n     You can download a wine-mono .msi file from\n https://github.com/madewokherd/wine-mono/releases/latest/\n and install it with \"wine msiexec /i wine-mono-*-x86.msi\"\n\n         Cancelling Winlink Express installation..."
-        return
-    fi
+    # wine-mono is faster and more reliable to install than dotnet46, but wine-mono doesn't yet support the ARDOP_Win.exe modem packaged with Winlink Express.
+    # Users running low-end systems, ARM-x64 emulators, or versions of Wine which break dotnet46 compatability may wish to install wine-mono instead of dotnet46 and use ARDOPC for Linux.
+    w_call dotnet46
 
-    # vb6run and pdh_nt4 are required for VARA Winlink modems
-    # since winetricks requires static links with hard-coded SHA256's, and since VARA doesn't auto-update, the user must manually install VARA modems for now
+    # vb6run and pdh_nt4 are required for VARA modems, which interface with Winlink Express.
+    # Users must manually install VARA modems after Winlink Express installation for now (since VARA modems do not have auto-update features and since winetricks relies on static links with SHA256 hashes).
     w_call vb6run
     w_call pdh_nt4
 


### PR DESCRIPTION
I would like to add this verb to winetricks to aid the more hardware-oriented amateur radio hobbyists who want to try the Winlink Express client-side software. Please let me know your thoughts on adding this verb - and if you have any ideas for this code.

There have been many informal installation guides and scripts for installing Winlink Express on Linux via wine over the years, including my own project [Winɘlink](https://github.com/WheezyE/Winelink) - which I am in the process of merging into [Pi-Apps](https://pi-apps.io/). Winlink Express' main developers have actively responded to compatibility improvements specifically for Wine on several occasions and even included allusions to Wine in their changelogs. I believe many users could benefit from incorporating it into winetricks. This proposed verb's version is frozen in time with an archive.org link, but the program itself checks for updates once installed.

Thank you!
Eric (KI7POL)