### PR TITLE
Update README's Debian install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://github.com/Winetricks/winetricks/releases
 The ```winetricks``` package should be used if it is available and up to date. The package is available in most mainstream (Unix-like) Operating Systems:
 
 * Arch: https://www.archlinux.org/packages/multilib/x86_64/winetricks/
-* Debian: https://packages.debian.org/sid/winetricks
+* Debian: https://packages.debian.org/search?searchon=names&keywords=winetricks
 * Fedora: https://fedoraproject.org/wiki/Wine#Packages
 * FreeBSD: https://www.freebsd.org/cgi/ports.cgi?query=winetricks&stype=all
 * Gentoo: https://packages.gentoo.org/packages/app-emulation/winetricks


### PR DESCRIPTION
# Change
This PR changes the README's Debian install instructions. It removes the existing link to the unstable Debian package, and replaces it with a link where user the user can first choose their Debian version. This change helps prevent typical users from borking their systems (see below).

# Justification
The [`README.md`'s Debian install instructions](https://github.com/Winetricks/winetricks/blob/master/README.md?plain=1#L20) link to winetricks within Debian's sid (unstable) package list. This is fine if someone downloads the winetricks `.deb` and installs manually, but at the download page the Debian site actually advises against this:

> If you are running Debian, it is strongly suggested to use a package manager like [aptitude](https://packages.debian.org/sid/aptitude) or [synaptic](https://packages.debian.org/sid/synaptic) to download and install packages, instead of doing so manually via this website.
>
> You should be able to use any of the listed mirrors by adding a line to your /etc/apt/sources.list like this:
>
> deb http://ftp.de.debian.org/debian sid main contrib

Following those instructions is a very bad idea for most users as it creates [a difficult-to-unwind "FrankenDebian"](https://wiki.debian.org/DontBreakDebian#Don.27t_make_a_FrankenDebian) situation for those running stable Debian (which is most users). It's not clear to those who might land on that page from the winetricks README.md link that the instructions pertain only to unstable Debian. The change in this PR sends the user to a page where they must choose their appropriate version of Debian.