### PR TITLE
Fix Unicode $USER

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -1054,7 +1054,7 @@ w_pathconv()
 # Expand an environment variable and print it to stdout
 w_expand_env()
 {
-    winetricks_early_wine_arch cmd.exe /c echo "%$1%"
+    winetricks_early_wine_arch cmd.exe /c 'chcp 65001 > nul && echo "%$1%"'
 }
 
 # Determine what architecture a binary file is built for, silently continue in case of failure.

--- a/src/winetricks
+++ b/src/winetricks
@@ -1054,7 +1054,7 @@ w_pathconv()
 # Expand an environment variable and print it to stdout
 w_expand_env()
 {
-    winetricks_early_wine_arch cmd.exe /c 'chcp 65001 > nul && echo "%$1%"'
+    winetricks_early_wine_arch cmd.exe /c "chcp 65001 > nul && echo %$1%"
 }
 
 # Determine what architecture a binary file is built for, silently continue in case of failure.


### PR DESCRIPTION
My `$USER` is `Dāvis` which contains Unicode and that causes `%AppData%` to be `C:\users\Dāvis\AppData\Roaming`
Currently `winetricks` doesn't work at all for me and fails with:
```
grep: (standard input): binary file matches
------------------------------------------------------
WINEPREFIX INFO:
Drive C: total 12
[...]

Registry info:
/mnt/Wine/system.reg:#arch=win64
/mnt/Wine/userdef.reg:#arch=win64
/mnt/Wine/user.reg:#arch=win64
------------------------------------------------------
------------------------------------------------------
warning: wine cmd.exe /c echo '%AppData%' returned empty string, error message ""
------------------------------------------------------
```

Reason is that because when `cmd.exe` pipes output it will use Windows Code Page which won't be recognized by Linux/grep (it thinks it's binary output). So this PR fixes it by enforcing that output is in UTF-8 instead which works correctly.
