### PR TITLE
Update URL for ucrtbase2019 to remove hardcoded archive.org prefix

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -13964,7 +13964,7 @@ load_ucrtbase2019()
     w_override_dlls native,builtin ucrtbase
 
     # Microsoft download no longer containts ucrtbase so get the last known version from archive.org
-    w_download https://web.archive.org/web/20210415064013/https://download.visualstudio.microsoft.com/download/pr/85d47aa9-69ae-4162-8300-e6b7e4bf3cf3/14563755AC24A874241935EF2C22C5FCE973ACB001F99E524145113B2DC638C1/VC_redist.x86.exe 14563755ac24a874241935ef2c22c5fce973acb001f99e524145113b2dc638c1
+    w_download https://download.visualstudio.microsoft.com/download/pr/85d47aa9-69ae-4162-8300-e6b7e4bf3cf3/14563755AC24A874241935EF2C22C5FCE973ACB001F99E524145113B2DC638C1/VC_redist.x86.exe 14563755ac24a874241935ef2c22c5fce973acb001f99e524145113b2dc638c1
 
     w_try_cabextract --directory="${W_TMP}/win32"  "${W_CACHE}"/"${W_PACKAGE}"/VC_redist.x86.exe -F 'a10'
     w_try_cabextract --directory="${W_SYSTEM32_DLLS}" "${W_TMP}/win32/a10" -F 'ucrtbase.dll'
@@ -13972,7 +13972,7 @@ load_ucrtbase2019()
     case "${W_ARCH}" in
         win64)
             # Microsoft download no longer containts ucrtbase so get the last known version from archive.org
-            w_download https://web.archive.org/web/20210414165612/https://download.visualstudio.microsoft.com/download/pr/85d47aa9-69ae-4162-8300-e6b7e4bf3cf3/52B196BBE9016488C735E7B41805B651261FFA5D7AA86EB6A1D0095BE83687B2/VC_redist.x64.exe 52b196bbe9016488c735e7b41805b651261ffa5d7aa86eb6a1d0095be83687b2
+            w_download https://download.visualstudio.microsoft.com/download/pr/85d47aa9-69ae-4162-8300-e6b7e4bf3cf3/52B196BBE9016488C735E7B41805B651261FFA5D7AA86EB6A1D0095BE83687B2/VC_redist.x64.exe 52b196bbe9016488c735e7b41805b651261ffa5d7aa86eb6a1d0095be83687b2
 
             w_try_cabextract --directory="${W_TMP}/win64"  "${W_CACHE}"/"${W_PACKAGE}"/VC_redist.x64.exe -F 'a10'
             w_try_cabextract --directory="${W_SYSTEM64_DLLS}" "${W_TMP}/win64/a10" -F 'ucrtbase.dll'

--- a/src/winetricks
+++ b/src/winetricks
@@ -13963,7 +13963,7 @@ load_ucrtbase2019()
 {
     w_override_dlls native,builtin ucrtbase
 
-    # Microsoft download no longer containts ucrtbase so get the last known version from archive.org
+    # 2024/10/11: ucrtbase.dll is available again - reverted from archive.org to microsoft URL
     w_download https://download.visualstudio.microsoft.com/download/pr/85d47aa9-69ae-4162-8300-e6b7e4bf3cf3/14563755AC24A874241935EF2C22C5FCE973ACB001F99E524145113B2DC638C1/VC_redist.x86.exe 14563755ac24a874241935ef2c22c5fce973acb001f99e524145113b2dc638c1
 
     w_try_cabextract --directory="${W_TMP}/win32"  "${W_CACHE}"/"${W_PACKAGE}"/VC_redist.x86.exe -F 'a10'
@@ -13971,7 +13971,7 @@ load_ucrtbase2019()
 
     case "${W_ARCH}" in
         win64)
-            # Microsoft download no longer containts ucrtbase so get the last known version from archive.org
+            # 2024/10/11: ucrtbase.dll is available again - reverted from archive.org to microsoft URL
             w_download https://download.visualstudio.microsoft.com/download/pr/85d47aa9-69ae-4162-8300-e6b7e4bf3cf3/52B196BBE9016488C735E7B41805B651261FFA5D7AA86EB6A1D0095BE83687B2/VC_redist.x64.exe 52b196bbe9016488c735e7b41805b651261ffa5d7aa86eb6a1d0095be83687b2
 
             w_try_cabextract --directory="${W_TMP}/win64"  "${W_CACHE}"/"${W_PACKAGE}"/VC_redist.x64.exe -F 'a10'


### PR DESCRIPTION
It seems like the `archive.org` prefix is automatically added in the download function (on second try), meaning there shouldn't be a need for hardcoding the `archive.org` URL prefix.

I've tested a quick game installation using the downloaded EXE from the Microsoft servers & everything seemed to run fine.

### Note
Theoretically there could be another reason for the permanent  URL prefix - e.g. the setup file on the Microsoft servers changed at some point, no longer containing a working `ucrtbase.dll`. Play-testing Tarkov didn't reveal any issues with the dll..
edit: since the file is checked via `sha256sum` - this shouldn't be a concern either.