### PR TITLE
misc: don't initialize the Wine prefix before every single verb

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -4361,11 +4361,17 @@ winetricks_set_wineprefix()
     # Note: these are arch independent, but are needed by some arch dependent variables
     # Defining here to avoid having two arch checks:
     if ! test "$1"; then
-        WINEPREFIX="${WINETRICKS_ORIGINAL_WINEPREFIX}"
+        NEW_WINEPREFIX="${WINETRICKS_ORIGINAL_WINEPREFIX}"
     else
-        WINEPREFIX="${W_PREFIXES_ROOT}/$1"
+        NEW_WINEPREFIX="${W_PREFIXES_ROOT}/$1"
     fi
 
+    if test "${WINEPREFIX}" = "${NEW_WINEPREFIX}"; then
+        # A previous verb already set the prefix
+        return
+    fi
+
+    WINEPREFIX="${NEW_WINEPREFIX}"
     export WINEPREFIX
     w_try_mkdir "$(dirname "${WINEPREFIX}")"
 


### PR DESCRIPTION
This reduces the run time of `winetricks allfonts` on Wine 9.22 on my Intel i7-1360P laptop from 5 minutes 19 seconds to 3 minutes 34 seconds, a 33% decrease.