### PR TITLE
Add developer tag to AppStream metadata

### DIFF
--- a/src/io.github.winetricks.Winetricks.metainfo.xml
+++ b/src/io.github.winetricks.Winetricks.metainfo.xml
@@ -6,6 +6,9 @@
   <metadata_license>CC0-1.0</metadata_license>
   <name>Winetricks</name>
   <developer_name>Austin English and others</developer_name>
+  <developer id="io.github.winetricks">
+    <name>Austin English and others</name>
+  </developer>
   <summary>Work around problems and install applications under Wine</summary>
   <description>
     <p>


### PR DESCRIPTION
To make the metadata compatible with future AppStream standard version that uses the [developer tag](https://freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer) instead of developer_name, but keep the original one for compatibility purposes.

@austin987 Feel free to review and merge. :-)