### PR TITLE
Do not show Win64 warnings anymore in unattended mode. Eg. -q

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -4549,6 +4549,11 @@ winetricks_set_wineprefix()
             else
                 W_NO_WIN64_WARNINGS=0
             fi
+
+            # In unattended mode, do NOT show any Win64 warnings
+            if [ -n "${W_OPT_UNATTENDED}" ]; then
+                W_NO_WIN64_WARNINGS=1
+            fi
         fi
 
         # In case of GUI, only warn once per prefix, per session (i.e., don't warn next time)


### PR DESCRIPTION
- Stop showing this annoying Windows 64-bit bottle warning, when using a 64-bit bottle in unattended mode (eg. `-q` flag is set).

Fixes: #2172