### PR TITLE
w_set_winver: change default to win10

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -2327,8 +2327,8 @@ w_set_winver()
         # These are the mismatched ones:
         # winecfg doesn't accept 'default' as an option (as of wine-5.9):
         # https://bugs.winehq.org/show_bug.cgi?id=49241
-        # For now, assuming win7:
-        default)  _W_winver="win7";;
+        # For now, assuming win10:
+        default)  _W_winver="win10";;
         win2k3)   _W_winver="win2003";;
         win2k8)   _W_winver="win2008";;
         win2k8r2) _W_winver="win2008r2";;


### PR DESCRIPTION
All recent versions of wine support setting win10, it's the default for wine-10.0 plus many applications now require a minimum win10