### PR TITLE
powershell_core: bump to version 7.4.11

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -11469,8 +11469,8 @@ w_metadata powershell_core dlls \
     publisher="Microsoft" \
     year="2024" \
     media="download" \
-    file1="PowerShell-7.4.7-win-x86.msi" \
-    file2="PowerShell-7.4.7-win-x64.msi"
+    file1="PowerShell-7.4.11-win-x86.msi" \
+    file2="PowerShell-7.4.11-win-x64.msi"
 
 load_powershell_core()
 {
@@ -11478,14 +11478,14 @@ load_powershell_core()
     #w_package_unsupported_win32
 
     # Download PowerShell Core 7.4.x MSI (Latest LTS Release)
-    # https://github.com/PowerShell/PowerShell/releases/v7.4.7
+    # https://github.com/PowerShell/PowerShell/releases/v7.4.11
     if [ "${W_ARCH}" = "win64" ]; then
-        w_download "https://github.com/PowerShell/PowerShell/releases/download/v7.4.7/PowerShell-7.4.7-win-x64.msi" 217b5575398d5e4a0ac67aff7b468c696a66c3e209685cf338032fc0a5f032ec
+        w_download "https://github.com/PowerShell/PowerShell/releases/download/v7.4.11/PowerShell-7.4.11-win-x64.msi" 9579011c463a3ad6abf890736a97e2fbba9a7b4e09ce851576ccf263e15bdc97
         # Disable SC2154 due to shellcheck not knowing metadata is sourced before this function is run
         # shellcheck disable=SC2154
         msi="${file2}"
     elif [ "${W_ARCH}" = "win32" ]; then
-        w_download "https://github.com/PowerShell/PowerShell/releases/download/v7.4.7/PowerShell-7.4.7-win-x86.msi" 2d9d4a1433e63c84d62ce70aef8ce4d7a9dd177f197a69a9f6a9180e83706d24
+        w_download "https://github.com/PowerShell/PowerShell/releases/download/v7.4.11/PowerShell-7.4.11-win-x86.msi" beaed5a0860421383afd18b7d4c2b2663f62b6a89b4e30ac0894575aa65226f8
         # shellcheck disable=SC2154
         msi="${file1}"
     fi


### PR DESCRIPTION
This bumps powershell core to the latest LTS release of 7.4.11

Additionally: Options for telemetry and windows update are disabled by default in the installer.