### PR TITLE
Add newer versions of dxvk-nvapi and a "latest" verb

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -7715,6 +7715,26 @@ load_dxvk_nvapi009()
 
 #----------------------------------------------------------------
 
+w_metadata dxvk_nvapi dlls \
+    title="Alternative NVAPI Vulkan implementation on top of DXVK for Linux / Wine (latest)" \
+    publisher="Jens Peters" \
+    year="2025" \
+    media="download" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/nvapi.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/nvapi64.dll"
+
+load_dxvk_nvapi()
+{
+    # https://github.com/jp7677/dxvk-nvapi
+    _W_dxvk_nvapi_version="$(w_get_github_latest_release jp7677 dxvk-nvapi)"
+    _W_dxvk_nvapi_version="${_W_dxvk_nvapi_version#v}"
+    w_linkcheck_ignore=1 w_download "https://github.com/jp7677/dxvk-nvapi/releases/download/v${_W_dxvk_nvapi_version}/dxvk-nvapi-v${_W_dxvk_nvapi_version}.tar.gz"
+    helper_dxvk_nvapi "dxvk-nvapi-v${_W_dxvk_nvapi_version}.tar.gz" "7.1" "nvapi,nvapi64"
+    unset _W_dxvk_nvapi_version
+}
+
+#----------------------------------------------------------------
+
 # $1 - vkd3d-proton archive name (required)
 helper_vkd3d_proton()
 {

--- a/src/winetricks
+++ b/src/winetricks
@@ -7698,6 +7698,21 @@ load_dxvk_nvapi0061()
     helper_dxvk_nvapi "${file1}" "7.1" "nvapi,nvapi64"
 }
 
+w_metadata dxvk_nvapi009 dlls \
+    title="Alternative NVAPI Vulkan implementation on top of DXVK for Linux / Wine (0.9.0)" \
+    publisher="Jens Peters" \
+    year="2025" \
+    media="download" \
+    file1="dxvk-nvapi-v0.9.0.tar.gz" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/nvapi.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/nvapi64.dll"
+
+load_dxvk_nvapi009()
+{
+    w_download "https://github.com/jp7677/dxvk-nvapi/releases/download/v0.9.0/dxvk-nvapi-v0.9.0.tar.gz" 98be815a7a10e7e0474ad9a01f205ca5279cf6d749f5094e94b39f3d09a39f1d
+    helper_dxvk_nvapi "${file1}" "7.1" "nvapi,nvapi64"
+}
+
 #----------------------------------------------------------------
 
 # $1 - vkd3d-proton archive name (required)


### PR DESCRIPTION
Newer versions have support for HDR and the currently-available version (0.6.1) makes some games crash on launch.