### PR TITLE
Add verb: msls31_x64

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -11072,7 +11072,7 @@ load_msscript()
 #----------------------------------------------------------------
 
 w_metadata msls31 dlls \
-    title="MS Line Services" \
+    title="MS Line Services (32-bit only)" \
     publisher="Microsoft" \
     year="2001" \
     media="download" \

--- a/src/winetricks
+++ b/src/winetricks
@@ -11092,6 +11092,32 @@ load_msls31()
 
 #----------------------------------------------------------------
 
+w_metadata msls31_x64 dlls \
+    title="MS Line Services (both 32-bit and 64-bit versions)" \
+    publisher="Microsoft" \
+    year="2001" \
+    media="download" \
+    file1="IE8-WindowsServer2003-x64-ENU.exe" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/msls31.dll" \
+    installed_file2="${W_SYSTEM64_DLLS_WIN}/msls31.dll"    
+
+load_msls31_x64()
+{
+    # Needed by native RichEdit and Internet Explorer
+    # Installs newer version of msls31.dll as well as both 32-bit and 64-bit versions as needed
+
+    w_download https://download.microsoft.com/download/7/5/4/754D6601-662D-4E39-9788-6F90D8E5C097/IE8-WindowsServer2003-x64-ENU.exe bcff753e92ceabf31cfefaa6def146335c7cb27a50b95cd4f4658a0c3326f499
+       
+    w_try_cabextract --directory="${W_CACHE}"/msls31_x64 "${W_CACHE}"/msls31_x64/IE8-WindowsServer2003-x64-ENU.exe -F wow/wmsls31.dll
+    w_try_cp_dll "${W_CACHE}"/msls31_x64/wow/wmsls31.dll "${W_SYSTEM32_DLLS}"/msls31.dll
+
+    if [ "${W_ARCH}" = "win64" ]; then
+        w_try_cabextract --directory="${W_SYSTEM64_DLLS}" "${W_CACHE}"/msls31_x64/IE8-WindowsServer2003-x64-ENU.exe -F msls31.dll
+    fi
+}
+
+#----------------------------------------------------------------
+
 w_metadata msmask dlls \
     title="MS Masked Edit Control" \
     publisher="Microsoft" \


### PR DESCRIPTION
Added a new verb `msls31_x64` which installs both a 32-bit and 64-bit version of the dll as needed, depending on the arch. The existing `msls31` verb only installs a 32-bit version, which causes a crash with 64-bit apps using rich text with `msftedit` and extended Unicode characters.

The official IE8 installer has the needed dlls, so this PR adapts the `ie8` verb and strips it down to just handling both versions of msls31.dll.

I created a new verb since `msls31` is called by other functions, so did not want to introduce anything unexpected. The version of the dll included with the IE8 installer is slightly newer than the one grabbed by `msls31`.

Also updated the title of `msls31` to make it clear it's 32-bit only.

Thank you.
