### PR TITLE
refactor: avoid x-prefix in comparisons

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -4290,7 +4290,7 @@ winetricks_die_if_user_not_dirowner()
     fi
     _W_nuser=$(id -u)
     _W_nowner=$(stat -c '%u' "${_W_checkdir}")
-    if test x"${_W_nuser}" != x"${_W_nowner}"; then
+    if test "${_W_nuser}" != "${_W_nowner}"; then
         w_die "You ($(id -un)) don't own ${_W_checkdir}.  Don't run this tool as another user!"
     fi
 }


### PR DESCRIPTION
According to shellcheck prefixing with 'x' is unnecessary, causing it to error when linting the winetricks script. See https://www.shellcheck.net/wiki/SC2268 for details.
