### PR TITLE
dsound: Allow builtin fallback for dsound.dll

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -9787,7 +9787,7 @@ load_dsound()
 
     # Don't try to register native dsound; it doesn't export DllRegisterServer().
     #w_try_regsvr32 dsound.dll
-    w_override_dlls native dsound
+    w_override_dlls native,builtin dsound
 }
 
 #----------------------------------------------------------------


### PR DESCRIPTION
The dsound verb only installs 32-bit dsound, which means that setting dsound.dll to native-only breaks 64-bit dsound.