### PR TITLE
winetricks_usage: add a missing '_EOF_'

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -5122,6 +5122,7 @@ list-installed        列出已安装的脚本
 arch=32|64            创建 32 位或 64 位 wineprefix，此选项必须在 prefix=foobar 之前指定，默认 wineprefix 不支持此选项
 prefix=foobar         选择 WINEPREFIX 为 ${W_PREFIXES_ROOT}/foobar
 annihilate            删除该 WINEPREFIX 内的所有数据和应用程序
+_EOF_
             ;;
         *)
             cat <<_EOF_


### PR DESCRIPTION
This fixes regression introduced in 65c4a139b3a [1], which causes 'winetricks --help' to only print 'Executing cd /usr/bin' in any language other than 'zh_CN', for which the English usage would also be printed.

1. https://github.com/Winetricks/winetricks/commit/65c4a139b3a

Closes: https://github.com/Winetricks/winetricks/pull/2434