### PR TITLE
dinputto8: bump version to 1.0.92.0

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -6476,7 +6476,7 @@ load_dinput8()
 #----------------------------------------------------------------
 
 w_metadata dinputto8 dlls \
-    title="A dll module that is designed to improve compatibility in games using DirectInput 1-7 by converting all API calls to their equivalent DirectInput 8 (1.0.78.0)" \
+    title="A dll module that is designed to improve compatibility in games using DirectInput 1-7 by converting all API calls to their equivalent DirectInput 8 (1.0.92.0)" \
     homepage="https://github.com/elishacloud/dinputto8" \
     publisher="Elisha Riedlinger" \
     year="2018" \
@@ -6487,7 +6487,7 @@ w_metadata dinputto8 dlls \
 
 load_dinputto8()
 {
-    w_download https://github.com/elishacloud/dinputto8/releases/download/v1.0.78.0/dinput.dll 467f50cac676635ed68658b8be32e1a2cacece37a22bb13e8ec8330706a32ca7
+    w_download https://github.com/elishacloud/dinputto8/releases/download/v1.0.92.0/dinput.dll 8f1e53a55c66f870b91c1e43a39c02a4a87900cf453776de41643863bdfa00e6
     w_try_cp_dll "${W_CACHE}/${W_PACKAGE}/dinput.dll" "${W_SYSTEM32_DLLS}/dinput.dll"
     w_override_dlls native dinput
 }


### PR DESCRIPTION
Bump version to https://github.com/elishacloud/dinputto8/releases/tag/v1.0.92.0.

Since the cache (`~/.cache/winetricks/dinputto8/dinput.dll`) does not change its name between versions, users must delete the cache to update.
