### PR TITLE
Avoid corruption of W_PROGRAMS_WIN and W_PROGRAMS_X86_WIN when running from syswow64

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -1104,9 +1104,14 @@ w_pathconv()
 }
 
 # Expand an environment variable and print it to stdout
+# Move to $WINEPREFIX to avoid corruption of W_PROGRAMS_WIN and W_PROGRAMS_X86_WIN when running from syswow64
 w_expand_env()
 {
+    _W_dl_olddir=$(pwd)
+    w_try_cd "${WINEPREFIX}"
     winetricks_early_wine_arch cmd.exe /c "chcp 65001 > nul & echo %$1%"
+    w_try_cd "${_W_dl_olddir}"
+    unset _W_dl_olddir
 }
 
 # Determine what architecture a binary file is built for, silently continue in case of failure.


### PR DESCRIPTION
The corruption occurs in the 64bit prefix when the component installation is run in the syswow64 directory:
+ W_PROGRAMS_WIN='C:\Program Files (x86)'
++ w_pathconv -u 'C:\Program Files (x86)'
++ case "${W_PLATFORM}" in
++ case "$@" in
++ winetricks_wintounix 'C:\Program Files (x86)'
++ _W_winp_='C:\Program Files (x86)'
++ _W_winp='\Program Files (x86)'
++ printf %s /home/guest/.wine/dosdevices/c:
++ echo '\Program Files (x86)'
++ sed 's,\\,/,g'
+ W_PROGRAMS_UNIX='/home/guest/.wine/dosdevices/c:/Program Files (x86)'
...
+ W_PROGRAMS_X86_WIN='C:\Program Files (x86) (x86)'
+ W_PROGRAMS_X86_UNIX='/home/guest/.wine/dosdevices/c:/Program Files (x86) (x86)'

To avoid this, I added cd to the root of the prefix.