### PR TITLE
Do not give a warning about unknown file arch (when -q is set)

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -4605,10 +4605,8 @@ winetricks_set_wineprefix()
                 _W_wineserver_binary_arch="$(winetricks_get_file_arch "${WINE_BINDIR}/wineserver")"
             fi
         fi
-        if [ -z "${W_OPT_UNATTENDED}" ]; then
-            if [ -z "${_W_wineserver_binary_arch}" ]; then
-                w_warn "Unknown file arch of ${WINESERVER_BIN}."
-            fi
+        if [ -z "${W_OPT_UNATTENDED}" ] && [ -z "${_W_wineserver_binary_arch}" ]; then
+            w_warn "Unknown file arch of ${WINESERVER_BIN}."
         fi
 
         if [ -z "${WINE_BIN}" ]; then
@@ -4624,10 +4622,8 @@ winetricks_set_wineprefix()
                 _W_wine_binary_arch="$(winetricks_get_file_arch "${WINE_BINDIR}/wine")"
             fi
         fi
-        if [ -z "${W_OPT_UNATTENDED}" ]; then
-            if [ -z "${_W_wine_binary_arch}" ]; then
-                w_warn "Unknown file arch of ${WINE_BIN}."
-            fi
+        if [ -z "${W_OPT_UNATTENDED}" ] && [ -z "${_W_wine_binary_arch}" ]; then
+            w_warn "Unknown file arch of ${WINE_BIN}."
         fi
 
         # determine wow64 type (new/old)


### PR DESCRIPTION
Under Debian Trixie (just an example), I still get "Unknown file arch for /usr/bin/wine" despite the `-q` option (`--unattended`).

<img width="516" height="225" alt="image" src="https://github.com/user-attachments/assets/99df55ca-5743-4c27-ad3a-d80722dbe6be" />


This is **very** **annoying**, especially since I'm using winetricks with the `-q` option. This PR should fix that.