### PR TITLE
vb5run: Add known good Wine version

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -12878,7 +12878,7 @@ w_metadata vb5run dlls \
 
 load_vb5run()
 {
-    w_package_broken "https://bugs.winehq.org/show_bug.cgi?id=56209" 8.10
+    w_package_broken "https://bugs.winehq.org/show_bug.cgi?id=56209" 8.10 10.18
 
     w_download https://download.microsoft.com/download/vb50pro/utility/1/win98/en-us/msvbvm50.exe b5f8ea5b9d8b30822a2be2cdcb89cda99ec0149832659ad81f45360daa6e6965
     w_try_cd "${W_CACHE}/${W_PACKAGE}"


### PR DESCRIPTION
The Wine bug https://bugs.winehq.org/show_bug.cgi?id=56209 has been fixed since 10.18, so mark vb5run as no longer broken since that Wine version.