### PR TITLE
directx9: download from Microsoft's official redist instead of holarse mirror

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -5529,7 +5529,7 @@ helper_directx_dl()
     # FIXME: none of the verbs that use this will show download status right
     # until file1 metadata is extended to handle common cache dir
     # 2021/01/28: https://download.microsoft.com/download/E/E/1/EE17FF74-6C45-4575-9CF4-7FC2597ACD18/directx_feb2010_redist.exe
-    w_download_to directx9 https://files.holarse-linuxgaming.de/mirrors/microsoft/directx_feb2010_redist.exe f6d191e89a963d7cca34f169d30f49eab99c1ed3bb92da73ec43617caaa1e93f
+    w_download_to directx9 https://download.microsoft.com/download/E/E/1/EE17FF74-6C45-4575-9CF4-7FC2597ACD18/directx_feb2010_redist.exe f6d191e89a963d7cca34f169d30f49eab99c1ed3bb92da73ec43617caaa1e93f
 
     DIRECTX_NAME=directx_feb2010_redist.exe
 }
@@ -5540,7 +5540,7 @@ helper_directx_Jun2010()
     # June 2010 DirectX 9c User Redistributable
     # https://www.microsoft.com/en-us/download/details.aspx?id=8109
     # 2021/01/28: https://download.microsoft.com/download/8/4/A/84A35BF1-DAFE-4AE8-82AF-AD2AE20B6B14/directx_Jun2010_redist.exe
-    w_download_to directx9 https://files.holarse-linuxgaming.de/mirrors/microsoft/directx_Jun2010_redist.exe 8746ee1a84a083a90e37899d71d50d5c7c015e69688a466aa80447f011780c0d
+    w_download_to directx9 https://download.microsoft.com/download/8/4/A/84A35BF1-DAFE-4AE8-82AF-AD2AE20B6B14/directx_Jun2010_redist.exe 8746ee1a84a083a90e37899d71d50d5c7c015e69688a466aa80447f011780c0d
 
     DIRECTX_NAME=directx_Jun2010_redist.exe
 }


### PR DESCRIPTION
## Summary
- The `directx9` verbs downloaded `directx_feb2010_redist.exe` and `directx_Jun2010_redist.exe` from the third-party `files.holarse-linuxgaming.de` mirror, which has been reported failing for users (directx9-11 and d3dcompiler no longer install).
- Both files are still served from Microsoft's official download endpoint — these official URLs were already documented in the comments next to each `w_download_to` call but were not the ones actually used.
- Switch the primary download URL to Microsoft's official redist. The Wayback Machine fallback already built into `w_download_to` still covers the rare case where the official endpoint is unreachable.

## Changes
| File | Change |
|------|--------|
| `src/winetricks` | `helper_directx_dl`: use official Microsoft URL for `directx_feb2010_redist.exe` |
| `src/winetricks` | `helper_directx_Jun2010`: use official Microsoft URL for `directx_Jun2010_redist.exe` |

## Test Plan
- [ ] `winetricks directx9` installs successfully using the official Microsoft endpoint
- [ ] SHA256 of the downloaded file still matches the existing checksums (`f6d191e8...` / `8746ee1a...`)
- [ ] `sh -n src/winetricks` (and `make shell-checks` where shellcheck is available) pass

Fixes #2474
