### PR TITLE
WINESERVER should not ignore WINE

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -5053,9 +5053,9 @@ winetricks_wine_setup()
             for x in \
                 "${WINESERVER}" \
                 "${WINE}server" \
-                "$(command -v wineserver 2> /dev/null)" \
                 "$(dirname "${WINE}")/server/wineserver" \
                 "$(dirname "${WINE}")/wineserver" \
+                "$(command -v wineserver 2> /dev/null)" \
                 /usr/bin/wineserver-development \
                 /usr/lib/wine/wineserver \
                 /usr/lib/i386-kfreebsd-gnu/wine/wineserver \


### PR DESCRIPTION
$WINESERVER is found in the $PATH and ignores $WINE. Moving this after checking $WINE fixes this.